### PR TITLE
[Bug] calculateSummary scores from Details strings instead of structured findings

### DIFF
--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -200,12 +200,12 @@ func (sa *SecurityAuditor) calculateSummary(results []types.AuditResult) Summary
 
 	for _, result := range results {
 		switch {
-		case result.Status == "COMPLETED" && !containsWarning(result.Details):
-			summary.PassedChecks++
-		case result.Status == "WARNING" || containsWarning(result.Details):
-			summary.WarningChecks++
 		case result.Status == "ERROR":
 			summary.FailedChecks++
+		case len(result.Findings) > 0:
+			summary.WarningChecks++
+		case result.Status == "COMPLETED":
+			summary.PassedChecks++
 		default:
 			summary.SkippedChecks++
 		}
@@ -254,14 +254,4 @@ func timeCheck(fn func() types.AuditResult) types.AuditResult {
 	result.EndTime = end
 	result.Duration = end.Sub(start)
 	return result
-}
-
-func containsWarning(details []string) bool {
-	for _, detail := range details {
-		if strings.Contains(detail, "WARNING") ||
-			strings.Contains(detail, types.SymbolWarning) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary

`calculateSummary` was scoring warning and failure counts by scanning `result.Details` strings for `[!]` via `containsWarning`. Now that `result.Findings` is populated by all Windows and Linux checkers, summary scoring derives from structured finding data instead of string pattern matching.

## Changes

- `internal/security/audit/audit.go` — rewrite `calculateSummary` to score from `result.Findings` length and `result.Status`; remove
  `containsWarning` entirely

## Scoring Rules

- `ERROR` status → failed
- One or more findings of any severity → warning
- `COMPLETED` with no findings → passed
- Any other state → skipped

## Checklist

- [x] `internal/security/audit/audit.go` — `calculateSummary`
- [x] `internal/security/audit/audit.go` — `containsWarning` removed
- [x] `gosec` — 0 issues
- [x] `govulncheck` — no vulnerabilities
- [x] `golangci-lint` — 0 issues
- [x] CI pipeline — all jobs passed

Closes #44 