### PR TITLE
[Enhancement] Populate structured findings for Windows checkers

### DIFF
--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/papa0four/orkowatch/internal/security/checker"
-	"github.com/papa0four/orkowatch/internal/security/types"
 	"github.com/papa0four/orkowatch/internal/security/registry"
+	"github.com/papa0four/orkowatch/internal/security/types"
 )
 
 // SecurityAuditor handles the orchestration of security checks
@@ -70,17 +70,17 @@ func NewSecurityAuditor(opts Options) *SecurityAuditor {
 	ctx := registry.DetectOS()
 
 	auditor := &SecurityAuditor{
-		verbose: opts.Verbose,
-		options: opts,
+		verbose:   opts.Verbose,
+		options:   opts,
 		osContext: ctx,
 	}
 
 	switch runtime.GOOS {
 	case "windows":
-		auditor.sshChecker = checker.NewWindowsSSHChecker()
-		auditor.firewallChecker = checker.NewWindowsFirewallChecker()
-		auditor.userChecker = checker.NewWindowsUserChecker()
-		auditor.permissionChecker = checker.NewWindowsPermissionChecker()
+		auditor.sshChecker = checker.NewWindowsSSHChecker(ctx)
+		auditor.firewallChecker = checker.NewWindowsFirewallChecker(ctx)
+		auditor.userChecker = checker.NewWindowsUserChecker(ctx)
+		auditor.permissionChecker = checker.NewWindowsPermissionChecker(ctx)
 	default:
 		auditor.sshChecker = checker.NewUnixSSHChecker()
 		auditor.firewallChecker = checker.NewUnixFirewallChecker()

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/papa0four/orkowatch/internal/security/checker"
 	"github.com/papa0four/orkowatch/internal/security/types"
+	"github.com/papa0four/orkowatch/internal/security/registry"
 )
 
 // SecurityAuditor handles the orchestration of security checks
@@ -22,6 +23,7 @@ type SecurityAuditor struct {
 	permissionChecker checker.PermissionChecker
 	verbose           bool
 	options           Options
+	osContext         registry.OSContext
 }
 
 // Options configures the audit process
@@ -65,9 +67,12 @@ type Summary struct {
 
 // NewSecurityAuditor creates a new security auditor based on the OS
 func NewSecurityAuditor(opts Options) *SecurityAuditor {
+	ctx := registry.DetectOS()
+
 	auditor := &SecurityAuditor{
 		verbose: opts.Verbose,
 		options: opts,
+		osContext: ctx,
 	}
 
 	switch runtime.GOOS {

--- a/internal/security/checker/firewall.go
+++ b/internal/security/checker/firewall.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/papa0four/orkowatch/internal/security/registry"
 	"github.com/papa0four/orkowatch/internal/security/types"
 )
 
@@ -18,7 +19,9 @@ type FirewallChecker interface {
 type UnixFirewallChecker struct{}
 
 // WindowsFirewallChecker implements FirewallChecker for Windows systems
-type WindowsFirewallChecker struct{}
+type WindowsFirewallChecker struct {
+	ctx registry.OSContext
+}
 
 // NewUnixFirewallChecker creates a new Unix firewall checker
 func NewUnixFirewallChecker() *UnixFirewallChecker {
@@ -26,8 +29,8 @@ func NewUnixFirewallChecker() *UnixFirewallChecker {
 }
 
 // NewWindowsFirewallChecker creates a new Windows firewall checker
-func NewWindowsFirewallChecker() *WindowsFirewallChecker {
-	return &WindowsFirewallChecker{}
+func NewWindowsFirewallChecker(ctx registry.OSContext) *WindowsFirewallChecker {
+	return &WindowsFirewallChecker{ctx: ctx}
 }
 
 // firewallTool represents a firewall management tool
@@ -111,6 +114,7 @@ func (f *WindowsFirewallChecker) Check() types.AuditResult {
 		Status:      "CHECKING",
 		Description: "Analyzing Windows Firewall Configuration",
 		Details:     make([]string, 0),
+		Findings:    make([]types.Finding, 0),
 	}
 
 	// Check firewall status for all profiles
@@ -127,20 +131,35 @@ func (f *WindowsFirewallChecker) Check() types.AuditResult {
 	// Parse firewall profiles status
 	profiles := parseWindowsFirewallStatus(string(output))
 	activeProfiles := 0
+	inactiveProfiles := 0
 	for profile, state := range profiles {
 		if state {
 			activeProfiles++
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s profile is active", types.SymbolOK, profile))
 		} else {
+			inactiveProfiles++
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: %s profile is inactive", types.SymbolWarning, profile))
 		}
 	}
 
+	// One finding per inactive profile
+	if inactiveProfiles > 0 && activeProfiles > 0 {
+		if def, ok := registry.Lookup(f.ctx, "firewall.profile_inactive"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+			})
+		}
+	}
+
 	// Check firewall rules if at least one profile is active
 	if activeProfiles > 0 {
-		cmd = exec.Command("netsh", "advfirewall", "firewall", "show", "rule", "name-all", "verbose")
+		cmd = exec.Command("netsh", "advfirewall", "firewall", "show", "rule", "name=all", "verbose")
 		output, err := cmd.CombinedOutput()
 		if err == nil {
 			rules := parseWindowsFirewallRules(string(output))
@@ -158,6 +177,15 @@ func (f *WindowsFirewallChecker) Check() types.AuditResult {
 		result.Description = "Windows Firewall is disabled for all profiles"
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s CRITICAL: Windows Firewall is completely disabled", types.SymbolCritical))
+		if def, ok := registry.Lookup(f.ctx, "firewall.all_profiles_disabled"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+			})
+		}
 	} else {
 		result.Status = "COMPLETED"
 		result.Description = fmt.Sprintf("Windows Firewall is active on %d profile(s)", activeProfiles)

--- a/internal/security/checker/permissions.go
+++ b/internal/security/checker/permissions.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/papa0four/orkowatch/internal/security/registry"
 	"github.com/papa0four/orkowatch/internal/security/types"
 )
 
@@ -49,6 +50,7 @@ type UnixPermissionChecker struct {
 // WindowsPermissionChecker implements PermissionChecker for Windows systems
 type WindowsPermissionChecker struct {
 	Paths []string
+	ctx   registry.OSContext
 }
 
 // criticalPath represents a path that needs permission checking
@@ -71,7 +73,7 @@ func NewUnixPermissionChecker() *UnixPermissionChecker {
 }
 
 // NewWindowsPermissionChecker creates a new Windows permission checker
-func NewWindowsPermissionChecker() *WindowsPermissionChecker {
+func NewWindowsPermissionChecker(ctx registry.OSContext) *WindowsPermissionChecker {
 	return &WindowsPermissionChecker{
 		Paths: []string{
 			"C:\\Windows\\System32",
@@ -80,6 +82,7 @@ func NewWindowsPermissionChecker() *WindowsPermissionChecker {
 			"C:\\ProgramData",
 			"C:\\Users",
 		},
+		ctx: ctx,
 	}
 }
 
@@ -269,6 +272,7 @@ func (p *WindowsPermissionChecker) Check() types.AuditResult {
 		Status:      "CHECKING",
 		Description: "Analyzing Windows file and directory permissions",
 		Details:     make([]string, 0),
+		Findings:    make([]types.Finding, 0),
 	}
 
 	for _, path := range p.Paths {
@@ -293,6 +297,9 @@ func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, result *
 		return fmt.Errorf("failed to check permissions: %v", err)
 	}
 
+	everyoneFindingAdded := false
+	usersFindingAdded := false
+
 	// Analyze permissions
 	lines := strings.Split(string(output), "\n")
 	for _, line := range lines {
@@ -301,17 +308,40 @@ func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, result *
 			continue
 		}
 
-		// Check for potentially dangerous permissions
 		if strings.Contains(line, "Everyone:(OI)(CI)(F)") ||
 			strings.Contains(line, "Everyone:(F)") {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: Full control granted to Everyone group on %s",
 					types.SymbolWarning, line))
+			if !everyoneFindingAdded {
+				if def, ok := registry.Lookup(p.ctx, "permissions.everyone_full_control"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+					})
+				}
+				everyoneFindingAdded = true
+			}
 		} else if strings.Contains(line, "Users:(OI)(CI)(F)") ||
 			strings.Contains(line, "Users:(F)") {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: Full control granted to Users group on %s",
 					types.SymbolWarning, line))
+			if !usersFindingAdded {
+				if def, ok := registry.Lookup(p.ctx, "permissions.users_full_control"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+					})
+				}
+				usersFindingAdded = true
+			}
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolInfo, line))
@@ -334,6 +364,8 @@ func (p *WindowsPermissionChecker) checkNetworkShares(result *types.AuditResult)
 	shares := strings.Split(string(output), "\n")
 	result.Details = append(result.Details, "\nNetwork Shares:")
 
