### PR TITLE
Resolve RunE ownership conflict and restore missing validation in security

### DIFF
--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -215,18 +215,18 @@ func logVerboseConfig(checks []string) {
 
 func runAuditWithTimeout(checks []string) error {
 	opts := audit.Options{
-		Verbose:  		verbose,
-		CustomPaths:  	customPaths,
-		SkipChecks: 	skipChecks,
-		MinSeverity:	minSeverity,
-		Timeout:  		timeout,
+		Verbose:        verbose,
+		CustomPaths:    customPaths,
+		SkipChecks:     skipChecks,
+		MinSeverity:    minSeverity,
+		Timeout:        timeout,
 		SpecificChecks: checks,
 	}
 
 	auditor := audit.NewSecurityAuditor(opts)
 
 	resultChan := make(chan *audit.Result, 1)
-	errorChan  := make(chan error, 1)
+	errorChan := make(chan error, 1)
 
 	go func() {
 		result, err := auditor.RunAudit()

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -61,7 +61,6 @@ You can run all checks or specify individual checks to run.`,
 
   # Run checks and save report to file
   owatch security_audit -v -o json --report-file audit.json`,
-	RunE: runSecurityAudit,
 }
 
 // Formatter types
@@ -135,7 +134,7 @@ func init() {
 		"Check permissions of specified file path")
 }
 
-func runSecurityAudit(cmd *cobra.Command, args []string) error {
+func buildChecks() []string {
 	var checks []string
 	if checkSSH {
 		checks = append(checks, "ssh")
@@ -149,66 +148,7 @@ func runSecurityAudit(cmd *cobra.Command, args []string) error {
 	if checkFilePerms != "" {
 		checks = append(checks, "file-permissions")
 	}
-
-	if len(checks) == 0 && !verbose {
-		fmt.Println("No checks specified. Use --help to see available options.")
-		return cmd.Help()
-	}
-
-	if err := validateFlags(); err != nil {
-		return err
-	}
-
-	opts := audit.Options{
-		Verbose:        verbose,
-		CustomPaths:    customPaths,
-		SkipChecks:     skipChecks,
-		MinSeverity:    minSeverity,
-		Timeout:        timeout,
-		SpecificChecks: checks,
-	}
-
-	auditor := audit.NewSecurityAuditor(opts)
-
-	if verbose {
-		fmt.Println("[*] Starting security audit...")
-		if len(checks) > 0 {
-			fmt.Printf("[*] Running checks: %s\n", strings.Join(checks, ", "))
-		} else {
-			fmt.Println("[*] Running comprehensive security audit")
-		}
-		fmt.Printf("[*] Output format: %s\n", outputFormat)
-		if len(customPaths) > 0 {
-			fmt.Printf("[*] Custom paths: %s\n", strings.Join(customPaths, ", "))
-		}
-		if len(skipChecks) > 0 {
-			fmt.Printf("[*] Skipped checks: %s\n", strings.Join(skipChecks, ", "))
-		}
-		fmt.Printf("[*] Minimum severity: %s\n", minSeverity)
-		fmt.Printf("[*] Timeout: %s\n", timeout)
-		fmt.Println()
-	}
-
-	resultChan := make(chan *audit.Result, 1)
-	errorChan := make(chan error, 1)
-
-	go func() {
-		result, err := auditor.RunAudit()
-		if err != nil {
-			errorChan <- err
-			return
-		}
-		resultChan <- result
-	}()
-
-	select {
-	case result := <-resultChan:
-		return outputResults(result)
-	case err := <-errorChan:
-		return fmt.Errorf("audit failed: %w", err)
-	case <-time.After(timeout):
-		return fmt.Errorf("audit timed out after %v", timeout)
-	}
+	return checks
 }
 
 func validateFlags() error {
@@ -250,6 +190,61 @@ func validateFlags() error {
 	}
 
 	return nil
+}
+
+func logVerboseConfig(checks []string) {
+	if !verbose {
+		return
+	}
+	if len(checks) > 0 {
+		fmt.Printf("[*] Running checks: %s\n", strings.Join(checks, ", "))
+	} else {
+		fmt.Println("[*] Runnning comprehensive security audit")
+	}
+	fmt.Printf("[*] Output format: %s\n", outputFormat)
+	if len(customPaths) > 0 {
+		fmt.Printf("[*] Custom paths: %s\n", strings.Join(customPaths, ", "))
+	}
+	if len(skipChecks) > 0 {
+		fmt.Printf("[*] Skipped checks: %s\n", strings.Join(skipChecks, ", "))
+	}
+	fmt.Printf("[*] Minimum severity: %s\n", minSeverity)
+	fmt.Printf("[*] Timeout: %s\n", timeout)
+	fmt.Println()
+}
+
+func runAuditWithTimeout(checks []string) error {
+	opts := audit.Options{
+		Verbose:  		verbose,
+		CustomPaths:  	customPaths,
+		SkipChecks: 	skipChecks,
+		MinSeverity:	minSeverity,
+		Timeout:  		timeout,
+		SpecificChecks: checks,
+	}
+
+	auditor := audit.NewSecurityAuditor(opts)
+
+	resultChan := make(chan *audit.Result, 1)
+	errorChan  := make(chan error, 1)
+
+	go func() {
+		result, err := auditor.RunAudit()
+		if err != nil {
+			errorChan <- err
+			return
+		}
+		resultChan <- result
+	}()
+
+	select {
+	case result := <-resultChan:
+		return outputResults(result)
+	case err := <-errorChan:
+		return fmt.Errorf("audit failed: %w", err)
+	case <-time.After(timeout):
+		return fmt.Errorf("audit timeout after %v", timeout)
+	}
 }
 
 func outputResults(result *audit.Result) error {

--- a/cmd/commands/security/security_unix.go
+++ b/cmd/commands/security/security_unix.go
@@ -7,11 +7,8 @@ package security
 import (
 	"fmt"
 	"runtime"
-	"strings"
 
 	"github.com/spf13/cobra"
-
-	"github.com/papa0four/orkowatch/internal/security/audit"
 )
 
 func init() {
@@ -19,41 +16,21 @@ func init() {
 }
 
 func runUnixAudit(cmd *cobra.Command, args []string) error {
-	var checks []string
-	if checkSSH {
-		checks = append(checks, "ssh")
+	checks := buildChecks()
+
+	if len(checks) == 0 && !verbose {
+		fmt.Println("No checks specified. User --help to see available options.")
+		return cmd.Help()
 	}
-	if checkFirewall {
-		checks = append(checks, "firewall")
-	}
-	if checkUsers {
-		checks = append(checks, "users")
-	}
-	if checkFilePerms != "" {
-		checks = append(checks, "file-permissions")
+
+	if err := validateFlags(); err != nil {
+		return err
 	}
 
 	if verbose {
 		fmt.Printf("[*] Running security audit for OS: %s\n", runtime.GOOS)
-		if len(checks) > 0 {
-			fmt.Printf("[*] Running checks: %s\n", strings.Join(checks, ", "))
-		}
 	}
+	logVerboseConfig(checks)
 
-	opts := audit.Options{
-		Verbose:        verbose,
-		CustomPaths:    customPaths,
-		SkipChecks:     skipChecks,
-		MinSeverity:    minSeverity,
-		Timeout:        timeout,
-		SpecificChecks: checks,
-	}
-
-	auditor := audit.NewSecurityAuditor(opts)
-	result, err := auditor.RunAudit()
-	if err != nil {
-		return fmt.Errorf("audit failed: %w", err)
-	}
-
-	return outputResults(result)
+	return runAuditWithTimeout(checks)
 }

--- a/cmd/commands/security/security_windows.go
+++ b/cmd/commands/security/security_windows.go
@@ -7,11 +7,8 @@ package security
 import (
 	"fmt"
 	"runtime"
-	"strings"
 
 	"github.com/spf13/cobra"
-
-	"github.com/papa0four/orkowatch/internal/security/audit"
 )
 
 func init() {
@@ -19,41 +16,21 @@ func init() {
 }
 
 func runWindowsAudit(cmd *cobra.Command, args []string) error {
-	var checks []string
-	if checkSSH {
-		checks = append(checks, "ssh")
+	checks := buildChecks()
+
+	if len(checks) == 0 && !verbose {
+		fmt.Println("No checks specified. User --help to see available options.")
+		return cmd.Help()
 	}
-	if checkFirewall {
-		checks = append(checks, "firewall")
-	}
-	if checkUsers {
-		checks = append(checks, "users")
-	}
-	if checkFilePerms != "" {
-		checks = append(checks, "file-permissions")
+
+	if err := validateFlags(); err != nil {
+		return err
 	}
 
 	if verbose {
 		fmt.Printf("[*] Running security audit for OS: %s\n", runtime.GOOS)
-		if len(checks) > 0 {
-			fmt.Printf("[*] Running checks: %s\n", strings.Join(checks, ", "))
-		}
 	}
+	logVerboseConfig(checks)
 
-	opts := audit.Options{
-		Verbose:        verbose,
-		CustomPaths:    customPaths,
-		SkipChecks:     skipChecks,
-		MinSeverity:    minSeverity,
-		Timeout:        timeout,
-		SpecificChecks: checks,
-	}
-
-	auditor := audit.NewSecurityAuditor(opts)
-	result, err := auditor.RunAudit()
-	if err != nil {
-		return fmt.Errorf("audit failed: %w", err)
-	}
-
-	return outputResults(result)
+	return runAuditWithTimeout(checks)
 }


### PR DESCRIPTION
## Summary

`security.go` assigned `RunE: runSecurityAudit` in the `SecurityCmd` struct literal
while both platform files overwrote it via `init()`. Due to Go's initialization order,
the platform handler always won, making `runSecurityAudit` dead code on every platform
and silently dropping `validateFlags()` and timeout enforcement in the process.

## Changes

**`security.go`**
- Removed `RunE: runSecurityAudit` from the `SecurityCmd` struct literal
- Deleted `runSecurityAudit`
- Added `buildChecks()`, `validateFlags()`, `logVerboseConfig()`, and
  `runAuditWithTimeout()` as unexported helpers shared by both platform handlers

**`security_unix.go`**
- Removed manual check assembly, auditor setup, and direct audit execution
- Updated to call shared helpers
- Restored `validateFlags()` and timeout enforcement via `runAuditWithTimeout()`

**`security_windows.go`**
- Same changes as `security_unix.go`

## Result

Each compiled binary now has exactly one `RunE` handler, set once by its platform
`init()`. Flag validation and timeout enforcement are restored on all platforms.
Platform files retain their build-tag structure for future platform-specific work.

Closes #23 