### PR TITLE
[Enhancement] Populate structured findings for Linux checkers

### DIFF
--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -82,9 +82,9 @@ func NewSecurityAuditor(opts Options) *SecurityAuditor {
 		auditor.userChecker = checker.NewWindowsUserChecker(ctx)
 		auditor.permissionChecker = checker.NewWindowsPermissionChecker(ctx)
 	default:
-		auditor.sshChecker = checker.NewUnixSSHChecker()
+		auditor.sshChecker = checker.NewUnixSSHChecker(ctx)
 		auditor.firewallChecker = checker.NewUnixFirewallChecker()
-		auditor.userChecker = checker.NewUnixUserChecker()
+		auditor.userChecker = checker.NewUnixUserChecker(ctx)
 		auditor.permissionChecker = checker.NewUnixPermissionChecker()
 	}
 

--- a/internal/security/checker/ssh.go
+++ b/internal/security/checker/ssh.go
@@ -20,6 +20,7 @@ type SSHChecker interface {
 // UnixSSHChecker implements SSHChecker for Unix-like systems
 type UnixSSHChecker struct {
 	ConfigPaths []string
+	ctx         registry.OSContext
 }
 
 // WindowsSSHChecker implements SSHChecker for Windows systems
@@ -29,7 +30,7 @@ type WindowsSSHChecker struct {
 }
 
 // NewUnixSSHChecker creates a new Unix SSH checker with default paths
-func NewUnixSSHChecker() *UnixSSHChecker {
+func NewUnixSSHChecker(ctx registry.OSContext) *UnixSSHChecker {
 	return &UnixSSHChecker{
 		ConfigPaths: []string{
 			"/etc/ssh/sshd_config",
@@ -61,6 +62,7 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 		Status:      "CHECKING",
 		Description: "Analyzing SSH Configuration settings",
 		Details:     make([]string, 0),
+		Findings:    make([]types.Finding, 0),
 	}
 
 	var file *os.File
@@ -81,6 +83,15 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 		result.Description = fmt.Sprintf("SSH configuration file not found in any of: %v", s.ConfigPaths)
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s ERROR: No SSH configuration file found", types.SymbolError))
+		if def, ok := registry.Lookup(s.ctx, "ssh.config_not_found"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+			})
+		}
 		return result
 	}
 
@@ -125,6 +136,15 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 		if config.rootLogin {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: Root login is permitted", types.SymbolWarning))
+			if def, ok := registry.Lookup(s.ctx, "ssh.root_login_permitted"); ok {
+				result.Findings = append(result.Findings, types.Finding{
+					Title:       def.Title,
+					Severity:    def.Severity,
+					Description: def.Description,
+					Impact:      def.Impact,
+					Resolution:  def.Resolution,
+				})
+			}
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s Root login is disabled", types.SymbolOK))
@@ -132,6 +152,15 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 	} else {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s WARNING: PermitRootLogin setting not found (defaults may apply)", types.SymbolWarning))
+		if def, ok := registry.Lookup(s.ctx, "ssh.permit_root_login_not_set"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+			})
+		}
 	}
 
 	// Check password authentication
@@ -139,6 +168,15 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 		if config.passwordAuth {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: Password authentication is enabled", types.SymbolWarning))
+			if def, ok := registry.Lookup(s.ctx, "ssh.password_auth_enabled"); ok {
+				result.Findings = append(result.Findings, types.Finding{
+					Title:       def.Title,
+					Severity:    def.Severity,
+					Description: def.Description,
+					Impact:      def.Impact,
+					Resolution:  def.Resolution,
+				})
+			}
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s Password authentication is disabled", types.SymbolOK))
@@ -146,6 +184,15 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 	} else {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s WARNING: PasswordAuthentication setting not found (defaults may apply)", types.SymbolWarning))
+		if def, ok := registry.Lookup(s.ctx, "ssh.password_auth_not_set"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+			})
+		}
 	}
 
 	result.Status = "COMPLETED"

--- a/internal/security/checker/users.go
+++ b/internal/security/checker/users.go
@@ -33,6 +33,7 @@ type platformConfig struct {
 type UnixUserChecker struct {
 	config platformConfig
 	osType string
+	ctx    registry.OSContext
 }
 
 // WindowsUserChecker implements UserChecker for Windows systems
@@ -51,6 +52,12 @@ type userAccount struct {
 	isLocked   bool
 	isAdmin    bool
 	isDisabled bool
+}
+
+// authConfigResult holds the outcome of auth configuration detection.
+type authConfigResult struct {
+	Details []string
+	Keys    []registry.FindingKey
 }
 
 // getPlatformConfig returns the appropriate configuration for the current OS
@@ -89,10 +96,11 @@ func getPlatformConfig() platformConfig {
 }
 
 // NewUnixUserChecker creates a new Unix user checker with OS-specific settings
-func NewUnixUserChecker() *UnixUserChecker {
+func NewUnixUserChecker(ctx registry.OSContext) *UnixUserChecker {
 	return &UnixUserChecker{
 		config: getPlatformConfig(),
 		osType: runtime.GOOS,
+		ctx:    ctx,
 	}
 }
 
@@ -108,9 +116,22 @@ func (u *UnixUserChecker) Check() types.AuditResult {
 		Status:      "CHECKING",
 		Description: fmt.Sprintf("Analyzing user accounts on %s", u.osType),
 		Details:     make([]string, 0),
+		Findings:    make([]types.Finding, 0),
 	}
 
-	result.Details = append(result.Details, u.checkAuthConfig()...)
+	authResult := u.checkAuthConfig()
+	result.Details = append(result.Details, authResult.Details...)
+	for _, key := range authResult.Keys {
+		if def, ok := registry.Lookup(u.ctx, key); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+			})
+		}
+	}
 
 	users, err := u.getUsers()
 	if err != nil {
@@ -431,10 +452,12 @@ func (u *UnixUserChecker) analyzeUsers(users []userAccount, result *types.AuditR
 	}
 }
 
