### PR TITLE
[Chore] Add internal/security/registry foundation for structured finding definitions

### DIFF
--- a/internal/security/registry/data/darwin.yaml
+++ b/internal/security/registry/data/darwin.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/linux_alpine.yaml
+++ b/internal/security/registry/data/linux_alpine.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/linux_arch.yaml
+++ b/internal/security/registry/data/linux_arch.yaml
@@ -1,1 +1,273 @@
-# stub: findings for this platform/family are pending implementation
+# Arch family finding definitions for the orkowatch registry.
+# Covers Arch Linux, Manjaro, EndeavourOS, Garuda, Artix, and derivatives
+# identified via ID_LIKE=arch in /etc/os-release.
+# Severity tiers follow CVSS v3.1 base score ranges:
+#   CRITICAL 9.0-10.0 | HIGH 7.0-8.9 | MEDIUM 4.0-6.9 | LOW 0.1-3.9
+# All entries sourced from Arch Linux Security wiki, CIS Distribution
+# Independent Linux Benchmark v2.0.0, NIST SP 800-53 Rev 5, and
+# CVSS v3.1 scoring methodology.
+# Note: Arch Linux has no official CIS benchmark. Entries reference
+# the Arch Security wiki and CIS Distribution Independent where applicable.
+
+# -------------------------
+# Firewall checker findings
+# -------------------------
+
+firewall.no_firewall_installed:
+  title: "No firewall manager is installed or active"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-284"
+  description: >
+    Arch Linux does not install a firewall manager by default. Neither
+    iptables, nftables, ufw, nor firewalld was detected as active on
+    this system. The host has no host-based packet filtering in place.
+    Unlike Debian or RHEL family systems, Arch ships with no default
+    firewall configuration and requires explicit installation and
+    configuration by the administrator.
+  impact: >
+    All services bound to any network interface are directly reachable
+    without restriction. Any service started on the host — including
+    development servers, databases, or remote desktop tools — is
+    immediately network-accessible without explicit firewall rules.
+  resolution: >
+    Install and configure nftables, which is the modern kernel-level
+    replacement for iptables and the recommended choice on Arch:
+    pacman -S nftables && systemctl enable --now nftables. Create a
+    base ruleset in /etc/nftables.conf with a default drop policy and
+    explicit allow rules for required services.
+  references:
+    - "Arch Linux Security Wiki: https://wiki.archlinux.org/title/Security#Firewalls"
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §3.5"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+firewall.nftables_no_rules:
+  title: "nftables is active but has no rules configured"
+  severity: "HIGH"
+  cvss_score: 8.2
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H"
+  cwe: "CWE-284"
+  description: >
+    nftables is the active firewall manager but no rules are loaded.
+    An nftables instance with no ruleset provides no packet filtering —
+    all traffic is permitted by default. This is equivalent to having
+    no firewall active despite the service running.
+  impact: >
+    All listening services remain fully accessible on all interfaces.
+    The presence of a running nftables service may create a false
+    sense of security. Traffic filtering requires an explicit ruleset
+    to be loaded — an empty ruleset enforces nothing.
+  resolution: >
+    Create a base ruleset in /etc/nftables.conf with a default drop
+    policy on the input chain and explicit allow rules for required
+    services. Load the ruleset: nft -f /etc/nftables.conf. Enable
+    the service to persist across reboots: systemctl enable nftables.
+  references:
+    - "Arch Linux Wiki nftables: https://wiki.archlinux.org/title/nftables"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+firewall.iptables_default_accept:
+  title: "iptables default policy is ACCEPT on INPUT chain"
+  severity: "HIGH"
+  cvss_score: 8.6
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:H"
+  cwe: "CWE-284"
+  description: >
+    The iptables INPUT chain has a default policy of ACCEPT, meaning
+    any traffic not matched by an explicit rule is permitted through.
+    A secure firewall posture requires a default DROP or REJECT policy
+    with explicit allow rules for required traffic only.
+  impact: >
+    Any service listening on any interface is reachable unless explicitly
+    blocked by a rule. New services started on the host are automatically
+    network-accessible without any firewall change required. This inverts
+    the intended security model of deny-by-default.
+  resolution: >
+    Set a default DROP policy on the INPUT chain: iptables -P INPUT DROP.
+    Add explicit ACCEPT rules for required traffic before applying the
+    default drop to avoid lockout. Persist rules across reboots via
+    iptables-save > /etc/iptables/iptables.rules and enable the
+    iptables systemd service.
+  references:
+    - "Arch Linux Wiki iptables: https://wiki.archlinux.org/title/iptables"
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §3.5.3"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+# -------------------------
+# User checker findings
+# -------------------------
+
+users.sudo_nopasswd:
+  title: "Sudoers entry permits privilege escalation without password"
+  severity: "HIGH"
+  cvss_score: 8.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+  cwe: "CWE-269"
+  description: >
+    A sudoers rule contains the NOPASSWD tag, allowing one or more users
+    to execute commands with elevated privileges without providing a
+    password. On Arch-family systems this is commonly added during
+    initial setup for convenience and frequently left in place.
+  impact: >
+    Any attacker or process that gains access to the affected user account
+    can immediately escalate to root without any additional credential.
+    This is particularly significant on Arch systems where the primary
+    user account is commonly the sole administrator and frequently
+    targeted for NOPASSWD configuration during installation.
+  resolution: >
+    Remove NOPASSWD tags from sudoers rules: visudo. If passwordless
+    sudo is required for specific automation tasks, scope it to the
+    minimum required commands rather than ALL. Require password
+    confirmation for interactive administrative work.
+  references:
+    - "Arch Linux Security Wiki: https://wiki.archlinux.org/title/Security#sudo"
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.3.7"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/269.html"
+
+users.wheel_group_unrestricted:
+  title: "wheel group has unrestricted sudo access"
+  severity: "MEDIUM"
+  cvss_score: 6.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-269"
+  description: >
+    The wheel group is configured with unrestricted sudo access to all
+    commands. On Arch Linux this is the default sudoers configuration
+    when the wheel group line is uncommented during setup. Every member
+    of the wheel group can run any command as root.
+  impact: >
+    Compromise of any wheel group member account yields full root access
+    via sudo. If multiple user accounts are in the wheel group, the
+    attack surface for privilege escalation is multiplied. Unrestricted
+    wheel access provides no command-level containment.
+  resolution: >
+    Audit wheel group membership: getent group wheel. Remove accounts
+    that do not require administrative access. Consider restricting
+    sudo access to specific commands for accounts that only need
+    limited elevation rather than full wheel membership.
+  references:
+    - "Arch Linux Security Wiki: https://wiki.archlinux.org/title/Security#sudo"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/269.html"
+
+users.aur_helper_installed:
+  title: "AUR helper is installed"
+  severity: "LOW"
+  cvss_score: 3.3
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+  cwe: "CWE-829"
+  description: >
+    An AUR (Arch User Repository) helper such as yay, paru, or trizen
+    is installed. AUR packages are community-maintained PKGBUILDs that
+    are not reviewed or signed by Arch Linux maintainers. AUR helpers
+    automate the download and build of these packages, which execute
+    arbitrary build scripts with user privileges.
+  impact: >
+    AUR packages execute PKGBUILD scripts during installation that can
+    contain arbitrary commands. Malicious or compromised AUR packages
+    have historically been used to deliver malware. The risk is
+    proportional to the number of AUR packages installed and the
+    diligence with which PKGBUILDs are reviewed before installation.
+  resolution: >
+    Review all installed AUR packages and their PKGBUILDs. Remove AUR
+    packages that are available in the official repositories. Always
+    read PKGBUILDs before installing AUR packages. Consider using
+    an isolated build environment for AUR package compilation.
+  references:
+    - "Arch Linux AUR Security: https://wiki.archlinux.org/title/AUR#Safety"
+    - "NIST SP 800-53 Rev 5 CM-7 (Least Functionality)"
+    - "https://cwe.mitre.org/data/definitions/829.html"
+
+# -------------------------
+# Permissions checker findings
+# -------------------------
+
+permissions.shadow_world_readable:
+  title: "/etc/shadow is readable by non-root users"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:N"
+  cwe: "CWE-732"
+  description: >
+    /etc/shadow has permissions that allow non-root users to read its
+    contents. On Arch Linux the expected permission is 640 with ownership
+    root:shadow. Any deviation allows password hash extraction by
+    unprivileged users or processes.
+  impact: >
+    Any local user or process that can read /etc/shadow gains access to
+    all local password hashes for offline cracking. On Arch systems
+    where the primary user account is commonly the only human account,
+    cracking this hash yields full system access via sudo.
+  resolution: >
+    Restore correct permissions: chmod 640 /etc/shadow && chown
+    root:shadow /etc/shadow. Verify: ls -la /etc/shadow. Rotate
+    passwords for all accounts as a precaution if the file was
+    readable for an unknown period.
+  references:
+    - "Arch Linux Security Wiki: https://wiki.archlinux.org/title/Security"
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §6.1.3"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.pacman_cache_world_writable:
+  title: "pacman cache directory is world-writable"
+  severity: "HIGH"
+  cvss_score: 7.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-732"
+  description: >
+    The pacman package cache directory (/var/cache/pacman/pkg) is
+    world-writable. Package files in this directory are used by pacman
+    during installation and upgrades. A world-writable cache allows
+    any local user to replace cached package files with malicious
+    versions that will be installed on the next pacman operation.
+  impact: >
+    A local attacker can replace a cached package tarball with a
+    backdoored version. The next time pacman installs or upgrades
+    that package, the malicious version is installed with root
+    privileges. This enables persistent privilege escalation and
+    backdoor installation without exploiting any software vulnerability.
+  resolution: >
+    Restore correct permissions: chmod 755 /var/cache/pacman/pkg &&
+    chown root:root /var/cache/pacman/pkg. Verify no unexpected files
+    are present in the cache. Clear and repopulate the cache if
+    tampering is suspected: pacman -Scc.
+  references:
+    - "Arch Linux Wiki pacman: https://wiki.archlinux.org/title/pacman"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.ssh_dir_permissions:
+  title: "SSH directory or authorized_keys has incorrect permissions"
+  severity: "HIGH"
+  cvss_score: 7.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-732"
+  description: >
+    A user's ~/.ssh directory or ~/.ssh/authorized_keys file has
+    permissions that exceed the expected mode. On Arch Linux, OpenSSH
+    enforces StrictModes by default and will refuse to use keys from
+    directories or files with overly permissive modes. Misconfigured
+    permissions also enable unauthorized key injection by other local
+    users.
+  impact: >
+    World or group writable ~/.ssh directories allow other local users
+    to inject authorized keys, granting themselves SSH access as the
+    target user. On Arch systems where the primary user commonly has
+    full sudo access, this enables complete system compromise via
+    key injection alone.
+  resolution: >
+    Set correct permissions: chmod 700 ~/.ssh && chmod 600
+    ~/.ssh/authorized_keys. Verify ownership: chown -R <user>:<user>
+    ~/.ssh. Audit authorized_keys for unexpected entries. Verify
+    StrictModes yes is set or absent (default) in sshd_config.
+  references:
+    - "Arch Linux Security Wiki: https://wiki.archlinux.org/title/Security"
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.2.19"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"