+	adminShareFindingAdded := false
+
 	for _, share := range shares {
 		share = strings.TrimSpace(share)
 		if share == "" || strings.HasPrefix(share, "Share name") ||
@@ -341,12 +373,23 @@ func (p *WindowsPermissionChecker) checkNetworkShares(result *types.AuditResult)
 			continue
 		}
 
-		// Check share permissions
 		shareName := strings.Fields(share)[0]
 		if shareName == "ADMIN$" || shareName == "C$" || shareName == "IPC$" {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s Administrative share: %s",
 					types.SymbolWarning, share))
+			if !adminShareFindingAdded {
+				if def, ok := registry.Lookup(p.ctx, "permissions.admin_share_present"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+					})
+				}
+				adminShareFindingAdded = true
+			}
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolInfo, share))

--- a/internal/security/checker/ssh.go
+++ b/internal/security/checker/ssh.go
@@ -25,7 +25,7 @@ type UnixSSHChecker struct {
 // WindowsSSHChecker implements SSHChecker for Windows systems
 type WindowsSSHChecker struct {
 	ConfigPath string
-	ctx  	   registry.OSContext
+	ctx  	     registry.OSContext
 }
 
 // NewUnixSSHChecker creates a new Unix SSH checker with default paths
@@ -42,6 +42,7 @@ func NewUnixSSHChecker() *UnixSSHChecker {
 func NewWindowsSSHChecker() *WindowsSSHChecker {
 	return &WindowsSSHChecker{
 		ConfigPath: "C:\\ProgramData\\ssh\\sshd_config",
+		ctx:        ctx,
 	}
 }
 
@@ -159,6 +160,7 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 		Status:      "CHECKING",
 		Description: "Analyzing Windows SSH configuration",
 		Details:     make([]string, 0),
+		Findings:    make([]types.Finding, 0)
 	}
 
 	sshdInstalled := false
@@ -177,6 +179,15 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 		case "Stopped":
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s OpenSSH Server is installed but not running", types.SymbolWarning))
+			if def, ok := registry.Lookup(s.ctx, "ssh.server_not_running"); ok {
+				result.Findings = append(result.Findings, types.Finding{
+					Title:       def.Title,
+					Severity:    def.Severity,
+					Description: def.Description,
+					Impact:      def.Impact,
+					Resolution:  def.Resolution,
+				})
+			}
 		default:
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s OpenSSH Server service state: %s", types.SymbolInfo, serviceStatus))
@@ -240,6 +251,15 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 					if config.rootLogin {
 						result.Details = append(result.Details,
 							fmt.Sprintf("%s WARNING: Root login is permitted", types.SymbolWarning))
+						if def, ok := registry.Lookup(s.ctx, "ssh.root_login_permitted"); ok {
+							result.Findings = append(result.Findings, types.Finding{
+								Title:       def.Title,
+								Severity:    def.Severity,
+								Description: def.Description,
+								Impact:      def.Impact,
+								Resolution:  def.Resolution,
+							})
+						}
 					} else {
 						result.Details = append(result.Details,
 							fmt.Sprintf("%s Root login is disabled", types.SymbolOK))
@@ -250,6 +270,15 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 					if config.passwordAuth {
 						result.Details = append(result.Details,
 							fmt.Sprintf("%s WARNING: Password authentication is enabled", types.SymbolWarning))
+						if def, ok := registry.Lookup(s.ctx, "ssh.password_auth_enabled"); ok {
+							result.Findings = append(result.Findings, types.Finding{
+								Title:       def.Title,
+								Severity:    def.Severity,
+								Description: def.Description,
+								Impact:      def.Impact,
+								Resolution:  def.Resolution,
+							})
+						}
 					} else {
 						result.Details = append(result.Details,
 							fmt.Sprintf("%s Password authentication is disabled", types.SymbolOK))
@@ -259,6 +288,15 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: OpenSSH configuration file not found", types.SymbolWarning))
+			if def, ok := registry.Lookup(s.ctx, "ssh.config_missing"); ok {
+				result.Findings = append(result.Findings, types.Finding{
+					Title:       def.Title,
+					Severity:    def.Severity,
+					Description: def.Description,
+					Impact:      def.Impact,
+					Resolution:  def.Resolution,
+				})
+			}
 		}
 	}
 

--- a/internal/security/checker/ssh.go
+++ b/internal/security/checker/ssh.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/papa0four/orkowatch/internal/security/types"
+	"github.com/papa0four/orkowatch/internal/security/registry"
 )
 
 // SSHChecker defines interface for SSH configuration checking
