### PR TITLE
[Bug] Formatter output does not meet output contract

### DIFF
--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -13,7 +13,6 @@ import (
 	"github.com/papa0four/orkowatch/internal/osfingerprint"
 	"github.com/papa0four/orkowatch/internal/security/audit"
 	"github.com/papa0four/orkowatch/internal/security/formatter"
-	"github.com/papa0four/orkowatch/internal/security/types"
 	"github.com/papa0four/orkowatch/internal/softwarelist"
 )
 
@@ -250,10 +249,6 @@ func outputResults(result *ScanResult) error {
 		return fmt.Errorf("failed to format results: %w", err)
 	}
 
-	if result.SecurityAudit != nil {
-		printCriticalFindings(result.SecurityAudit)
-	}
-
 	return nil
 }
 
@@ -268,32 +263,6 @@ func isModuleSkipped(module string) bool {
 		}
 	}
 	return false
-}
-
-func printCriticalFindings(auditResult *audit.Result) {
-	var criticalCount, highCount int
-
-	for _, result := range auditResult.Results {
-		for _, finding := range result.Findings {
-			switch finding.Severity {
-			case types.SeverityCritical:
-				criticalCount++
-			case types.SeverityHigh:
-				highCount++
-			}
-		}
-	}
-
-	if criticalCount > 0 || highCount > 0 {
-		fmt.Printf("\n%s Critical Security Findings:\n", types.SymbolCritical)
-		if criticalCount > 0 {
-			fmt.Printf("  %d Critical severity issues found\n", criticalCount)
-		}
-		if highCount > 0 {
-			fmt.Printf("  %d High severity issues found\n", highCount)
-		}
-		fmt.Println("\nPlease review the detailed security audit section of the report.")
-	}
 }
 
 // isTerminal checks if the output is going to a terminal

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -282,37 +282,7 @@ func outputResults(result *audit.Result) error {
 		fmt.Println(output)
 	}
 
-	if !verbose {
-		printCriticalFindings(result)
-	}
-
 	return nil