-func (u *UnixUserChecker) checkAuthConfig() []string {
-	var details []string
+// checkAuthConfig detects authentication mechanisms configured on the system.
+func (u *UnixUserChecker) checkAuthConfig() authConfigResult {
+	var r authConfigResult
+
 	if _, err := os.Stat("/etc/pam.d"); err == nil {
-		details = append(details,
+		r.Details = append(r.Details,
 			fmt.Sprintf("%s PAM authentication is configured", types.SymbolInfo))
 
 		// Use os.DirFS to scope file reads to /etc/pam.d,
@@ -460,12 +483,12 @@ func (u *UnixUserChecker) checkAuthConfig() []string {
 				}
 				return nil
 			}); err != nil {
-				details = append(details,
+				r.Details = append(r.Details,
 					fmt.Sprintf("%s Could not scan PAM configuration: %v",
 						types.SymbolInfo, err))
 			}
 			if found {
-				details = append(details,
+				r.Details = append(r.Details,
 					fmt.Sprintf("%s Found authentication module: %s",
 						types.SymbolInfo, module))
 			}
@@ -473,21 +496,24 @@ func (u *UnixUserChecker) checkAuthConfig() []string {
 	}
 
 	if _, err := os.Stat("/etc/ldap.conf"); err == nil {
-		details = append(details,
+		r.Details = append(r.Details,
 			fmt.Sprintf("%s LDAP authentication is configured", types.SymbolWarning))
+		r.Keys = append(r.Keys, "users.ldap_configured")
 	}
 
 	if _, err := os.Stat("/etc/krb5.conf"); err == nil {
-		details = append(details,
+		r.Details = append(r.Details,
 			fmt.Sprintf("%s Kerberos authentication is configured", types.SymbolWarning))
+		r.Keys = append(r.Keys, "users.kerberos_configured")
 	}
 
 	if _, err := os.Stat("/etc/sssd/sssd.conf"); err == nil {
-		details = append(details,
+		r.Details = append(r.Details,
 			fmt.Sprintf("%s SSSD authentication is configured", types.SymbolWarning))
+		r.Keys = append(r.Keys, "users.sssd_configured")
 	}
 
-	return details
+	return r
 }
 
 func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
@@ -501,6 +527,15 @@ func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
 					result.Details = append(result.Details,
 						fmt.Sprintf("%s CRITICAL: User %s has no password set",
 							types.SymbolCritical, fields[passwdFieldUsername]))
+					if def, ok := registry.Lookup(u.ctx, "users.empty_password_hash"); ok {
+						result.Findings = append(result.Findings, types.Finding{
+							Title:       def.Title,
+							Severity:    def.Severity,
+							Description: def.Description,
+							Impact:      def.Impact,
+							Resolution:  def.Resolution,
+						})
+					}
 				}
 			}
 
@@ -519,6 +554,15 @@ func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
 			} else {
 				result.Details = append(result.Details,
 					fmt.Sprintf("%s WARNING: Root account is unlocked", types.SymbolWarning))
+				if def, ok := registry.Lookup(u.ctx, "users.root_account_unlocked"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+					})
+				}
 			}
 		}
 	}
@@ -535,6 +579,15 @@ func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
 						result.Details = append(result.Details,
 							fmt.Sprintf("%s CRITICAL: User %s has UID 0",
 								types.SymbolCritical, fields[0]))
+						if def, ok := registry.Lookup(u.ctx, "users.uid_zero_non_root"); ok {
+							result.Findings = append(result.Findings, types.Finding{
+								Title:       def.Title,
+								Severity:    def.Severity,
+								Description: def.Description,
+								Impact:      def.Impact,
+								Resolution:  def.Resolution,
+							})
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Wire `registry.OSContext` into the Unix SSH and user checker structs and populate `result.Findings` from the registry for every detected condition that maps to a finding key on Linux. `Details` strings are preserved unchanged as verbose-only raw diagnostic output.

## Changes

- `internal/security/audit/audit.go` — pass `OSContext` to `NewUnixSSHChecker` and `NewUnixUserChecker` constructors
- `internal/security/checker/ssh.go` — add `ctx` field to `UnixSSHChecker`; populate findings for `ssh.config_not_found`,
  `ssh.root_login_permitted`, `ssh.password_auth_enabled`, `ssh.permit_root_login_not_set`, `ssh.password_auth_not_set`
- `internal/security/checker/users.go` — add `ctx` field to `UnixUserChecker`; introduce `authConfigResult` type for pure
  detection in `checkAuthConfig`; populate findings for `users.ldap_configured`, `users.kerberos_configured`,
  `users.sssd_configured`, `users.empty_password_hash`, `users.root_account_unlocked`, `users.uid_zero_non_root`

## Notes

- Windows checker paths are untouched — landed in enhancement #40
- Darwin and BSD checker paths are untouched — scoped to future branches
- Unix firewall distro-aware detection is scoped to its own future branch
- Unix permissions findings are scoped to their own future branch
- `authConfigResult` keeps detection pure and finding emission in the caller — scalable as auth mechanisms grow

## Checklist

- [x] `internal/security/audit/audit.go` — Unix constructor calls
- [x] `internal/security/checker/ssh.go` — `UnixSSHChecker`
- [x] `internal/security/checker/users.go` — `UnixUserChecker`
- [x] `go build` — clean
- [x] `gosec` — 0 issues
- [x] `govulncheck` — no vulnerabilities
- [x] `golangci-lint` — 0 issues
- [x] `go vet` — clean

Closes #42 