### PR TITLE
[Bug] Fix Windows audit correctness: SSH hang, per-check timing never set, kernel version silent failure

### DIFF
--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -143,8 +143,6 @@ func runOSFingerprint() (*osfingerprint.OSInfo, error) {
 	}
 
 	if allVerbose {
-		// fmt.Printf("[*] OS: %s | Platform: %s | Version: %s | Kernel: %s\n",
-		// 	info.OS, info.Platform, info.PlatformVersion, info.KernelVersion)
 		line := fmt.Sprintf("[*] OS: %s | Platform: %s | OS Version: %s",
 			info.OS, info.Platform, info.PlatformVersion)
 		if info.KernelVersion != "" && info.KernelVersion != info.PlatformVersion {
@@ -169,7 +167,7 @@ func runSoftwareInventory() (string, int, error) {
 	softwareCount := strings.Count(software, "\n") + 1
 
 	if allVerbose {
-		fmt.Printf("[*] Found %d installed packages\n", softwareCount)
+		fmt.Printf("[*] Found %d installed packages\n\n", softwareCount)
 		fmt.Println(software)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.3
 require (
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sys v0.44.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -16,5 +17,4 @@ require (
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.8.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	golang.org/x/sys v0.26.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
-golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/papa0four/orkowatch/internal/security/checker"
 	"github.com/papa0four/orkowatch/internal/security/types"
-	"github.com/papa0four/orkowatch/internal/softwarelist"
 )
 
 // SecurityAuditor handles the orchestration of security checks
@@ -104,16 +103,16 @@ func (sa *SecurityAuditor) RunAudit() (*Result, error) {
 			var checkResult types.AuditResult
 			switch check {
 			case "ssh":
-				checkResult = sa.sshChecker.Check()
+				checkResult = timeCheck(sa.sshChecker.Check)
 				result.Results = append(result.Results, checkResult)
 			case "firewall":
-				checkResult = sa.firewallChecker.Check()
+				checkResult = timeCheck(sa.firewallChecker.Check)
 				result.Results = append(result.Results, checkResult)
 			case "users":
-				checkResult = sa.userChecker.Check()
+				checkResult = timeCheck(sa.userChecker.Check)
 				result.Results = append(result.Results, checkResult)
 			case "file-permissions":
-				checkResult = sa.permissionChecker.Check()
+				checkResult = timeCheck(sa.permissionChecker.Check)
 				result.Results = append(result.Results, checkResult)
 			}
 		}
@@ -143,7 +142,7 @@ func (sa *SecurityAuditor) runAllChecks(result *Result) (*Result, error) {
 		if sa.verbose {
 			fmt.Println("[*] Running SSH configuration check...")
 		}
-		resultsChan <- sa.sshChecker.Check()
+		resultsChan <- timeCheck(sa.sshChecker.Check)
 	}()
 
 	wg.Add(1)
@@ -152,7 +151,7 @@ func (sa *SecurityAuditor) runAllChecks(result *Result) (*Result, error) {
 		if sa.verbose {
 			fmt.Println("[*] Running firewall configuration check...")
 		}
-		resultsChan <- sa.firewallChecker.Check()
+		resultsChan <- timeCheck(sa.firewallChecker.Check)
 	}()
 
 	wg.Add(1)
@@ -161,7 +160,7 @@ func (sa *SecurityAuditor) runAllChecks(result *Result) (*Result, error) {
 		if sa.verbose {
 			fmt.Println("[*] Running user account security check...")
 		}
-		resultsChan <- sa.userChecker.Check()
+		resultsChan <- timeCheck(sa.userChecker.Check)
 	}()
 
 	wg.Add(1)
@@ -170,7 +169,7 @@ func (sa *SecurityAuditor) runAllChecks(result *Result) (*Result, error) {
 		if sa.verbose {
 			fmt.Println("[*] Running file permissions check...")
 		}
-		resultsChan <- sa.permissionChecker.Check()
+		resultsChan <- timeCheck(sa.permissionChecker.Check)
 	}()
 
 	go func() {
@@ -206,7 +205,6 @@ func (sa *SecurityAuditor) calculateSummary(results []types.AuditResult) Summary
 			summary.SkippedChecks++
 		}
 	}
-
 	return summary
 }
 
@@ -223,19 +221,13 @@ func getSystemInfo() SystemInfo {
 	if kernel, err := getKernelVersion(); err == nil {
 		info.KernelVersion = kernel
 	}
-
-	if softwareInfo, err := softwarelist.GetInstalledSoftware(); err == nil {
-		info.SoftwareInfo = softwareInfo
-		info.SoftwareCount = strings.Count(softwareInfo, "\n") + 1
-	}
-
 	return info
 }
 
 func getKernelVersion() (string, error) {
 	switch runtime.GOOS {
 	case "windows":
-		output, err := exec.Command("ver").CombinedOutput()
+		output, err := exec.Command("cmd", "/c", "ver").CombinedOutput()
 		if err != nil {
 			return "", err
 		}
@@ -247,6 +239,16 @@ func getKernelVersion() (string, error) {
 		}
 		return strings.TrimSpace(string(output)), nil
 	}
+}
+
+func timeCheck(fn func() types.AuditResult) types.AuditResult {
+	start := time.Now()
+	result := fn()
+	end := time.Now()
+	result.StartTime = start
+	result.EndTime = end
+	result.Duration = end.Sub(start)
+	return result
 }
 
 func containsWarning(details []string) bool {

--- a/internal/security/checker/ssh.go
+++ b/internal/security/checker/ssh.go
@@ -159,34 +159,51 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 		Details:     make([]string, 0),
 	}
 
-	// Check OpenSSH installation
-	cmd := exec.Command("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-Command",
-		"Get-WindowsCapability -Online | Where-Object {$_.Name -like '*OpenSSH.Server*' }")
-	output, err := cmd.CombinedOutput()
+	sshdInstalled := false
 
-	if err != nil {
-		result.Status = "ERROR"
-		result.Description = "Failed to check OpenSSH installation"
-		result.Details = append(result.Details,
-			fmt.Sprintf("%s Error checking OpenSSH installation: %v", types.SymbolError, err))
-		return result
+	// Check OpenSSH installation
+	cmd := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-Command",
+		"(Get-Service -Name sshd -ErrorAction SilentlyContinue).Status")
+	output, err := cmd.CombinedOutput()
+	serviceStatus := strings.TrimSpace(string(output))
+	if err == nil && serviceStatus != "" {
+		sshdInstalled = true
+		switch serviceStatus {
+		case "Running":
+			result.Details = append(result.Details,
+				fmt.Sprintf("%s OpenSSH Server is installed and running", types.SymbolOK))
+		case "Stopped":
+			result.Details = append(result.Details,
+				fmt.Sprintf("%s OpenSSH Server is installed but not running", types.SymbolWarning))
+		default:
+			result.Details = append(result.Details,
+				fmt.Sprintf("%s OpenSSH Server service state: %s", types.SymbolInfo, serviceStatus))
+		}
 	}
 
-	// Process OpenSSH installation status
-	if strings.Contains(string(output), "State : Installed") {
-		result.Details = append(result.Details,
-			fmt.Sprintf("%s OpenSSH Server is installed", types.SymbolOK))
+	const sshdBinaryPath = `C:\Windows\System32\OpenSSH\sshd.exe`
+	if !sshdInstalled {
+		if _, err := os.Stat(sshdBinaryPath); err == nil {
+			sshdInstalled = true
+			result.Details = append(result.Details,
+				fmt.Sprintf("%s OpenSSH Server binary found (service not detected)", types.SymbolInfo))
+		}
+	}
 
-		// Check OpenSSH configuration if installed
+	if !sshdInstalled {
+		result.Details = append(result.Details,
+			fmt.Sprintf("%s OpenSSH Server is not installed", types.SymbolInfo))
+	}
+
+	// Parse sshd_config if installed
+	if sshdInstalled {
 		if _, err := os.Stat(s.ConfigPath); err == nil {
-			file, err := os.Open(s.ConfigPath)
+			file, err := os.Open(s.ConfigPath) // #nosec G304 -- path set in NewWindowsSSHChecker to a hardcoded system location
 			if err != nil {
 				result.Details = append(result.Details,
 					fmt.Sprintf("%s ERROR: Cannot read OpenSSH configuration: %v", types.SymbolError, err))
 			} else {
 				defer file.Close() // nolint:errcheck // read-only file; close error does not affect scan results
-				result.Details = append(result.Details,
-					fmt.Sprintf("%s Analyzing OpenSSH configuration...", types.SymbolInfo))
 
 				config := &sshConfig{}
 				scanner := bufio.NewScanner(file)
@@ -217,7 +234,6 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 							types.SymbolError, err))
 				}
 
-				// Report OpenSSH configuration findings
 				if config.permRootFound {
 					if config.rootLogin {
 						result.Details = append(result.Details,
@@ -242,18 +258,14 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: OpenSSH configuration file not found", types.SymbolWarning))
 		}
-	} else {
-		result.Details = append(result.Details,
-			fmt.Sprintf("%s OpenSSH Server is not installed", types.SymbolInfo))
 	}
 
 	// Check for PuTTY installation
-	if _, err := os.Stat("C:\\Program Files\\PuTTY\\putty.exe"); err == nil {
+	if _, err := os.Stat(`C:\Program Files\PuTTY\putty.exe`); err == nil {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s PuTTY is installed", types.SymbolInfo))
 
-		// Check PuTTY registry settings
-		cmd = exec.Command("reg", "query", "HKCU\\Software\\SimonTatham\\PuTTY\\Sessions")
+		cmd = exec.Command("reg", "query", `HKCU\Software\SimonTatham\PuTTY\Sessions`)
 		output, err := cmd.CombinedOutput()
 		if err == nil && len(output) > 0 {
 			sessions := strings.Split(string(output), "\n")
@@ -261,7 +273,8 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 				fmt.Sprintf("%s PuTTY configured sessions:", types.SymbolInfo))
 			for _, session := range sessions {
 				if strings.TrimSpace(session) != "" {
-					result.Details = append(result.Details, fmt.Sprintf(" - %s", strings.TrimSpace(session)))
+					result.Details = append(result.Details,
+						fmt.Sprintf(" - %s", strings.TrimSpace(session)))
 				}
 			}
 		}

--- a/internal/security/formatter/formatter.go
+++ b/internal/security/formatter/formatter.go
@@ -129,6 +129,7 @@ func (f *Formatter) prepareOutput(result *audit.Result) map[string]interface{} {
 		"warning_checks": result.Summary.WarningChecks,
 		"failed_checks":  result.Summary.FailedChecks,
 		"skipped_checks": result.Summary.SkippedChecks,
+		"duration":       result.Duration.String(),
 	}
 
 	return output
@@ -202,7 +203,6 @@ const defaultTemplate = `
 Security Audit Report
 ====================
 Generated: {{.timestamp}}
-Duration: {{.duration}}
 
 {{if .system}}
 System Information
@@ -244,4 +244,5 @@ Passed: {{.summary.passed_checks}}
 Warnings: {{.summary.warning_checks}}
 Failed: {{.summary.failed_checks}}
 Skipped: {{.summary.skipped_checks}}
+Duration: {{.summary.duration}}
 `

--- a/internal/softwarelist/softwarelist.go
+++ b/internal/softwarelist/softwarelist.go
@@ -1,80 +1,13 @@
 // internal/softwarelist/softwarelist.go
 package softwarelist
 
-import (
-	"fmt"
-	"os/exec"
-	"runtime"
-	"strings"
-)
+import "fmt"
 
 // GetInstalledSoftware retrieves a list of installed software based on the OS
 func GetInstalledSoftware() (string, error) {
-	switch runtime.GOOS {
-	case "linux":
-		return getLinuxSoftware()
-	case "windows":
-		return getWindowsSoftware()
-	case "darwin":
-		return getMacSoftware()
-	case "freebsd":
-		return getFreeBSDSoftware()
-	default:
-		return "", fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+	result, err := getPlatformSoftware()
+	if err != nil {
+		return "", fmt.Errorf("software enumeration failed: %w", err)
 	}
-}
-
-func getLinuxSoftware() (string, error) {
-	if output, err := exec.Command("dpkg-query", "-l").Output(); err == nil {
-		return string(output), nil
-	}
-
-	if output, err := exec.Command("rpm", "-qa").Output(); err == nil {
-		return string(output), nil
-	}
-
-	return "", fmt.Errorf("insufficient permissions to list all software packages; try rerunning with sudo")
-}
-
-func getWindowsSoftware() (string, error) {
-	psQuery := strings.Join([]string{
-		`$paths = @(`,
-		`  'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',`,
-		`  'HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'`,
-		`)`,
-		`Get-ItemProperty $paths |`,
-		`  Select-Object DisplayName, DisplayVersion, Publisher, InstallDate |`,
-		`  Where-Object { $_.DisplayName } |`,
-		`  Format-Table -AutoSize`,
-	}, " ")
-
-	output, err := exec.Command("powershell", "-NoProfile", "-Command", psQuery).Output() // #nosec G204 -- psQuery is constructed from hardcoded string literals; no user input is included
-	if err == nil {
-		return string(output), nil
-	}
-
-	output, err = exec.Command("wmic", "product", "get", "name,version").Output()
-	if err == nil {
-		return string(output), nil
-	}
-
-	return "", fmt.Errorf("insufficient permissions to list all software packages; try rerunning as Administrator")
-}
-
-func getMacSoftware() (string, error) {
-	output, err := exec.Command("system_profiler", "SPApplicationsDataType").Output()
-	if err == nil {
-		return string(output), nil
-	}
-
-	return "", fmt.Errorf("insufficient permissions to list all software packages; try rerunning with sudo")
-}
-
-func getFreeBSDSoftware() (string, error) {
-	output, err := exec.Command("pkg", "info").Output()
-	if err == nil {
-		return string(output), nil
-	}
-
-	return "", fmt.Errorf("insufficient permissions to list all software packages; try rerunning with sudo")
+	return result, nil
 }

--- a/internal/softwarelist/softwarelist_unix.go
+++ b/internal/softwarelist/softwarelist_unix.go
@@ -1,0 +1,42 @@
+//go:build linux || darwin || freebsd
+
+// internal/softwarelist/softwarelist_unix.go
+package softwarelist
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// getPlatformSoftware enumerates installed software using the appropriate
+// package manager or system tool for the current Unix-like platform.
+func getPlatformSoftware() (string, error) {
+	switch runtime.GOOS {
+	case "linux":
+		if output, err := exec.Command("dpkg-query", "-l").Output(); err == nil {
+			return string(output), nil
+		}
+		if output, err := exec.Command("rpm", "-qa").Output(); err == nil {
+			return string(output), nil
+		}
+		return "", fmt.Errorf("no supported package manager found; try rerunning with sudo")
+
+	case "darwin":
+		output, err := exec.Command("system_profiler", "SPApplicationsDataType").Output()
+		if err == nil {
+			return string(output), nil
+		}
+		return "", fmt.Errorf("insufficient permissions to list software packages; try rerunning with sudo")
+
+	case "freebsd":
+		output, err := exec.Command("pkg", "info").Output()
+		if err == nil {
+			return string(output), nil
+		}
+		return "", fmt.Errorf("insufficient permissions to list software packages; try rerunning with sudo")
+
+	default:
+		return "", fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+	}
+}

--- a/internal/softwarelist/softwarelist_windows.go
+++ b/internal/softwarelist/softwarelist_windows.go
@@ -1,0 +1,114 @@
+//go:build windows
+
+// internal/softwarelist/softwarelist_windows.go
+package softwarelist
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// getPlatformSoftware reads installed software directly from the Windows
+// registry. Four locations are checked for complete coverage:
+//   - HKLM 64-bit uninstall path (system-wide 64-bit installs)
+//   - HKLM 32-bit Wow6432Node path (system-wide 32-bit installs)
+//   - HKCU 64-bit uninstall path (current user 64-bit installs)
+//   - HKCU 32-bit Wow6432Node path (current user 32-bit installs)
+//
+// A display name map deduplicates entries that appear in multiple paths.
+// wmic is called as a fallback for environments where registry
+// access is restricted, but its use is flagged since it is deprecated as of
+// Windows 10 21H1.
+func getPlatformSoftware() (string, error) {
+	const (
+		uninstallPath   = `Software\Microsoft\Windows\CurrentVersion\Uninstall`
+		uninstallPath32 = `Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall`
+	)
+
+	type registryTarget struct {
+		root registry.Key
+		path string
+	}
+
+	targets := []registryTarget{
+		{registry.LOCAL_MACHINE, uninstallPath},
+		{registry.LOCAL_MACHINE, uninstallPath32},
+		{registry.CURRENT_USER, uninstallPath},
+		{registry.CURRENT_USER, uninstallPath32},
+	}
+
+	type entry struct {
+		name    string
+		version string
+	}
+
+	seen := make(map[string]bool)
+	var entries []entry
+
+	for _, target := range targets {
+		k, err := registry.OpenKey(target.root, target.path,
+			registry.ENUMERATE_SUB_KEYS|registry.QUERY_VALUE)
+		if err != nil {
+			continue
+		}
+
+		subkeys, readErr := k.ReadSubKeyNames(-1)
+		if closeErr := k.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "[!] WARNING: failed to close registry key %s: %v\n", target.path, closeErr)
+		}
+		if readErr != nil {
+			continue
+		}
+
+		for _, sub := range subkeys {
+			sk, err := registry.OpenKey(target.root,
+				target.path+`\`+sub, registry.QUERY_VALUE)
+			if err != nil {
+				continue
+			}
+
+			name, _, err := sk.GetStringValue("DisplayName")
+			if err != nil || name == "" {
+				if closeErr := sk.Close(); closeErr != nil {
+					fmt.Fprintf(os.Stderr, "[!] WARNING: failed to close registry subkey %s: %v\n", sub, closeErr)
+				}
+				continue
+			}
+
+			version, _, _ := sk.GetStringValue("DisplayVersion") //nolint:errcheck // version is optional; missing or unreadable value is treated as empty
+			if closeErr := sk.Close(); closeErr != nil {
+				fmt.Fprintf(os.Stderr, "[!] WARNING: failed to close registry subkey %s: %v\n", sub, closeErr)
+			}
+
+			if seen[name] {
+				continue
+			}
+
+			seen[name] = true
+			entries = append(entries, entry{name: name, version: version})
+		}
+	}
+
+	if len(entries) > 0 {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%-60s %s\n", "Name", "Version")
+		for _, e := range entries {
+			fmt.Fprintf(&sb, "%-60s %s\n", e.name, e.version)
+		}
+		return sb.String(), nil
+	}
+
+	// wmic fallback
+	fmt.Fprintln(os.Stderr,
+		"[!] WARNING: registry read returned no results; falling back to wmic (deprecated on Windows 10 21H1+)")
+	output, err := exec.Command("wmic", "product", "get", "name,version").Output()
+	if err == nil {
+		return string(output), nil
+	}
+
+	return "", fmt.Errorf("insufficient permissions to list software packages; try rerunning as Administrator")
+}


### PR DESCRIPTION
## Overview

Resolves three correctness bugs in the Windows audit path. Fixes are applied
in dependency order: the SSH hang first so timing data is meaningful, then
per-check timing instrumentation, then kernel version cleanup. Includes a
related performance fix for the software enumeration duplication that caused
a 60+ second hang on the `all` command.

## Changes

### SSH Checker Blocks on Network Call
- Replaced `Get-WindowsCapability -Online` with a local `Get-Service sshd`
  query and an `os.Stat` fallback check on the OpenSSH binary
- Eliminates a 60 second hang caused by a Windows Update network call with
  no timeout

### Per-Check Duration Always Reported 0s
- Added `timeCheck()` helper in `audit.go` wrapping each checker call with
  wall-clock timing
- Populates `StartTime`, `EndTime`, and `Duration` on every `AuditResult`
  in both the specific-checks path and the goroutine path in `runAllChecks`

### Kernel Version Fails Silently on Windows
- Fixed `getKernelVersion()` Windows path from `exec.Command("ver")` to
  `exec.Command("cmd", "/c", "ver")`
- Removed the now-redundant `softwarelist` call from `getSystemInfo()` since
  software enumeration belongs to the software module, not the security auditor

### Software Enumeration Duplication and Performance
- Replaced the PowerShell registry query in `getWindowsSoftware()` with a
  direct in-process registry read via `golang.org/x/sys/windows/registry`
- Reads all four registry locations: HKLM and HKCU for both 64-bit and
  32-bit uninstall paths, with deduplication
- Retains `wmic` as a last-resort fallback with a deprecation warning
- Split `softwarelist.go` into platform-specific files: `softwarelist.go`
  as the wrapper, `softwarelist_windows.go`, and `softwarelist_unix.go`
- Updated `golang.org/x/sys` to `v0.44.0` to resolve GO-2026-5024
- Total `all` command runtime reduced from 62 seconds to under 3 seconds

## Files Changed

- `internal/security/checker/ssh.go`
- `internal/security/audit/audit.go`
- `internal/security/formatter/formatter.go`
- `internal/softwarelist/softwarelist.go`
- `internal/softwarelist/softwarelist_windows.go` (new)
- `internal/softwarelist/softwarelist_unix.go` (new)
- `go.mod` / `go.sum`

Closes #29 