-}
-
-func printCriticalFindings(result *audit.Result) {
-	var criticalCount, highCount int
-
-	for _, checkResult := range result.Results {
-		for _, finding := range checkResult.Findings {
-			switch finding.Severity {
-			case types.SeverityCritical:
-				criticalCount++
-			case types.SeverityHigh:
-				highCount++
-			}
-		}
-	}
-
-	if criticalCount > 0 || highCount > 0 {
-		fmt.Printf("\n%s Security Issues Found:\n", types.SymbolCritical)
-		if criticalCount > 0 {
-			fmt.Printf("  %d Critical severity findings\n", criticalCount)
-		}
-		if highCount > 0 {
-			fmt.Printf("  %d High severity findings\n", highCount)
-		}
-		fmt.Println("\nPlease review the detailed report and take appropriate action.")
-	}
 }
 
 func formatJSON(result *audit.Result) (string, error) {
@@ -392,48 +362,52 @@ func formatText(result *audit.Result) (string, error) {
 		fmt.Fprintf(&builder, "Kernel: %s\n\n", result.SystemInfo.KernelVersion)
 	}
 
+	hasFindings := false
+
 	for _, checkResult := range result.Results {
 		fmt.Fprintf(&builder, "Check: %s\n", checkResult.Name)
 		fmt.Fprintf(&builder, "Status: %s\n", checkResult.Status)
-		if verbose {
-			fmt.Fprintf(&builder, "Duration: %v\n", checkResult.Duration)
-			if len(checkResult.Details) > 0 {
-				builder.WriteString("\nDetails:\n")
-				for _, detail := range checkResult.Details {
-					fmt.Fprintf(&builder, "  %s\n", detail)
+		fmt.Fprintf(&builder, "Duration: %v\n", checkResult.Duration)
+
+		if len(checkResult.Findings) > 0 {
+			hasFindings = true
+			builder.WriteString("Findings:\n")
+			for _, finding := range checkResult.Findings {
+				symbol, label := types.SeverityFormat(finding.Severity)
+				fmt.Fprintf(&builder, "%s %s  %s\n", symbol, label, finding.Title)
+				if verbose {
+					if finding.Description != "" {
+						fmt.Fprintf(&builder, "  Description: %s\n", finding.Description)
+					}
+					if finding.Impact != "" {
+						fmt.Fprintf(&builder, "  Impact: %s\n", finding.Impact)
+					}
+					if finding.Resolution != "" {
+						fmt.Fprintf(&builder, "  Resolution: %s\n", finding.Resolution)
+					}
 				}
 			}
 		}
 
-		if len(checkResult.Findings) > 0 {
-			builder.WriteString("\nFindings:\n")
-			for _, finding := range checkResult.Findings {
-				fmt.Fprintf(&builder, "  [%s] %s\n", finding.Severity, finding.Title)
-				if verbose {
-					if finding.Description != "" {
-						fmt.Fprintf(&builder, "    Description: %s\n", finding.Description)
-					}
-					if finding.Impact != "" {
-						fmt.Fprintf(&builder, "    Impact: %s\n", finding.Impact)
-					}
-					if finding.Resolution != "" {
-						fmt.Fprintf(&builder, "    Resolution: %s\n", finding.Resolution)
-					}
-				}
+		if verbose && len(checkResult.Details) > 0 {
+			builder.WriteString("Raw Diagnostic Output:\n")
+			for _, detail := range checkResult.Details {
+				fmt.Fprintf(&builder, "  %s\n", detail)
 			}
 		}
 
 		builder.WriteString("\n")
 	}
 
-	builder.WriteString("\nSummary:\n")
+	builder.WriteString("Summary:\n")
 	fmt.Fprintf(&builder, "Checks Run: %d\n", len(result.Results))
 	fmt.Fprintf(&builder, "Passed:     %d\n", result.Summary.PassedChecks)
 	fmt.Fprintf(&builder, "Warnings:   %d\n", result.Summary.WarningChecks)
 	fmt.Fprintf(&builder, "Failed:     %d\n", result.Summary.FailedChecks)
+	fmt.Fprintf(&builder, "Duration:   %v\n", result.Duration)
 
-	if verbose {
-		fmt.Fprintf(&builder, "Duration:   %v\n", result.Duration)
+	if !verbose && hasFindings {
+		builder.WriteString("\nRun with -v for full finding details, impact analysis, and remediation guidance.\n")
 	}
 
 	return builder.String(), nil

--- a/internal/security/formatter/formatter.go
+++ b/internal/security/formatter/formatter.go
@@ -107,6 +107,8 @@ func (f *Formatter) prepareOutput(result *audit.Result) map[string]interface{} {
 	// Add metadata
 	output["timestamp"] = time.Now().UTC().Format(time.RFC3339)
 	output["duration"] = result.Duration.String()
+	output["verbose"] = f.options.Verbose
+	output["non_verbose"] = !f.options.Verbose
 
 	// Add system information if requested
 	if f.options.IncludeSystem {
@@ -132,6 +134,15 @@ func (f *Formatter) prepareOutput(result *audit.Result) map[string]interface{} {
 		"duration":       result.Duration.String(),
 	}
 
+	hasFindings := false
+	for _, r := range formattedResults {
+		if _, ok := r["findings"]; ok {
+			hasFindings = true
+			break
+		}
+	}
+	output["has_findings"] = hasFindings
+
 	return output
 }
 
@@ -148,10 +159,13 @@ func (f *Formatter) formatCheck(check types.AuditResult) map[string]interface{} 
 	var relevantFindings []map[string]interface{}
 	for _, finding := range check.Findings {
 		if isSeverityRelevant(finding.Severity, f.options.MinSeverity) {
+			symbol, label := types.SeverityFormat(finding.Severity)
 			formattedFinding := map[string]interface{}{
 				"title":    finding.Title,
 				"severity": finding.Severity,
 				"category": finding.Category,
+				"symbol":   symbol,
+				"label":    label,
 			}
 
 			if f.options.Verbose {
@@ -199,11 +213,9 @@ func isSeverityRelevant(findingSeverity, minSeverity string) bool {
 }
 
 // Default text template
-const defaultTemplate = `
-Security Audit Report
+const defaultTemplate = `Security Audit Report
 ====================
 Generated: {{.timestamp}}
-
 {{if .system}}
 System Information
 -----------------
@@ -213,36 +225,27 @@ Hostname: {{.system.Hostname}}
 Kernel Version: {{.system.KernelVersion}}
 Software Count: {{.system.SoftwareCount}}
 {{end}}
-
 Check Results
 ------------
 {{range .results}}
 Check: {{.name}}
 Status: {{.status}}
-Description: {{.description}}
 Duration: {{.duration}}
-
-{{if .findings}}
-Findings:
-{{range .findings}}
-  - [{{.severity}}] {{.title}}
+{{if .findings}}Findings:
+{{range .findings}}{{.symbol}} {{.label}}  {{.title}}
+{{if $.verbose}}{{if .description}}  Description: {{.description}}
+{{end}}{{if .impact}}  Impact: {{.impact}}
+{{end}}{{if .resolution}}  Resolution: {{.resolution}}
+{{end}}{{end}}{{end}}{{end}}{{if and $.verbose .details}}Raw Diagnostic Output:
+{{range .details}}  {{.}}
+{{end}}{{end}}
 {{end}}
-{{end}}
-
-{{if .details}}
-Details:
-{{range .details}}
-  {{.}}
-{{end}}
-{{end}}
-{{end}}
-
-Summary
--------
-Total Checks: {{.summary.total_checks}}
-Passed: {{.summary.passed_checks}}
-Warnings: {{.summary.warning_checks}}
-Failed: {{.summary.failed_checks}}
-Skipped: {{.summary.skipped_checks}}
-Duration: {{.summary.duration}}
-`
+Summary:
+Checks Run: {{.summary.total_checks}}
+Passed:     {{.summary.passed_checks}}
+Warnings:   {{.summary.warning_checks}}
+Failed:     {{.summary.failed_checks}}
+Duration:   {{.summary.duration}}
+{{if and .non_verbose .has_findings}}
+Run with -v for full finding details, impact analysis, and remediation guidance.
+{{end}}`

--- a/internal/security/types/types.go
+++ b/internal/security/types/types.go
@@ -74,3 +74,19 @@ type ValidationError struct {
 func (e *ValidationError) Error() string {
 	return fmt.Sprintf("validation error in %s: %s - %s", e.Checker, e.Field, e.Message)
 }
+
+// SeverityFormat returns the display symbol and fixed-width padded severity label
+func SeverityFormat(severity string) (symbol, label string) {
+	switch severity {
+	case SeverityCritical:
+		return SymbolCritical, "CRITICAL"
+	case SeverityHigh:
+		return SymbolWarning, "HIGH    "
+	case SeverityMedium:
+		return SymbolWarning, "MEDIUM  "
+	case SeverityLow:
+		return SymbolInfo, "LOW     "
+	default:
+		return SymbolInfo, severity
+	}
+}


### PR DESCRIPTION
## Summary

Brings `formatText` in `security.go` and `defaultTemplate` in `formatter.go` in line with the agreed output contract for `bug/31`. Centralizes severity formatting in the `types` package so both renderers produce identical symbol and label alignment from a single source. Removes the duplicate `printCriticalFindings` trailer in `security.go` and `all.go` whose output is now surfaced correctly by the findings block in the new renderers.

## Changes

- `internal/security/types/types.go` — add exported `SeverityFormat` function returning the symbol and fixed-width padded severity label 
- `cmd/commands/security/security.go` — update `formatText` to render findings with `types.SeverityFormat`, gate raw diagnostic output behind verbose, append hint line after summary when non-verbose and findings exist; remove `printCriticalFindings` and its call site
- `cmd/commands/all.go` — remove `printCriticalFindings` and its call site; remove now-unused `types` import
- `internal/security/formatter/formatter.go` — inject `verbose`, `non_verbose`, and `has_findings` into template data; populate `symbol` and `label` per finding via `types.SeverityFormat`; replace `defaultTemplate` to match the same contract

## Output Contract

Per-check duration is always shown. Total duration always appears in the summary. Non-verbose renders findings with fixed-width severity alignment. Verbose adds description, impact, and resolution per finding, plus the raw diagnostic output section. A hint line is appended after the summary in non-verbose mode only when findings exist.

## Notes

- `SeverityFormat` lives in `types` since severity constants and symbols already live there — single source of truth for severity rendering
- Future renderers (TUI, NVD enrichment) consume the same function

## Checklist

- [x] `internal/security/types/types.go` — `SeverityFormat`
- [x] `cmd/commands/security/security.go` — `formatText`, `printCriticalFindings` removed
- [x] `cmd/commands/all.go` — `printCriticalFindings` removed, `types` import cleaned
- [x] `internal/security/formatter/formatter.go` — `prepareOutput`, `formatCheck`, `defaultTemplate`
- [x] `gosec` — 0 issues
- [x] `govulncheck` — no vulnerabilities
- [x] `golangci-lint` — 0 issues

Closes #46 