@@ -24,6 +25,7 @@ type UnixSSHChecker struct {
 // WindowsSSHChecker implements SSHChecker for Windows systems
 type WindowsSSHChecker struct {
 	ConfigPath string
+	ctx  	   registry.OSContext
 }
 
 // NewUnixSSHChecker creates a new Unix SSH checker with default paths

--- a/internal/security/checker/ssh.go
+++ b/internal/security/checker/ssh.go
@@ -8,8 +8,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/papa0four/orkowatch/internal/security/types"
 	"github.com/papa0four/orkowatch/internal/security/registry"
+	"github.com/papa0four/orkowatch/internal/security/types"
 )
 
 // SSHChecker defines interface for SSH configuration checking
@@ -25,7 +25,7 @@ type UnixSSHChecker struct {
 // WindowsSSHChecker implements SSHChecker for Windows systems
 type WindowsSSHChecker struct {
 	ConfigPath string
-	ctx  	     registry.OSContext
+	ctx        registry.OSContext
 }
 
 // NewUnixSSHChecker creates a new Unix SSH checker with default paths
@@ -39,7 +39,7 @@ func NewUnixSSHChecker() *UnixSSHChecker {
 }
 
 // NewWindowsSSHChecker creates a new Windows SSH checker
-func NewWindowsSSHChecker() *WindowsSSHChecker {
+func NewWindowsSSHChecker(ctx registry.OSContext) *WindowsSSHChecker {
 	return &WindowsSSHChecker{
 		ConfigPath: "C:\\ProgramData\\ssh\\sshd_config",
 		ctx:        ctx,
@@ -160,7 +160,7 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 		Status:      "CHECKING",
 		Description: "Analyzing Windows SSH configuration",
 		Details:     make([]string, 0),
-		Findings:    make([]types.Finding, 0)
+		Findings:    make([]types.Finding, 0),
 	}
 
 	sshdInstalled := false

--- a/internal/security/checker/users.go
+++ b/internal/security/checker/users.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/papa0four/orkowatch/internal/security/registry"
 	"github.com/papa0four/orkowatch/internal/security/types"
 )
 
@@ -35,7 +36,9 @@ type UnixUserChecker struct {
 }
 
 // WindowsUserChecker implements UserChecker for Windows systems
-type WindowsUserChecker struct{}
+type WindowsUserChecker struct {
+	ctx registry.OSContext
+}
 
 // userAccount represents a parsed user account
 type userAccount struct {
@@ -94,8 +97,8 @@ func NewUnixUserChecker() *UnixUserChecker {
 }
 
 // NewWindowsUserChecker creates a new Windows user checker
-func NewWindowsUserChecker() *WindowsUserChecker {
-	return &WindowsUserChecker{}
+func NewWindowsUserChecker(ctx registry.OSContext) *WindowsUserChecker {
+	return &WindowsUserChecker{ctx: ctx}
 }
 
 // Check implements UserChecker interface for Unix systems
@@ -552,6 +555,7 @@ func (w *WindowsUserChecker) Check() types.AuditResult {
 		Status:      "CHECKING",
 		Description: "Analyzing Windows user accounts and security settings",
 		Details:     make([]string, 0),
+		Findings:    make([]types.Finding, 0),
 	}
 
 	users, err := w.getWindowsUsers()
@@ -627,6 +631,8 @@ func (w *WindowsUserChecker) getWindowsUsers() ([]windowsUserInfo, error) {
 }
 
 func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result *types.AuditResult) {
+	noPasswordFindingAdded := false
+
 	for _, user := range users {
 		details := user.Name
 
@@ -634,6 +640,15 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 			details += " (Administrator)"
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolWarning, details))
+			if def, ok := registry.Lookup(w.ctx, "users.administrator_account_active"); ok {
+				result.Findings = append(result.Findings, types.Finding{
+					Title:       def.Title,
+					Severity:    def.Severity,
+					Description: def.Description,
+					Impact:      def.Impact,
+					Resolution:  def.Resolution,
+				})
+			}
 		} else if !user.Enabled {
 			details += " (Disabled)"
 			result.Details = append(result.Details,
@@ -642,6 +657,19 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 			details += " (No Password Required)"
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolWarning, details))
+			// One finding for the class of violation, not one per user account
+			if !noPasswordFindingAdded {
+				if def, ok := registry.Lookup(w.ctx, "users.no_password_required"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+					})
+				}
+				noPasswordFindingAdded = true
+			}
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolOK, details))
@@ -673,6 +701,15 @@ func (w *WindowsUserChecker) checkSecurityPolicies(result *types.AuditResult) {
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: User Account Control (UAC) is disabled", types.SymbolWarning))
+			if def, ok := registry.Lookup(w.ctx, "users.uac_disabled"); ok {
+				result.Findings = append(result.Findings, types.Finding{
+					Title:       def.Title,
+					Severity:    def.Severity,
+					Description: def.Description,
+					Impact:      def.Impact,
+					Resolution:  def.Resolution,
+				})
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Wire `registry.OSContext` into all four Windows checker structs and populate `result.Findings` from the registry for every detected condition that maps to a finding key. `Details` strings are preserved unchanged as verbose-only raw diagnostic output.

## Changes

- `internal/security/audit/audit.go` — call `registry.DetectOS()` once in `NewSecurityAuditor`, store `OSContext` on the auditor, pass to each Windows checker constructor
- `internal/security/checker/ssh.go` — add `ctx` field to `WindowsSSHChecker`; populate findings for `ssh.server_not_running`,
  `ssh.config_missing`, `ssh.root_login_permitted`, `ssh.password_auth_enabled`
- `internal/security/checker/firewall.go` — add `ctx` field to `WindowsFirewallChecker`; populate findings for `firewall.profile_inactive`, `firewall.all_profiles_disabled`; correct `netsh` rule query argument from `name-all` to `name=all`
- `internal/security/checker/users.go` — add `ctx` field to `WindowsUserChecker`; populate findings for `users.administrator_account_active`, `users.no_password_required`, `users.uac_disabled`; deduplication guards prevent multiple findings for the same violation class
- `internal/security/checker/permissions.go` — add `ctx` field to `WindowsPermissionChecker`; populate findings for
  `permissions.everyone_full_control`, `permissions.users_full_control`, `permissions.admin_share_present`; deduplication guards in place

## Notes

- Unix, Darwin, and BSD checker paths are untouched — scoped to future branches
- Known false positive on Microsoft-linked accounts flagged by `users.no_password_required` is tracked under bug #32

## Checklist

- [x] `internal/security/audit/audit.go` — `NewSecurityAuditor`
- [x] `internal/security/checker/ssh.go` — `WindowsSSHChecker`
- [x] `internal/security/checker/firewall.go` — `WindowsFirewallChecker`
- [x] `internal/security/checker/users.go` — `WindowsUserChecker`
- [x] `internal/security/checker/permissions.go` — `WindowsPermissionChecker`
- [x] `gosec` — 0 issues
- [x] `govulncheck` — no vulnerabilities
- [x] `golangci-lint` — 0 issues

Closes #40 