### PR TITLE
Remove duplicate software inventory function from audit package

### DIFF
--- a/internal/softwarelist/softwarelist.go
+++ b/internal/softwarelist/softwarelist.go
@@ -48,7 +48,7 @@ func getWindowsSoftware() (string, error) {
 		`  Format-Table -AutoSize`,
 	}, " ")
 
-	output, err := exec.Command("powershell", "-NoProfile", "-Command", psQuery).Output()
+	output, err := exec.Command("powershell", "-NoProfile", "-Command", psQuery).Output() // #nosec G204 -- psQuery is constructed from hardcoded string literals; no user input is included
 	if err == nil {
 		return string(output), nil
 	}


### PR DESCRIPTION
## Summary

`audit.go` contained a `getSoftwareInfo()` function that duplicated the purpose
of `softwarelist.GetInstalledSoftware()` with inferior platform coverage on every
supported OS. The audit was bypassing the more complete implementation that already
existed in the `softwarelist` package.

## Coverage Gaps Resolved

| Platform | Before | After |
|----------|--------|-------|
| Linux | `dpkg-query` only | `dpkg-query` → `rpm` fallback |
| Windows | PowerShell registry (32-bit path only) | PowerShell registry (64-bit + 32-bit) -> `wmic` fallback |
| macOS | `system_profiler` filtered to Name/Version | `system_profiler` full output |
| FreeBSD | Not supported | `pkg info` |

## Changes

**`softwarelist.go`**
- Updated `getWindowsSoftware()` to query both 64-bit and 32-bit registry
  uninstall paths via PowerShell, falling back to `wmic` for older systems

**`audit.go`**
- Deleted `getSoftwareInfo()`
- Updated `getSystemInfo()` to call `softwarelist.GetInstalledSoftware()`
- Software count derived from the returned string in `getSystemInfo()`
- Added `softwarelist` import

Closes #25 