--- a/internal/security/registry/data/linux_arch.yaml
+++ b/internal/security/registry/data/linux_arch.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/linux_common.yaml
+++ b/internal/security/registry/data/linux_common.yaml
@@ -1,0 +1,431 @@
+# Linux common finding definitions for the orkowatch registry.
+# These findings apply across all Linux distributions regardless of family.
+# Severity tiers follow CVSS v3.1 base score ranges:
+#   CRITICAL 9.0-10.0 | HIGH 7.0-8.9 | MEDIUM 4.0-6.9 | LOW 0.1-3.9
+# All entries sourced from CIS Distribution Independent Linux Benchmark v2.0.0,
+# NIST SP 800-53 Rev 5, and CVSS v3.1 scoring methodology.
+
+# -------------------------
+# SSH checker findings
+# -------------------------
+
+ssh.config_not_found:
+  title: "SSH daemon configuration file not found"
+  severity: "MEDIUM"
+  cvss_score: 5.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L"
+  cwe: "CWE-16"
+  description: >
+    No sshd_config file was found at any expected path. Without an explicit
+    configuration file, sshd falls back to compiled-in defaults which vary
+    by distribution and OpenSSH version. Default configurations frequently
+    permit password authentication and may not restrict root login.
+  impact: >
+    An SSH daemon running without an explicit configuration file may permit
+    password-based authentication, weak ciphers, or root login depending on
+    compiled defaults. The security posture of the service cannot be verified
+    without a configuration file present.
+  resolution: >
+    Create /etc/ssh/sshd_config with explicit directives for
+    PasswordAuthentication, PermitRootLogin, AllowUsers, and cipher
+    suites. Restart sshd after making changes: systemctl restart sshd.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.2"
+    - "NIST SP 800-53 Rev 5 CM-6 (Configuration Settings)"
+    - "https://cwe.mitre.org/data/definitions/16.html"
+
+ssh.root_login_permitted:
+  title: "SSH PermitRootLogin is not explicitly disabled"
+  severity: "CRITICAL"
+  cvss_score: 9.8
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-250"
+  description: >
+    PermitRootLogin is not set to no in sshd_config. Direct root login
+    over SSH gives an attacker full system control upon credential compromise
+    with no privilege escalation step required. OpenSSH defaults vary by
+    version — absence of this directive is not safe.
+  impact: >
+    A successful brute-force, credential stuffing, or key theft attack
+    against the root account yields immediate full control of the host.
+    No additional exploitation step is required post-authentication.
+    Combined with password authentication, this represents maximum SSH
+    exposure.
+  resolution: >
+    Set PermitRootLogin no in /etc/ssh/sshd_config and restart sshd.
+    Administrative access should use key-based authentication to a
+    non-privileged account followed by explicit privilege escalation
+    via sudo.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.2.8"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "NIST SP 800-53 Rev 5 IA-2 (Identification and Authentication)"
+    - "https://cwe.mitre.org/data/definitions/250.html"
+
+ssh.password_auth_enabled:
+  title: "SSH password authentication is enabled"
+  severity: "HIGH"
+  cvss_score: 7.5
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-521"
+  description: >
+    PasswordAuthentication is set to yes in sshd_config. Password-based
+    SSH authentication is susceptible to brute-force and credential stuffing
+    attacks. Any account reachable via SSH with a weak or reused password
+    is directly at risk.
+  impact: >
+    Automated brute-force tools can systematically attempt credentials
+    against the SSH service. Credential exposure from unrelated data
+    breaches directly translates to SSH access risk for any account
+    with a matching password.
+  resolution: >
+    Set PasswordAuthentication no in /etc/ssh/sshd_config and configure
+    key-based authentication exclusively. Distribute authorized_keys to
+    required users before disabling password auth to avoid lockout.
+    Restart sshd after changes.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.2.11"
+    - "NIST SP 800-53 Rev 5 IA-5(1) (Authenticator Management)"
+    - "https://cwe.mitre.org/data/definitions/521.html"
+
+ssh.permit_root_login_not_set:
+  title: "PermitRootLogin directive is absent from SSH configuration"
+  severity: "MEDIUM"
+  cvss_score: 5.9
+  cvss_vector: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-16"
+  description: >
+    The PermitRootLogin directive was not found in sshd_config. OpenSSH
+    compiled defaults vary by distribution and version. On some systems
+    the default permits root login; on others it does not. Absence of
+    an explicit setting leaves the behavior undefined and
+    distribution-dependent.
+  impact: >
+    Without an explicit PermitRootLogin directive, the effective policy
+    depends on the OpenSSH build configuration for the installed version.
+    System updates or package replacements may silently change the
+    effective default.
+  resolution: >
+    Add PermitRootLogin no explicitly to /etc/ssh/sshd_config regardless
+    of the assumed default. Explicit configuration is always safer than
+    relying on compiled-in defaults.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.2.8"
+    - "NIST SP 800-53 Rev 5 CM-6 (Configuration Settings)"
+    - "https://cwe.mitre.org/data/definitions/16.html"
+
+ssh.password_auth_not_set:
+  title: "PasswordAuthentication directive is absent from SSH configuration"
+  severity: "MEDIUM"
+  cvss_score: 5.9
+  cvss_vector: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-16"
+  description: >
+    The PasswordAuthentication directive was not found in sshd_config.
+    OpenSSH defaults to permitting password authentication when this
+    directive is absent, meaning the service may accept password-based
+    logins even without explicit configuration.
+  impact: >
+    Password authentication may be silently active. Any account accessible
+    via SSH with a weak or reused password is exposed to brute-force
+    attacks without the operator being aware that password auth is enabled.
+  resolution: >
+    Add PasswordAuthentication no explicitly to /etc/ssh/sshd_config.
+    Configure key-based authentication before disabling password auth
+    to prevent lockout. Restart sshd after changes.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.2.11"
+    - "NIST SP 800-53 Rev 5 CM-6 (Configuration Settings)"
+    - "https://cwe.mitre.org/data/definitions/16.html"
+
+# -------------------------
+# Firewall checker findings
+# -------------------------
+
+firewall.no_active_manager:
+  title: "No active firewall manager detected"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-284"
+  description: >
+    None of the recognized firewall managers (iptables, ufw, firewalld,
+    pfctl) are active on this system. The host has no detected host-based
+    packet filtering in place. All listening services are reachable on
+    all interfaces without network-level access control.
+  impact: >
+    Every service bound to a network interface is directly reachable without
+    restriction. This eliminates host-based network controls as a
+    defense-in-depth layer against exploitation, lateral movement, and
+    unauthorized access to internal services.
+  resolution: >
+    Install and enable an appropriate firewall manager for the distribution.
+    On Debian/Ubuntu: ufw enable. On RHEL/Fedora: systemctl enable --now
+    firewalld. Configure rules to permit only required traffic and deny
+    all else by default.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §3.5"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+# -------------------------
+# User checker findings
+# -------------------------
+
+users.empty_password_hash:
+  title: "User account has no password set in /etc/shadow"
+  severity: "CRITICAL"
+  cvss_score: 9.8
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-258"
+  description: >
+    One or more user accounts have an empty password hash field in
+    /etc/shadow. An empty hash means the account has no password and
+    can be accessed without any credential on systems where password
+    authentication is permitted.
+  impact: >
+    Any local or remote attacker can authenticate as this user without
+    providing a password. If the account has sudo access or elevated
+    privileges, this represents an immediate critical compromise path
+    requiring no exploitation.
+  resolution: >
+    Set a strong password immediately: passwd <username>. If the account
+    is a service account that should not allow interactive login, lock it:
+    passwd -l <username> and set the shell to /usr/sbin/nologin in
+    /etc/passwd.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §6.2.1"
+    - "NIST SP 800-53 Rev 5 IA-5 (Authenticator Management)"
+    - "https://cwe.mitre.org/data/definitions/258.html"
+
+users.uid_zero_non_root:
+  title: "Non-root account has UID 0"
+  severity: "CRITICAL"
+  cvss_score: 9.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+  cwe: "CWE-250"
+  description: >
+    A user account other than root has been assigned UID 0. On Linux and
+    Unix systems, UID 0 confers full superuser privileges regardless of
+    the account name. Any account with UID 0 is effectively root.
+  impact: >
+    Compromise of any UID 0 account yields complete system control
+    identical to compromising the root account. Multiple UID 0 accounts
+    expand the attack surface for privilege escalation and make audit
+    trails ambiguous — actions appear to come from different accounts
+    but carry identical privileges.
+  resolution: >
+    Immediately reassign a non-zero UID to the affected account or
+    remove it if it is not required: usermod -u <new_uid> <username>.
+    Investigate how UID 0 was assigned and whether unauthorized access
+    occurred. Only the root account should have UID 0.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §6.2.5"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/250.html"
+
+users.root_account_unlocked:
+  title: "Root account is not locked"
+  severity: "MEDIUM"
+  cvss_score: 6.7
+  cvss_vector: "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-284"
+  description: >
+    The root account is not in a locked state. On systems where
+    administrative access is managed via sudo, the root account itself
+    should be locked to prevent direct root login via password
+    authentication while preserving sudo-based escalation.
+  impact: >
+    An unlocked root account with a password can be targeted directly
+    via SSH brute-force if PermitRootLogin is not explicitly disabled,
+    or via local authentication bypass techniques. Locking root forces
+    all privileged access through auditable sudo paths.
+  resolution: >
+    Lock the root account password: passwd -l root. Ensure sudo is
+    configured to provide necessary administrative access before locking.
+    Verify PermitRootLogin no is set in sshd_config independently.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.4.1"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+users.ldap_configured:
+  title: "LDAP authentication is configured"
+  severity: "LOW"
+  cvss_score: 2.3
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N"
+  cwe: "CWE-287"
+  description: >
+    /etc/ldap.conf is present, indicating LDAP-based authentication is
+    configured. LDAP authentication introduces a network dependency for
+    local login and may expose credentials if the LDAP connection is
+    not encrypted.
+  impact: >
+    If LDAP is configured without TLS/LDAPS, credentials are transmitted
+    in cleartext over the network. An LDAP server outage may prevent
+    local login. Misconfigured LDAP referrals can expose the system to
+    authentication bypass.
+  resolution: >
+    Verify LDAP is configured with TLS (ldaps:// or StartTLS).
+    Ensure a local fallback authentication method exists for system
+    recovery. Review /etc/ldap.conf for cleartext bind credentials.
+  references:
+    - "NIST SP 800-53 Rev 5 IA-3 (Device Identification and Authentication)"
+    - "https://cwe.mitre.org/data/definitions/287.html"
+
+users.kerberos_configured:
+  title: "Kerberos authentication is configured"
+  severity: "LOW"
+  cvss_score: 2.3
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N"
+  cwe: "CWE-287"
+  description: >
+    /etc/krb5.conf is present, indicating Kerberos authentication is
+    configured. Kerberos introduces a KDC dependency for authentication
+    and requires time synchronization within 5 minutes to function
+    correctly.
+  impact: >
+    KDC unavailability or clock skew may prevent authentication. Weak
+    Kerberos encryption types (DES, RC4) in krb5.conf expose ticket
+    traffic to offline cracking. Misconfigured realms may permit
+    cross-realm authentication abuse.
+  resolution: >
+    Review /etc/krb5.conf for deprecated encryption types and remove
+    DES and RC4 entries. Ensure time synchronization is configured.
+    Verify KDC redundancy for availability.
+  references:
+    - "NIST SP 800-53 Rev 5 IA-3 (Device Identification and Authentication)"
+    - "https://cwe.mitre.org/data/definitions/287.html"
+
+users.sssd_configured:
+  title: "SSSD authentication is configured"
+  severity: "LOW"
+  cvss_score: 2.3
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N"
+  cwe: "CWE-287"
+  description: >
+    /etc/sssd/sssd.conf is present, indicating the System Security
+    Services Daemon is configured for centralized identity management.
+    SSSD introduces external identity provider dependencies for
+    authentication.
+  impact: >
+    SSSD misconfiguration or identity provider unavailability may prevent
+    login. Overly permissive SSSD filter configurations may allow
+    unauthorized accounts to authenticate. Cache poisoning is possible
+    if SSSD offline caching is misconfigured.
+  resolution: >
+    Review /etc/sssd/sssd.conf for access_provider and ldap_access_filter
+    settings. Ensure the identity provider connection uses TLS. Test
+    offline authentication behavior to verify local fallback functions
+    correctly.
+  references:
+    - "NIST SP 800-53 Rev 5 IA-3 (Device Identification and Authentication)"
+    - "https://cwe.mitre.org/data/definitions/287.html"
+
+# -------------------------
+# Permissions checker findings
+# -------------------------
+
+permissions.path_exceeds_expected_mode:
+  title: "File or directory permissions exceed expected mode"
+  severity: "MEDIUM"
+  cvss_score: 5.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-732"
+  description: >
+    A critical system file or directory has permissions that exceed the
+    expected mode defined by CIS benchmarks. Overly permissive settings
+    on files such as /etc/passwd, /etc/shadow, or /etc/sudoers allow
+    unauthorized users to read or modify sensitive system data.
+  impact: >
+    World-readable shadow files expose password hashes to offline cracking.
+    World-writable configuration files allow unauthorized modification of
+    authentication, sudo, or service configuration. The specific impact
+    depends on which path is affected.
+  resolution: >
+    Restore expected permissions using chmod. For common critical files:
+    chmod 644 /etc/passwd, chmod 000 /etc/shadow, chmod 440 /etc/sudoers.
+    Use the CIS benchmark for the specific distribution to verify
+    expected modes for all critical paths.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §6.1"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.world_writable_file:
+  title: "World-writable file found in monitored path"
+  severity: "HIGH"
+  cvss_score: 7.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-732"
+  description: >
+    A file with world-writable permissions (mode includes 0002) was found
+    within a monitored directory. World-writable files can be modified by
+    any local user regardless of ownership, enabling content injection,
+    configuration tampering, or script replacement.
+  impact: >
+    Any local user or process can overwrite the file contents. On executable
+    files or scripts run by privileged processes, this enables direct
+    privilege escalation. On configuration files, this enables service
+    manipulation or credential injection.
+  resolution: >
+    Remove world-writable permission immediately: chmod o-w <path>.
+    Investigate why the permission was set and whether the file was
+    modified. Audit cron jobs, service scripts, and init files that
+    reference the affected path.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §6.1.10"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.suid_sgid_binary:
+  title: "SUID or SGID binary found"
+  severity: "MEDIUM"
+  cvss_score: 6.7
+  cvss_vector: "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-250"
+  description: >
+    A binary with the SUID or SGID bit set was found. SUID binaries
+    execute with the file owner's privileges rather than the calling
+    user's privileges. Unexpected SUID binaries may have been planted
+    for privilege escalation or left from misconfigured software
+    installation.
+  impact: >
+    Exploitation of a vulnerable SUID binary allows a low-privileged
+    user to execute code as root or another privileged user without
+    sudo access. SUID binaries with known vulnerabilities are a common
+    local privilege escalation vector.
+  resolution: >
+    Audit all SUID/SGID binaries: find / -perm /6000 -type f. Remove
+    the SUID bit from any binary that does not require it: chmod u-s
+    <path>. Compare against a known-good baseline for the distribution
+    to identify unexpected additions.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §6.1.11, §6.1.12"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/250.html"
+
+permissions.unowned_file:
+  title: "File with no valid owner or group found"
+  severity: "MEDIUM"
+  cvss_score: 4.4
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
+  cwe: "CWE-732"
+  description: >
+    A file with no valid owning user or group was found. Unowned files
+    typically result from user account deletion without cleaning up
+    associated files, or from improper software installation. They
+    represent an ownership gap that may be exploitable.
+  impact: >
+    Unowned files can be claimed by any user who creates an account with
+    the matching numeric UID or GID. If the file is a binary, script,
+    or configuration file in a sensitive location, the new owner gains
+    control over it, potentially enabling privilege escalation.
+  resolution: >
+    Assign appropriate ownership: chown <user>:<group> <path>. If the
+    file is not needed, remove it. Audit recently deleted accounts to
+    identify the source of orphaned files.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §6.1.13, §6.1.14"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"

--- a/internal/security/registry/data/linux_debian.yaml
+++ b/internal/security/registry/data/linux_debian.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/linux_debian.yaml
+++ b/internal/security/registry/data/linux_debian.yaml
@@ -1,1 +1,197 @@
-# stub: findings for this platform/family are pending implementation
+# Debian family finding definitions for the orkowatch registry.
+# Covers Debian, Ubuntu, Kali, Parrot, Pop!_OS, Mint, and derivatives
+# identified via ID_LIKE=debian in /etc/os-release.
+# Severity tiers follow CVSS v3.1 base score ranges:
+#   CRITICAL 9.0-10.0 | HIGH 7.0-8.9 | MEDIUM 4.0-6.9 | LOW 0.1-3.9
+# All entries sourced from CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0,
+# NIST SP 800-53 Rev 5, and CVSS v3.1 scoring methodology.
+
+# -------------------------
+# Firewall checker findings
+# -------------------------
+
+firewall.ufw_inactive:
+  title: "UFW firewall is installed but not active"
+  severity: "HIGH"
+  cvss_score: 8.2
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H"
+  cwe: "CWE-284"
+  description: >
+    Uncomplicated Firewall (UFW) is the default firewall management tool
+    on Debian and Ubuntu systems. UFW is installed but reported as inactive,
+    meaning no host-based packet filtering is enforced on any network
+    interface despite the tool being present.
+  impact: >
+    All listening services are reachable on all interfaces without
+    restriction. UFW being inactive despite installation suggests the
+    firewall was intentionally disabled or never enabled after installation,
+    leaving the host without a host-based network control layer.
+  resolution: >
+    Enable UFW and configure a default-deny policy: ufw default deny
+    incoming && ufw default allow outgoing && ufw enable. Add explicit
+    allow rules for required services before enabling to avoid lockout:
+    ufw allow ssh.
+  references:
+    - "CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0 §3.5.1"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+firewall.ufw_not_installed:
+  title: "No recognized firewall manager is installed"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-284"
+  description: >
+    Neither UFW nor any other recognized firewall manager (iptables,
+    nftables, firewalld) was detected on this Debian-family system.
+    The host has no host-based packet filtering installed or active.
+  impact: >
+    All services bound to network interfaces are directly reachable without
+    any network-level access control. This eliminates host-based boundary
+    protection entirely and maximizes exposure of all listening services
+    to the network.
+  resolution: >
+    Install and enable UFW: apt install ufw && ufw default deny incoming
+    && ufw default allow outgoing && ufw allow ssh && ufw enable. Verify
+    status with: ufw status verbose.
+  references:
+    - "CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0 §3.5.1"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+# -------------------------
+# User checker findings
+# -------------------------
+
+users.sudo_nopasswd:
+  title: "Sudoers entry permits privilege escalation without password"
+  severity: "HIGH"
+  cvss_score: 8.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+  cwe: "CWE-269"
+  description: >
+    A sudoers rule contains the NOPASSWD tag, allowing one or more users
+    to execute commands with elevated privileges without providing a
+    password. This is commonly found in /etc/sudoers or files under
+    /etc/sudoers.d/ on Debian-family systems.
+  impact: >
+    Any attacker or process that gains access to the affected user account
+    can immediately escalate to root or another privileged user without
+    any additional credential. This eliminates the password barrier for
+    privilege escalation entirely for the affected account.
+  resolution: >
+    Remove NOPASSWD tags from sudoers rules unless operationally required.
+    Edit safely with: visudo. If NOPASSWD is required for automation,
+    scope it to the minimum required commands rather than ALL.
+  references:
+    - "CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0 §5.3.7"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/269.html"
+
+users.passwd_no_shadow:
+  title: "Password hashes stored in /etc/passwd instead of /etc/shadow"
+  severity: "HIGH"
+  cvss_score: 7.5
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-522"
+  description: >
+    One or more user accounts have password hashes stored directly in
+    /etc/passwd rather than /etc/shadow. The passwd file is world-readable
+    by design, meaning password hashes are exposed to all local users and
+    potentially to processes that can read the filesystem.
+  impact: >
+    World-readable password hashes can be extracted by any local user and
+    subjected to offline cracking without any privilege escalation. Weak
+    or reused passwords will be cracked quickly with modern tooling.
+  resolution: >
+    Run pwconv to migrate password hashes to /etc/shadow and set the
+    passwd field to x for all accounts. Verify with: pwck -r. Ensure
+    /etc/shadow has permissions 000 or 640 with root ownership.
+  references:
+    - "CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0 §6.2.2"
+    - "NIST SP 800-53 Rev 5 IA-5 (Authenticator Management)"
+    - "https://cwe.mitre.org/data/definitions/522.html"
+
+# -------------------------
+# Permissions checker findings
+# -------------------------
+
+permissions.shadow_world_readable:
+  title: "/etc/shadow is readable by non-root users"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:N"
+  cwe: "CWE-732"
+  description: >
+    /etc/shadow has permissions that allow non-root users to read its
+    contents. The shadow file contains hashed passwords for all local
+    accounts. On Debian-family systems the expected permission is 640
+    with ownership root:shadow, or 000 on some configurations.
+  impact: >
+    Any local user or process that can read /etc/shadow gains access to
+    all local password hashes. These can be subjected to offline cracking
+    without further exploitation. Cracked credentials enable lateral
+    movement and privilege escalation.
+  resolution: >
+    Restore correct permissions immediately: chmod 640 /etc/shadow &&
+    chown root:shadow /etc/shadow. Verify with: ls -la /etc/shadow.
+    Rotate passwords for all local accounts as a precaution if the
+    file was readable for an unknown period.
+  references:
+    - "CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0 §6.1.3"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.sudoers_world_readable:
+  title: "/etc/sudoers has overly permissive permissions"
+  severity: "HIGH"
+  cvss_score: 7.1
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-732"
+  description: >
+    /etc/sudoers has permissions that exceed the expected 0440 mode.
+    The sudoers file defines privilege escalation rules for the system.
+    Overly permissive modes allow unauthorized users to read escalation
+    rules or, if writable, modify them.
+  impact: >
+    A readable sudoers file exposes the full privilege escalation policy
+    to any local user, revealing which accounts can escalate and to what
+    commands. A writable sudoers file allows direct injection of NOPASSWD
+    rules for any account.
+  resolution: >
+    Restore correct permissions: chmod 440 /etc/sudoers && chown
+    root:root /etc/sudoers. Apply the same to files under /etc/sudoers.d/.
+    Always edit sudoers via visudo to prevent syntax errors that could
+    break sudo access.
+  references:
+    - "CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0 §5.3.2"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.ssh_dir_permissions:
+  title: "SSH directory or authorized_keys has incorrect permissions"
+  severity: "HIGH"
+  cvss_score: 7.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-732"
+  description: >
+    A user's ~/.ssh directory or ~/.ssh/authorized_keys file has
+    permissions that exceed the expected mode. OpenSSH enforces strict
+    permission requirements and may refuse to use keys from directories
+    or files with overly permissive modes, but misconfigured permissions
+    also allow unauthorized key injection.
+  impact: >
+    World or group writable ~/.ssh directories allow other users to inject
+    authorized keys, granting themselves SSH access as the target user.
+    If the target user has sudo access, this enables full privilege
+    escalation via key injection without touching any password.
+  resolution: >
+    Set correct permissions: chmod 700 ~/.ssh && chmod 600
+    ~/.ssh/authorized_keys. Verify ownership is correct: chown -R
+    <user>:<user> ~/.ssh. Audit authorized_keys contents for unexpected
+    entries.
+  references:
+    - "CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0 §5.2.19"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"

--- a/internal/security/registry/data/linux_fedora.yaml
+++ b/internal/security/registry/data/linux_fedora.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/linux_rhel.yaml
+++ b/internal/security/registry/data/linux_rhel.yaml
@@ -1,1 +1,283 @@
-# stub: findings for this platform/family are pending implementation
+# RHEL family finding definitions for the orkowatch registry.
+# Covers RHEL, CentOS, Rocky Linux, AlmaLinux, Oracle Linux, Amazon Linux,
+# and derivatives identified via ID_LIKE=rhel in /etc/os-release.
+# Severity tiers follow CVSS v3.1 base score ranges:
+#   CRITICAL 9.0-10.0 | HIGH 7.0-8.9 | MEDIUM 4.0-6.9 | LOW 0.1-3.9
+# All entries sourced from CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0,
+# NIST SP 800-53 Rev 5, and CVSS v3.1 scoring methodology.
+
+# -------------------------
+# Firewall checker findings
+# -------------------------
+
+firewall.firewalld_not_running:
+  title: "firewalld is installed but not running"
+  severity: "HIGH"
+  cvss_score: 8.2
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H"
+  cwe: "CWE-284"
+  description: >
+    firewalld is the default firewall management tool on RHEL-family systems.
+    The service is installed but not in a running state, meaning no
+    host-based packet filtering is enforced on any network interface
+    despite the tool being present.
+  impact: >
+    All listening services are reachable on all interfaces without
+    restriction. firewalld being inactive despite installation suggests
+    the service was stopped or disabled after installation, leaving
+    the host without a host-based network control layer.
+  resolution: >
+    Enable and start firewalld: systemctl enable --now firewalld.
+    Verify status with: firewall-cmd --state. Configure zones and
+    services appropriate to the host role. Add required service rules
+    before enabling to avoid lockout: firewall-cmd --permanent
+    --add-service=ssh && firewall-cmd --reload.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §3.5.1"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+firewall.firewalld_not_installed:
+  title: "No recognized firewall manager is installed"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-284"
+  description: >
+    Neither firewalld nor any other recognized firewall manager (iptables,
+    nftables) was detected on this RHEL-family system. The host has no
+    host-based packet filtering installed or active.
+  impact: >
+    All services bound to network interfaces are directly reachable without
+    any network-level access control. This eliminates host-based boundary
+    protection entirely and maximizes exposure of all listening services
+    to the network.
+  resolution: >
+    Install and enable firewalld: dnf install firewalld && systemctl
+    enable --now firewalld. Configure default zone policy to drop or
+    reject and add explicit rules for required services.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §3.5.1"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+firewall.firewalld_default_zone_public:
+  title: "firewalld default zone is set to public"
+  severity: "MEDIUM"
+  cvss_score: 5.3
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+  cwe: "CWE-284"
+  description: >
+    The firewalld default zone is set to public, which is the least
+    restrictive predefined zone and permits ssh and dhcpv6-client
+    services by default. On RHEL-family servers, the default zone
+    should reflect the actual network trust level of the primary
+    interface.
+  impact: >
+    Interfaces assigned to the public zone permit inbound SSH and
+    DHCPv6 client traffic by default without explicit administrator
+    action. Additional services added without zone consideration may
+    be inadvertently exposed on the public zone.
+  resolution: >
+    Review and set the default zone appropriate to the deployment
+    environment: firewall-cmd --set-default-zone=<zone>. For servers,
+    the drop or block zone with explicit service allowances is more
+    appropriate than public.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §3.5.1.4"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+# -------------------------
+# User checker findings
+# -------------------------
+
+users.sudo_nopasswd:
+  title: "Sudoers entry permits privilege escalation without password"
+  severity: "HIGH"
+  cvss_score: 8.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+  cwe: "CWE-269"
+  description: >
+    A sudoers rule contains the NOPASSWD tag, allowing one or more users
+    to execute commands with elevated privileges without providing a
+    password. On RHEL-family systems this is commonly found in
+    /etc/sudoers or files under /etc/sudoers.d/.
+  impact: >
+    Any attacker or process that gains access to the affected user account
+    can immediately escalate to root or another privileged user without
+    any additional credential. This eliminates the password barrier for
+    privilege escalation entirely for the affected account.
+  resolution: >
+    Remove NOPASSWD tags from sudoers rules unless operationally required.
+    Edit safely with: visudo. If NOPASSWD is required for automation,
+    scope it to the minimum required commands rather than ALL.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §5.3.7"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/269.html"
+
+users.wheel_group_empty:
+  title: "The wheel group has no members"
+  severity: "LOW"
+  cvss_score: 2.1
+  cvss_vector: "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:L/A:N"
+  cwe: "CWE-269"
+  description: >
+    The wheel group, which controls sudo access on RHEL-family systems,
+    has no members. On systems where the sudoers configuration grants
+    sudo access to the wheel group, an empty wheel group means no
+    standard user has a defined path to administrative access.
+  impact: >
+    Administrators may be using direct root login or undefined privilege
+    escalation paths that bypass audit logging. Lack of wheel group
+    membership may indicate sudo is not properly configured as the
+    primary escalation mechanism.
+  resolution: >
+    Add appropriate administrator accounts to the wheel group:
+    usermod -aG wheel <username>. Verify sudoers grants wheel group
+    access: grep wheel /etc/sudoers. Ensure direct root login is
+    disabled and sudo is the sole escalation path.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §5.3"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/269.html"
+
+users.passwd_no_shadow:
+  title: "Password hashes stored in /etc/passwd instead of /etc/shadow"
+  severity: "HIGH"
+  cvss_score: 7.5
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-522"
+  description: >
+    One or more user accounts have password hashes stored directly in
+    /etc/passwd rather than /etc/shadow. The passwd file is world-readable
+    by design, meaning password hashes are exposed to all local users and
+    any process that can read the filesystem.
+  impact: >
+    World-readable password hashes can be extracted by any local user and
+    subjected to offline cracking without any privilege escalation required.
+    Weak or reused passwords will be cracked quickly with modern tooling.
+  resolution: >
+    Run pwconv to migrate password hashes to /etc/shadow and replace
+    passwd field entries with x. Verify with: pwck -r. Ensure /etc/shadow
+    has permissions 000 with root ownership on RHEL-family systems.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §6.2.2"
+    - "NIST SP 800-53 Rev 5 IA-5 (Authenticator Management)"
+    - "https://cwe.mitre.org/data/definitions/522.html"
+
+# -------------------------
+# Permissions checker findings
+# -------------------------
+
+permissions.shadow_world_readable:
+  title: "/etc/shadow is readable by non-root users"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:N"
+  cwe: "CWE-732"
+  description: >
+    /etc/shadow has permissions that allow non-root users to read its
+    contents. On RHEL-family systems the expected permission is 000
+    with ownership root:root. Any deviation allows password hash
+    extraction by unprivileged users.
+  impact: >
+    Any local user or process that can read /etc/shadow gains access to
+    all local password hashes. These can be subjected to offline cracking
+    without further exploitation. Cracked credentials enable lateral
+    movement and privilege escalation across any system sharing those
+    credentials.
+  resolution: >
+    Restore correct permissions immediately: chmod 000 /etc/shadow &&
+    chown root:root /etc/shadow. Verify with: ls -la /etc/shadow.
+    Rotate passwords for all local accounts as a precaution if the
+    file was readable for an unknown period.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §6.1.3"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.sudoers_world_readable:
+  title: "/etc/sudoers has overly permissive permissions"
+  severity: "HIGH"
+  cvss_score: 7.1
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-732"
+  description: >
+    /etc/sudoers has permissions that exceed the expected 0440 mode.
+    The sudoers file defines privilege escalation rules for the system.
+    Overly permissive modes allow unauthorized users to read escalation
+    rules or, if writable, modify them directly.
+  impact: >
+    A readable sudoers file exposes the full privilege escalation policy
+    to any local user, revealing which accounts can escalate and to what
+    commands. A writable sudoers file allows direct injection of NOPASSWD
+    rules, granting immediate root access to any account.
+  resolution: >
+    Restore correct permissions: chmod 440 /etc/sudoers && chown
+    root:root /etc/sudoers. Apply the same to all files under
+    /etc/sudoers.d/. Always edit via visudo to prevent syntax errors
+    that could break sudo access entirely.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §5.3.2"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.ssh_dir_permissions:
+  title: "SSH directory or authorized_keys has incorrect permissions"
+  severity: "HIGH"
+  cvss_score: 7.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-732"
+  description: >
+    A user's ~/.ssh directory or ~/.ssh/authorized_keys file has
+    permissions that exceed the expected mode. OpenSSH on RHEL-family
+    systems enforces strict permission requirements via StrictModes and
+    will refuse keys from directories or files with overly permissive
+    modes, but misconfigured permissions also enable unauthorized key
+    injection.
+  impact: >
+    World or group writable ~/.ssh directories allow other local users
+    to inject authorized keys, granting themselves SSH access as the
+    target user without knowing their password. If the target user has
+    wheel or sudo access, this enables full privilege escalation.
+  resolution: >
+    Set correct permissions: chmod 700 ~/.ssh && chmod 600
+    ~/.ssh/authorized_keys. Verify ownership: chown -R <user>:<user>
+    ~/.ssh. Audit authorized_keys contents for unexpected entries.
+    Enable SSH StrictModes in sshd_config if not already set.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §5.2.19"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.selinux_disabled:
+  title: "SELinux is disabled or set to permissive mode"
+  severity: "HIGH"
+  cvss_score: 7.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-284"
+  description: >
+    SELinux is either disabled or configured in permissive mode on this
+    RHEL-family system. SELinux provides mandatory access controls that
+    confine processes and users beyond standard POSIX permissions.
+    Permissive mode logs policy violations but does not enforce them.
+    Disabled mode provides no MAC enforcement whatsoever.
+  impact: >
+    Without SELinux enforcement, process confinement is absent. A
+    compromised service running as a confined SELinux type would normally
+    be restricted from accessing resources outside its policy domain.
+    Without enforcement, a compromised process has the full permissions
+    of its Unix user, significantly expanding the blast radius of any
+    exploitation.
+  resolution: >
+    Set SELinux to enforcing mode in /etc/selinux/config:
+    SELINUX=enforcing. Apply immediately without reboot: setenforce 1.
+    Resolve any AVC denials before switching to enforcing to avoid
+    service disruption: ausearch -m avc | audit2allow.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §1.6.1"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "NIST SP 800-53 Rev 5 SI-16 (Memory Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"

--- a/internal/security/registry/data/linux_rhel.yaml
+++ b/internal/security/registry/data/linux_rhel.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/linux_suse.yaml
+++ b/internal/security/registry/data/linux_suse.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/unix_freebsd.yaml
+++ b/internal/security/registry/data/unix_freebsd.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/unix_openbsd.yaml
+++ b/internal/security/registry/data/unix_openbsd.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/windows.yaml
+++ b/internal/security/registry/data/windows.yaml
@@ -1,0 +1,326 @@
+# Windows finding definitions for the orkowatch registry.
+# Severity tiers follow CVSS v3.1 base score ranges:
+#   CRITICAL 9.0-10.0 | HIGH 7.0-8.9 | MEDIUM 4.0-6.9 | LOW 0.1-3.9
+# All entries are sourced from CIS Windows 11 Benchmark v3.0.0,
+# NIST SP 800-53 Rev 5, and CVSS v3.1 scoring methodology.
+
+# -------------------------
+# SSH checker findings
+# -------------------------
+
+ssh.server_not_running:
+  title: "OpenSSH Server installed but not running"
+  severity: "MEDIUM"
+  cvss_score: 5.3
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
+  cwe: "CWE-16"
+  description: >
+    The OpenSSH Server (sshd) service is installed but currently stopped.
+    An installed but inactive SSH daemon represents an unmanaged attack
+    surface that any administrator-level process or user can start without
+    additional installation steps.
+  impact: >
+    If started, an unconfigured or default-configured SSH service may permit
+    password authentication or expose the system to brute-force attacks.
+    Presence alone indicates unreviewed remote access capability.
+  resolution: >
+    If SSH is not required, remove the OpenSSH Server optional feature via
+    Settings > Apps > Optional Features. If required, configure
+    C:\ProgramData\ssh\sshd_config before enabling the service and restrict
+    access via Windows Firewall rules.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §18.10.56"
+    - "NIST SP 800-53 Rev 5 CM-7 (Least Functionality)"
+    - "https://cwe.mitre.org/data/definitions/16.html"
+
+ssh.config_missing:
+  title: "OpenSSH configuration file not found"
+  severity: "MEDIUM"
+  cvss_score: 5.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L"
+  cwe: "CWE-16"
+  description: >
+    No sshd_config file was found at C:\ProgramData\ssh\sshd_config.
+    Without an explicit configuration file, sshd falls back to compiled-in
+    defaults which may permit password authentication and use deprecated
+    algorithms.
+  impact: >
+    Default SSH configurations frequently fail CIS and DISA STIG requirements.
+    An attacker who starts the SSH service inherits permissive defaults,
+    potentially enabling credential-based remote access without restriction.
+  resolution: >
+    Create C:\ProgramData\ssh\sshd_config with explicit directives for
+    PasswordAuthentication, PermitRootLogin, and AllowedUsers before
+    enabling the sshd service.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §18.10.56.2"
+    - "NIST SP 800-53 Rev 5 CM-6 (Configuration Settings)"
+    - "https://cwe.mitre.org/data/definitions/16.html"
+
+ssh.root_login_permitted:
+  title: "SSH PermitRootLogin is not explicitly disabled"
+  severity: "CRITICAL"
+  cvss_score: 9.8
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-250"
+  description: >
+    The SSH configuration does not explicitly set PermitRootLogin to no.
+    Direct privileged login over SSH gives an attacker full system control
+    upon credential compromise with no privilege escalation step required.
+  impact: >
+    A successful brute-force or credential stuffing attack against the root
+    or Administrator account yields immediate full control of the host.
+    No additional exploitation step is required post-authentication.
+  resolution: >
+    Set PermitRootLogin no in C:\ProgramData\ssh\sshd_config and restart
+    the sshd service. Administrative access should require key-based
+    authentication to a non-privileged account followed by explicit
+    privilege escalation.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §18.10.56.3"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "NIST SP 800-53 Rev 5 IA-2 (Identification and Authentication)"
+    - "https://cwe.mitre.org/data/definitions/250.html"
+
+ssh.password_auth_enabled:
+  title: "SSH password authentication is enabled"
+  severity: "HIGH"
+  cvss_score: 7.5
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-521"
+  description: >
+    PasswordAuthentication is set to yes in the SSH configuration.
+    Password-based SSH is susceptible to brute-force and credential
+    stuffing attacks, particularly when accounts have weak or reused
+    passwords.
+  impact: >
+    Any network-accessible SSH service with password authentication enabled
+    can be targeted by automated brute-force tools. Credential exposure
+    from unrelated breaches directly translates to SSH access risk.
+  resolution: >
+    Set PasswordAuthentication no in C:\ProgramData\ssh\sshd_config and
+    configure key-based authentication exclusively. Restart the sshd
+    service after making changes.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §18.10.56"
+    - "NIST SP 800-53 Rev 5 IA-5(1) (Authenticator Management)"
+    - "https://cwe.mitre.org/data/definitions/521.html"
+
+# -------------------------
+# Firewall checker findings
+# -------------------------
+
+firewall.profile_inactive:
+  title: "One or more Windows Firewall profiles are inactive"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-284"
+  description: >
+    One or more Windows Firewall profiles (Domain, Private, or Public) are
+    not active. A disabled firewall profile removes the host-based packet
+    filter for that network category, exposing all listening services to
+    unauthenticated network traffic matching that profile.
+  impact: >
+    All services bound to network interfaces governed by the inactive profile
+    become directly reachable without firewall enforcement. This eliminates
+    a critical defense-in-depth layer against lateral movement and remote
+    exploitation.
+  resolution: >
+    Enable all firewall profiles via: netsh advfirewall set allprofiles
+    state on. Verify profile state with: netsh advfirewall show allprofiles.
+    Ensure profiles remain enabled via Group Policy if the system is
+    domain-joined.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §9.1.1, §9.2.1, §9.3.1"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "NIST SP 800-53 Rev 5 SI-3 (Malicious Code Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+firewall.all_profiles_disabled:
+  title: "Windows Firewall is completely disabled on all profiles"
+  severity: "CRITICAL"
+  cvss_score: 9.8
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-284"
+  description: >
+    Windows Defender Firewall is disabled across all profiles — Domain,
+    Private, and Public. The host has no active host-based packet filtering
+    on any network interface. This is the highest-risk firewall
+    misconfiguration possible on a Windows host.
+  impact: >
+    Every listening service on every interface is reachable without
+    restriction. Combined with any other vulnerability, this eliminates
+    network-layer mitigation entirely. Lateral movement, exploitation of
+    unpatched services, and data exfiltration face no host-based network
+    controls.
+  resolution: >
+    Immediately enable all firewall profiles: netsh advfirewall set
+    allprofiles state on. Investigate how the firewall was disabled and
+    whether unauthorized access occurred during the period it was inactive.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §9.1.1, §9.2.1, §9.3.1"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+# -------------------------
+# User checker findings
+# -------------------------
+
+users.no_password_required:
+  title: "Active user account has no password required"
+  severity: "HIGH"
+  cvss_score: 8.4
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-309"
+  description: >
+    One or more active user accounts have PasswordRequired set to false,
+    meaning Windows does not enforce a password for interactive or network
+    logon. This is distinct from a blank password — the system will not
+    prompt for or validate any credential for these accounts.
+  impact: >
+    Any local attacker, malicious process, or lateral movement attempt can
+    authenticate as this user without any credential. This eliminates the
+    authentication layer entirely for affected accounts and grants access
+    to all resources the account can reach.
+  resolution: >
+    Require passwords for all active accounts via: net user <username> *
+    or via Local Security Policy > Account Policies > Password Policy.
+    Set the account password and ensure PasswordRequired is enforced.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §1.1"
+    - "NIST SP 800-53 Rev 5 IA-5 (Authenticator Management)"
+    - "https://cwe.mitre.org/data/definitions/309.html"
+
+users.administrator_account_active:
+  title: "User account has local Administrator privileges"
+  severity: "MEDIUM"
+  cvss_score: 6.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-250"
+  description: >
+    One or more user accounts are members of the local Administrators group.
+    Administrator-level accounts have unrestricted access to the local
+    system and can bypass most security controls including UAC when
+    configured to auto-elevate.
+  impact: >
+    Compromise of an Administrator account yields full local system control.
+    Combined with credential reuse or weak passwords, Administrator group
+    membership significantly increases the blast radius of any account
+    compromise.
+  resolution: >
+    Limit the local Administrators group to accounts that explicitly require
+    administrative access. Standard users should operate under least-privilege
+    accounts. Review group membership regularly via: Get-LocalGroupMember
+    -Group Administrators.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §2.2"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/250.html"
+
+users.uac_disabled:
+  title: "User Account Control (UAC) is disabled"
+  severity: "CRITICAL"
+  cvss_score: 9.3
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+  cwe: "CWE-250"
+  description: >
+    User Account Control is disabled via the EnableLUA registry key being
+    set to 0. UAC is the primary privilege escalation barrier on Windows.
+    Without it, any process running in the context of a local Administrator
+    account inherits full administrative rights without a consent prompt.
+  impact: >
+    Malware, scripts, or any process running as the logged-in administrator
+    gains unrestricted system access without triggering UAC elevation prompts.
+    This eliminates the integrity level separation that UAC enforces and
+    allows privilege escalation without any user interaction.
+  resolution: >
+    Enable UAC by setting HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\
+    Policies\System\EnableLUA to 1, or via Local Security Policy >
+    Security Options > User Account Control: Run all administrators in
+    Admin Approval Mode. A system restart is required.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §2.3.17"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/250.html"
+
+# -------------------------
+# Permissions checker findings
+# -------------------------
+
+permissions.everyone_full_control:
+  title: "Everyone group has full control on a system path"
+  severity: "CRITICAL"
+  cvss_score: 9.8
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-732"
+  description: >
+    The Everyone group has been granted Full Control (F) on a critical
+    system directory. This grants unrestricted read, write, execute, and
+    delete permissions to all users including unauthenticated network
+    users on some configurations.
+  impact: >
+    Any local or network user can replace, modify, or delete files in the
+    affected directory. On system directories such as System32 or Program
+    Files, this enables DLL planting, binary replacement, and direct
+    privilege escalation without any exploit required.
+  resolution: >
+    Remove the Everyone group permission immediately using icacls:
+    icacls <path> /remove "Everyone". Restore expected ACLs using icacls
+    <path> /reset for system directories. Investigate how this permission
+    was granted.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §2.2"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.users_full_control:
+  title: "Users group has full control on a system path"
+  severity: "HIGH"
+  cvss_score: 7.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-732"
+  description: >
+    The BUILTIN\Users group has been granted Full Control (F) on a critical
+    system directory. Any authenticated local user can read, write, execute,
+    and delete files in this location.
+  impact: >
+    Any standard user account can replace binaries or plant DLLs in the
+    affected system directory, enabling privilege escalation without
+    exploiting any software vulnerability. This is a common DLL hijacking
+    precondition.
+  resolution: >
+    Remove the Full Control grant for BUILTIN\Users and restore read-execute
+    permissions only: icacls <path> /remove:g "BUILTIN\Users" then
+    icacls <path> /grant "BUILTIN\Users:(RX)". Verify against expected
+    Windows ACL baselines.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §2.2"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.admin_share_present:
+  title: "Default administrative shares are present"
+  severity: "LOW"
+  cvss_score: 2.7
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N"
+  cwe: "CWE-284"
+  description: >
+    Default Windows administrative shares (C$, ADMIN$, IPC$) are present.
+    These shares are enabled by default and require Administrator credentials
+    to access remotely. They are informational in most environments but
+    represent a lateral movement path when Administrator credentials are
+    compromised.
+  impact: >
+    An attacker with valid Administrator credentials can use administrative
+    shares for remote file access and lateral movement (e.g. PsExec, WMI,
+    SMB-based tools) without installing any additional software on the target.
+  resolution: >
+    In high-security environments where remote administration is not required,
+    disable administrative shares via registry:
+    HKLM\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters\
+    AutoShareWks = 0. This persists across reboots. IPC$ cannot be disabled.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §18.3"
+    - "NIST SP 800-53 Rev 5 CM-7 (Least Functionality)"
+    - "https://cwe.mitre.org/data/definitions/284.html"

--- a/internal/security/registry/registry.go
+++ b/internal/security/registry/registry.go
@@ -1,0 +1,304 @@
+// internal/security/registry/registry.go
+package registry
+
+import (
+	"bufio"
+	_ "embed"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Platform identifies the host OS family
+type Platform string
+
+// Distro indentifies a *Nix distro family *if Windows, unused
+type Distro string
+
+// <checker>.<finding_id> to join checker detection logic and registry data
+type FindingKey string
+
+// Platform constants
+const (
+	PlatformWindows Platform = "windows"
+	PlatformLinux   Platform = "linux"
+	PlatformDarwin  Platform = "darwin"
+	PlatformUnix    Platform = "unix"
+	PlatformUnknown Platform = "unknown"
+)
+
+// Distro family constants where derivatives resolve to parent family
+const (
+	// Linux Families
+	DistroDebian  Distro = "debian"
+	DistroRHEL    Distro = "rhel"
+	DistroFedora  Distro = "fedora"
+	DistroArch    Distro = "arch"
+	DistroSUSE    Distro = "suse"
+	DistroAlpine  Distro = "alpine"
+	DistroGeneric Distro = "generic"
+
+	// Unix Families
+	DistroFreeBSD Distro = "freebsd"
+	DistroOpenBSD Distro = "openbsd"
+	DistroNetBSD  Distro = "netbsd"
+
+	// Non-Linux Platforms
+	DistroNone    Distro = ""
+	DistroUnknown Distro = "uknown"
+)
+
+// OSContext obtains full platform and distro info to pass to auditor before registry lookups
+type OSContext struct {
+	Platform Platform
+	Families []Distro
+}
+
+// FindingDefinition is a registry map for types.Finding
+type FindingDefinition struct {
+	Title       string   `yaml:"title"`
+	Severity    string   `yaml:"severity"`
+	CVSSScore   float64  `yaml:"cvss_score"`
+	CVSSVector  string   `yaml:"cvss_vector"`
+	CWE         string   `yaml:"cwe"`
+	Description string   `yaml:"description"`
+	Impact      string   `yaml:"impact"`
+	Resolution  string   `yaml:"resolution"`
+	References  []string `yaml:"references"`
+}
+
+// platformRegistry holds all indexed definitions
+type platformRegistry map[Platform]map[FindingKey]FindingDefinition
+
+// Linux family registry holds distro index findings
+type linuxFamilyRegistry map[Distro]map[FindingKey]FindingDefinition
+
+var (
+	registry      platformRegistry
+	linuxRegistry linuxFamilyRegistry
+)
+
+//go:embed data/windows.yaml
+var windowsData []byte
+
+//go:embed data/linux_common.yaml
+var linuxCommonData []byte
+
+//go:embed data/linux_debian.yaml
+var linuxDebianData []byte
+
+//go:embed data/linux_rhel.yaml
+var linuxRHELData []byte
+
+//go:embed data/linux_arch.yaml
+var linuxArchData []byte
+
+//go:embed data/linux_fedora.yaml
+var linuxFedoraData []byte
+
+//go:embed data/linux_suse.yaml
+var linuxSUSEData []byte
+
+//go:embed data/linux_alpine.yaml
+var linuxAlpineData []byte
+
+//go:embed data/darwin.yaml
+var darwinData []byte
+
+//go:embed data/unix_freebsd.yaml
+var unixFreeBSDData []byte
+
+//go:embed data/unix_openbsd.yaml
+var unixOpenBSDData []byte
+
+func init() {
+	registry = make(platformRegistry)
+	linuxRegistry = make(linuxFamilyRegistry)
+
+	registry[PlatformWindows] = mustLoad(windowsData)
+	registry[PlatformDarwin] = mustLoad(darwinData)
+
+	linuxRegistry[DistroGeneric] = mustLoad(linuxCommonData)
+	linuxRegistry[DistroDebian] = mustLoad(linuxDebianData)
+	linuxRegistry[DistroRHEL] = mustLoad(linuxRHELData)
+	linuxRegistry[DistroArch] = mustLoad(linuxArchData)
+	linuxRegistry[DistroFedora] = mustLoad(linuxFedoraData)
+	linuxRegistry[DistroSUSE] = mustLoad(linuxSUSEData)
+	linuxRegistry[DistroAlpine] = mustLoad(linuxAlpineData)
+
+	unixRegistry := make(map[Distro]map[FindingKey]FindingDefinition)
+	unixRegistry[DistroFreeBSD] = mustLoad(unixFreeBSDData)
+	unixRegistry[DistroOpenBSD] = mustLoad(unixOpenBSDData)
+	registry[PlatformUnix] = flattenUnix(unixRegistry)
+}
+
+// mustLoad parses a byte slice into a finding map
+func mustLoad(data []byte) map[FindingKey]FindingDefinition {
+	var raw map[string]FindingDefinition
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		panic("registry: failed to parse embedded YAML: " + err.Error())
+	}
+	out := make(map[FindingKey]FindingDefinition, len(raw))
+	for k, v := range raw {
+		out[FindingKey(k)] = v
+	}
+	return out
+}
+
+// flattenUnix merges unix family maps into a distro key map
+func flattenUnix(families map[Distro]map[FindingKey]FindingDefinition) map[FindingKey]FindingDefinition {
+	out := make(map[FindingKey]FindingDefinition)
+	for family, findings := range families {
+		for key, def := range findings {
+			prefixed := FindingKey(string(family) + "." + string(key))
+			out[prefixed] = def
+		}
+	}
+	return out
+}
+
+// Lookup retrieves a FindingDefinition for the given OSContext and key.
+func Lookup(ctx OSContext, key FindingKey) (FindingDefinition, bool) {
+	switch ctx.Platform {
+	case PlatformLinux:
+		for _, family := range ctx.Families {
+			if fm, ok := linuxRegistry[family]; ok {
+				if def, ok := fm[key]; ok {
+					return def, true
+				}
+			}
+		}
+		// fall through to common Linux findings
+		if def, ok := linuxRegistry[DistroGeneric][key]; ok {
+			return def, true
+		}
+		return FindingDefinition{}, false
+
+	default:
+		if pm, ok := registry[ctx.Platform]; ok {
+			if def, ok := pm[key]; ok {
+				return def, true
+			}
+		}
+		return FindingDefinition{}, false
+	}
+}
+
+// DetectOS identifies the current platform and, for Linux, resolves
+// the full distribution family chain from /etc/os-release.
+func DetectOS() OSContext {
+	switch platform := detectPlatform(); platform {
+	case PlatformLinux:
+		return OSContext{
+			Platform: PlatformLinux,
+			Families: detectLinuxFamilies(),
+		}
+	default:
+		return OSContext{Platform: platform}
+	}
+}
+
+// detectPlatform returns the Platform either via runtime.GOOS or /etc/os-release
+func detectPlatform() Platform {
+	// Check for Linux first via os-release presence
+	if _, err := os.Stat("/etc/os-release"); err == nil {
+		return PlatformLinux
+	}
+	// macOS
+	if _, err := os.Stat("/System/Library/CoreServices/SystemVersion.plist"); err == nil {
+		return PlatformDarwin
+	}
+	// FreeBSD / OpenBSD / NetBSD
+	if _, err := os.Stat("/etc/rc.conf"); err == nil {
+		return PlatformUnix
+	}
+	// Windows — none of the above exist
+	return PlatformWindows
+}
+
+// detectLinuxFamilies parses /etc/os-release and returns the
+// distro family chain ordered from most specific to least specific.
+func detectLinuxFamilies() []Distro {
+	file, err := os.Open("/etc/os-release")
+	if err != nil {
+		return []Distro{DistroGeneric}
+	}
+	defer file.Close() // nolint:errcheck // read-only file
+
+	var id, idLike string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "ID="):
+			id = strings.Trim(strings.TrimPrefix(line, "ID="), `"`)
+		case strings.HasPrefix(line, "ID_LIKE="):
+			idLike = strings.Trim(strings.TrimPrefix(line, "ID_LIKE="), `"`)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return []Distro{DistroGeneric}
+	}
+
+	var families []Distro
+
+	// Resolve the specific ID to a known family
+	if f := resolveDistro(id); f != DistroUnknown {
+		families = append(families, f)
+	}
+
+	// Walk ID_LIKE parent families in declared order
+	for _, parent := range strings.Fields(idLike) {
+		if f := resolveDistro(parent); f != DistroUnknown {
+			// avoid duplicates
+			if !containsDistro(families, f) {
+				families = append(families, f)
+			}
+		}
+	}
+
+	// Always terminate with generic as the final fallback
+	if !containsDistro(families, DistroGeneric) {
+		families = append(families, DistroGeneric)
+	}
+
+	return families
+}
+
+// resolveDistro maps a raw os-release ID or ID_LIKE token to a known Distro family constant.
+func resolveDistro(id string) Distro {
+	switch strings.ToLower(id) {
+	case "debian", "ubuntu", "linuxmint", "pop", "kali", "parrot",
+		"elementary", "raspbian", "zorin":
+		return DistroDebian
+	case "rhel", "centos", "rocky", "almalinux", "ol", "amzn":
+		return DistroRHEL
+	case "fedora":
+		return DistroFedora
+	case "arch", "manjaro", "endeavouros", "garuda", "artix":
+		return DistroArch
+	case "opensuse", "opensuse-leap", "opensuse-tumbleweed", "sles":
+		return DistroSUSE
+	case "alpine":
+		return DistroAlpine
+	case "freebsd":
+		return DistroFreeBSD
+	case "openbsd":
+		return DistroOpenBSD
+	case "netbsd":
+		return DistroNetBSD
+	default:
+		return DistroUnknown
+	}
+}
+
+// containsDistro reports whether d is present in families.
+func containsDistro(families []Distro, d Distro) bool {
+	for _, f := range families {
+		if f == d {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/security/registry/registry.go
+++ b/internal/security/registry/registry.go
@@ -16,7 +16,7 @@ type Platform string
 // Distro indentifies a *Nix distro family *if Windows, unused
 type Distro string
 
-// <checker>.<finding_id> to join checker detection logic and registry data
+// FindingKey formatted <checker>.<finding_id> to join checker detection logic and registry data
 type FindingKey string
 
 // Platform constants


### PR DESCRIPTION
## Overview
Introduces the `internal/security/registry` package — the authoritative source for all security finding definitions across platforms and distributions. This is the foundational layer required by `bug/31-nonverbose-output` to produce meaningful, structured output in both normal and verbose modes.

## What This Adds
- `internal/security/registry/registry.go` — platform and distro type constants, `OSContext`, `FindingDefinition`, `Lookup`, `DetectOS`, and `detectLinuxFamilies` with full family chain resolution via `/etc/os-release` `ID_LIKE` walking 
- `internal/security/registry/data/` — embedded YAML files loaded via `embed.FS` at compile time, zero runtime I/O, O(1) lookup

### Fully populated YAML data files
All entries sourced from CIS Benchmarks, NIST SP 800-53 Rev 5, and CVSS v3.1 scoring methodology with explicit references per finding:
- `windows.yaml` — SSH, firewall, user, and permissions findings for Windows, anchored to CIS Windows 11 Benchmark v3.0.0
- `linux_common.yaml` — findings identical across all Linux distributions, anchored to CIS Distribution Independent Linux Benchmark v2.0.0
- `linux_debian.yaml` — Debian/Ubuntu/Kali family findings, anchored to CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0
- `linux_rhel.yaml` — RHEL/Rocky/Alma/CentOS family findings, including SELinux, anchored to CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0
- `linux_arch.yaml` — Arch/Manjaro/EndeavourOS family findings, including nftables, AUR helpers, and pacman cache integrity

### Stub YAML files (pending implementation)
- `darwin.yaml`
- `linux_fedora.yaml`
- `linux_suse.yaml`
- `linux_alpine.yaml`
- `unix_freebsd.yaml`
- `unix_openbsd.yaml`

## What This Does Not Change
- No existing checker files are modified
- No existing output is changed
- No existing imports are affected
- Package compiles, vets, formats, and lints cleanly independently of all downstream changes

## Design Decisions
- `embed.FS` with YAML data files allows community contribution to finding definitions without modifying Go source code
- `OSContext` with `[]Distro` family chain enables derivative distros to resolve via `ID_LIKE` automatically without individual entries
- Lookup walks the family chain most-specific to least-specific, terminating at `DistroGeneric` (linux_common) as the final fallback
- All finding keys follow `<checker>.<finding_id>` convention and are stable join keys between checker detection logic and registry data

## Dependent Sub-Branches
This branch must merge into `bug/31-nonverbose-output` before the following sub-branches can begin:
- `chore/<N>-checker-findings` — update checkers to populate `Findings` via registry lookup
- `chore/<N>-audit-summary` — update `calculateSummary` to score from `Findings` severity instead of scanning `Details` strings
- `chore/<N>-formatter-output` — update `formatText` and `defaultTemplate` for non-verbose/verbose split with hint line
- `chore/<N>-enrichment-scaffold` — scaffold NVD enrichment client behind `--enrich` flag

## References
Closes #38 
Part of `bug/31-nonverbose-output`