### PR TITLE
[enhancement] Scaffold enrichment package and wire --enrich flag

### DIFF
--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -22,6 +22,7 @@ var (
 	allReportFile   string
 	skipModules     []string
 	allTimeout      time.Duration
+	allEnrich       bool
 )
 
 // allCmd represents the all command that combines all scanning modules
@@ -60,6 +61,8 @@ func init() {
 		"Modules to skip (comma-separated: os,software,security)")
 	allCmd.Flags().DurationVar(&allTimeout, "timeout", 30*time.Minute,
 		"Maximum time to run all scans")
+	allCmd.Flags().BoolVarP(&allEnrich, "enrich", "e", false,
+		"Query external sources to annotate findings with CVEs mapped to referenced CWEs")
 
 	RootCmd.AddCommand(allCmd)
 }
@@ -182,6 +185,7 @@ func runSecurityAuditModule() (*audit.Result, error) {
 		Verbose:     allVerbose,
 		MinSeverity: "LOW",
 		Timeout:     allTimeout / 3,
+		Enrich:      allEnrich,
 	}
 
 	auditor := audit.NewSecurityAuditor(opts)

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -30,6 +30,9 @@ var (
 	checkFirewall  bool
 	checkUsers     bool
 	checkFilePerms string
+
+	// enrichment flag
+	enrich bool
 )
 
 // SecurityCmd represents the security audit command
@@ -132,6 +135,8 @@ func init() {
 		"Run user accounts check")
 	SecurityCmd.Flags().StringVar(&checkFilePerms, "file-permissions", "",
 		"Check permissions of specified file path")
+	SecurityCmd.Flags().BoolVarP(&enrich, "enrich", "e", false,
+		"Query external sources to annotate findings with CVEs mapped to referenced CWEs")
 }
 
 func buildChecks() []string {
@@ -221,6 +226,7 @@ func runAuditWithTimeout(checks []string) error {
 		MinSeverity:    minSeverity,
 		Timeout:        timeout,
 		SpecificChecks: checks,
+		Enrich:         enrich,
 	}
 
 	auditor := audit.NewSecurityAuditor(opts)
@@ -349,6 +355,97 @@ func convertToFormattedResult(result *audit.Result) formattedResult {
 
 	return formatted
 }
+func renderEnrichmentBlock(builder *strings.Builder, result *audit.Result) {
+	if !result.EnrichmentRequested {
+		return
+	}
+
+	builder.WriteString("Enrichment:\n")
+
+	if result.EnrichmentError != nil {
+		fmt.Fprintf(builder, "  Unavailable: %v\n\n", result.EnrichmentError)
+		renderReferenceErrors(builder, result.References)
+		return
+	}
+
+	if len(result.References.CWEs) == 0 {
+		builder.WriteString("  No CWE references found in current findings.\n\n")
+		renderReferenceErrors(builder, result.References)
+		return
+	}
+
+	if result.Enrichment == nil {
+		builder.WriteString("  No enrichment data returned.\n\n")
+		renderReferenceErrors(builder, result.References)
+		return
+	}
+
+	rendered := 0
+	for _, cwe := range result.References.CWEs {
+		entry, ok := result.Enrichment.Successes[cwe]
+		if !ok {
+			continue
+		}
+		rendered++
+		fmt.Fprintf(builder, "  %s", cwe)
+		if entry.WeaknessName != "" {
+			fmt.Fprintf(builder, " - %s", entry.WeaknessName)
+		}
+		fmt.Fprintln(builder)
+
+		if entry.Status == "NO_MATCHES" || len(entry.MatchedCVEs) == 0 {
+			builder.WriteString("    No CVE matches in queried sources.\n")
+			continue
+		}
+
+		for _, match := range entry.MatchedCVEs {
+			symbol, label := types.SeverityFormat(match.CVSSSeverity)
+			fmt.Fprintf(builder, "    %s %s  %s (%.1f) [%s]\n",
+				symbol, label, match.CVEID, match.CVSSBaseScore, match.Source)
+			if verbose {
+				if match.Description != "" {
+					fmt.Fprintf(builder, "      Description: %s\n", match.Description)
+				}
+				if match.KnownExploited {
+					builder.WriteString("      Known Exploited: yes\n")
+				}
+				if match.PatchAvailable {
+					builder.WriteString("      Patch Available: yes\n")
+				}
+			}
+		}
+	}
+
+	if rendered == 0 {
+		builder.WriteString("  No enrichment data returned.\n")
+	}
+
+	if len(result.Enrichment.Failures) > 0 {
+		builder.WriteString("\n  Failed enrichments:\n")
+		for cwe, failure := range result.Enrichment.Failures {
+			fmt.Fprintf(builder, "    %s [%s]: %s",
+				cwe, failure.Source, failure.Reason)
+			if failure.Retryable {
+				builder.WriteString(" (retryable)")
+			}
+			fmt.Fprintln(builder)
+		}
+	}
+
+	builder.WriteString("\n")
+	renderReferenceErrors(builder, result.References)
+}
+
+func renderReferenceErrors(builder *strings.Builder, refs types.ReferenceExtraction) {
+	if len(refs.Errors) == 0 {
+		return
+	}
+	builder.WriteString("  Reference parsing errors:\n")
+	for _, err := range refs.Errors {
+		fmt.Fprintf(builder, "    %v\n", err)
+	}
+	builder.WriteString("\n")
+}
 
 func formatText(result *audit.Result) (string, error) {
 	var builder strings.Builder
@@ -399,6 +496,7 @@ func formatText(result *audit.Result) (string, error) {
 		builder.WriteString("\n")
 	}
 
+	renderEnrichmentBlock(&builder, result)
 	builder.WriteString("Summary:\n")
 	fmt.Fprintf(&builder, "Checks Run: %d\n", len(result.Results))
 	fmt.Fprintf(&builder, "Passed:     %d\n", result.Summary.PassedChecks)

--- a/docs/dev_guide/enrichment.md
+++ b/docs/dev_guide/enrichment.md
@@ -1,0 +1,490 @@
+# Enrichment Subsystem
+
+The enrichment subsystem adds external threat context to a completed local audit.
+It takes the CWE identifiers surfaced by the finding registry, queries one or more
+configured adapter sources, and returns matched CVEs grouped by the CWE that
+produced them. Enrichment is opt-in via `--enrich` / `-e` and always runs after
+the local audit completes. Enrichment failures never affect local audit results.
+
+---
+
+## Package location
+
+```
+internal/security/enrichment/
+  errors.go    -- sentinel error values
+  types.go     -- all exported types
+  validate.go  -- CWE ID normalization and validation
+  enricher.go  -- Enricher interface and NewEnricher constructor
+```
+
+---
+
+## Types
+
+### `Source`
+
+```go
+type Source string
+```
+
+Identifies which adapter contributed a field value. Defined constants:
+
+| Constant       | Value        |
+|----------------|--------------|
+| `SourceNVD`    | `"NVD"`      |
+| `SourceKEV`    | `"CISA-KEV"` |
+| `SourceEPSS`   | `"EPSS"`     |
+| `SourceGHSA`   | `"GHSA"`     |
+| `SourceMITRE`  | `"MITRE-CWE"`|
+
+Each field on `CWEEnrichment` that may be populated by different sources carries
+a parallel `*Source` field for attribution. Adapters set both the value and the
+source field together.
+
+### `Status`
+
+```go
+type Status string
+```
+
+Terminal state for an enrichment attempt on a single CWE.
+
+| Constant                | Value                  | Meaning                                      |
+|-------------------------|------------------------|----------------------------------------------|
+| `StatusEnriched`        | `"ENRICHED"`           | At least one CVE match was returned          |
+| `StatusFailed`          | `"FAILED"`             | All sources returned errors                  |
+| `StatusNoMatches`       | `"NO_MATCHES"`         | Sources responded but found no CVE matches   |
+| `StatusNoSourcesQueried`| `"NO_SOURCES_QUERIED"` | Request was valid but no sources were called |
+
+### `CWEEnrichment`
+
+```go
+type CWEEnrichment struct {
+    CWEID  string
+    Status Status
+
+    WeaknessName             string
+    WeaknessNameSource       Source
+
+    WeaknessDescription      string
+    WeaknessDescriptionSource Source
+
+    MatchedCVEs       []CVEMatch
+    MatchedCVEsSource Source
+
+    LastQueried time.Time
+}
+```
+
+Per-CWE enrichment data. `MatchedCVEs` is empty when `Status` is `NO_MATCHES`.
+`LastQueried` is set by the adapter; it informs cache expiry logic.
+
+### `CVEMatch`
+
+```go
+type CVEMatch struct {
+    CVEID         string
+    Source        Source
+    CVSSBaseScore float64
+    CVSSSeverity  string
+    CVSSVector    string
+
+    Published    time.Time
+    LastModified time.Time
+
+    KnownExploited         bool
+    ExploitPredictionScore float64
+    PatchAvailable         bool
+
+    Description string
+    References  []string
+}
+```
+
+A single CVE returned by an adapter as associated with a queried CWE.
+`KnownExploited` is populated from CISA KEV data. `ExploitPredictionScore` is
+populated from EPSS data. Adapters populate only the fields their source
+provides; zero values are valid for unset fields.
+
+### `Failure`
+
+```go
+type Failure struct {
+    CWEID     string
+    Source    Source
+    Reason    string
+    Err       error
+    Retryable bool
+}
+```
+
+Records why enrichment for a specific CWE from a specific source failed.
+`Retryable` signals that the failure is transient (network timeout, rate limit)
+and the caller may retry without changing input.
+
+### `Result`
+
+```go
+type Result struct {
+    Successes      map[string]CWEEnrichment
+    Failures       map[string]Failure
+    AdapterErrors  []error
+    SourcesQueried []Source
+    Duration       time.Duration
+}
+```
+
+Aggregate output of an enrichment run. Keys in `Successes` and `Failures` are
+canonical CWE IDs (`CWE-N`). A CWE key will appear in exactly one of the two
+maps. `AdapterErrors` holds errors that affected an entire adapter rather than
+a single CWE. `SourcesQueried` lists every source that was attempted regardless
+of outcome.
+
+### `EnrichRequest`
+
+```go
+type EnrichRequest struct {
+    CWEs        []string
+    BypassCache bool
+    Sources     []Source
+    MinSeverity string
+}
+```
+
+Input to `Enricher.Enrich`. `CWEs` must be canonical IDs (`CWE-N`); the
+adapter validates them on receipt. `BypassCache` forces a live fetch regardless
+of cached data. `Sources` restricts which adapters are called; an empty slice
+uses all configured adapters. `MinSeverity` filters CVE matches below a CVSS
+severity threshold.
+
+---
+
+## Errors
+
+All sentinels are in `errors.go` and are wrapped with `fmt.Errorf("%w", ...)` by
+callers that add context.
+
+| Sentinel                    | Meaning                                                                 |
+|-----------------------------|-------------------------------------------------------------------------|
+| `ErrNoEnricherConfigured`   | `NewEnricher` was called but no adapter is registered                   |
+| `ErrInvalidCWEID`           | A CWE identifier failed format validation                               |
+| `ErrEmptyRequest`           | `EnrichRequest.CWEs` was empty                                          |
+| `ErrMissingAPIKey`          | An adapter that requires an API key found none in the environment       |
+
+---
+
+## Validation
+
+`validate.go` exposes three functions. All three accept both canonical (`CWE-N`)
+and MITRE URL (`https://cwe.mitre.org/data/definitions/N.html`) forms and
+normalize to canonical.
+
+### `NormalizeCWEID(input string) (string, error)`
+
+Returns the canonical `CWE-N` form. Returns an error wrapping `ErrInvalidCWEID`
+if the input matches neither accepted form or contains non-digit characters in
+the numeric segment.
+
+### `ValidateCWEID(input string) error`
+
+Returns `nil` for valid input. Equivalent to calling `NormalizeCWEID` and
+discarding the normalized string. Use when only validity matters.
+
+### `NormalizeCWEIDs(inputs []string) (valid []string, errs []error)`
+
+Bulk normalization. Returns two slices: canonical IDs that passed validation and
+errors for those that did not. Rejects input slices larger than 10,000 entries
+with a single error. Does not deduplicate.
+
+**Validation rules enforced by all three functions:**
+
+- Input must have the prefix `CWE-` (canonical) or match the MITRE URL pattern.
+- The numeric segment following `CWE-` must be one or more ASCII digits only.
+- Minimum total length of the canonical form is 5 characters (`CWE-` + one digit).
+- No Unicode digits; only bytes `0x30`--`0x39` are accepted.
+
+---
+
+## Interface
+
+### `Enricher`
+
+```go
+type Enricher interface {
+    Enrich(ctx context.Context, req EnrichRequest) (Result, error)
+    Source() Source
+}
+```
+
+Every adapter implements this interface. Implementations must be safe for
+concurrent use. `Source()` returns the `Source` constant for that adapter,
+used by the orchestrator for attribution and logging.
+
+### `NewEnricher() (Enricher, error)`
+
+Returns the configured enricher. Until at least one adapter is registered,
+`NewEnricher` returns `nil, ErrNoEnricherConfigured`. This is the correct
+production state while no adapters exist.
+
+---
+
+## How enrichment is orchestrated
+
+The orchestration path lives in `internal/security/audit/audit.go`. The sequence
+is:
+
+1. `RunAudit` or `runAllChecks` completes all local checkers.
+2. `finalize` is called on the result.
+3. `finalize` calls `aggregateReferences` which calls `AllCWEReferences()` across
+   every `AuditResult.Findings` slice and stores the deduplicated extraction in
+   `audit.Result.References`.
+4. If `Options.Enrich` is false, `finalize` returns.
+5. `NewEnricher()` is called. If it returns `ErrNoEnricherConfigured`, the error
+   is stored in `audit.Result.EnrichmentError` and `finalize` returns. Local
+   results are unaffected.
+6. If `References.CWEs` is empty, `finalize` returns without calling the enricher.
+7. Otherwise `Enrich` is called with a context scoped to `Options.Timeout`.
+8. On success, `*enrichment.Result` is stored in `audit.Result.Enrichment`.
+9. On failure, the error is stored in `audit.Result.EnrichmentError`.
+
+`audit.Result.EnrichmentRequested` is always set from `Options.Enrich`
+regardless of outcome, so the renderer can distinguish "not requested" from
+"requested but failed."
+
+### `audit.Options.Enrich`
+
+```go
+type Options struct {
+    // ...
+    Enrich bool
+}
+```
+
+Set by `security_audit --enrich` / `-e` and `all --enrich` / `-e`.
+
+### `audit.Result` enrichment fields
+
+```go
+type Result struct {
+    // ...
+    EnrichmentRequested bool
+    EnrichmentError     error
+    Enrichment          *enrichment.Result
+    References          types.ReferenceExtraction
+}
+```
+
+`References` is always populated after `finalize` regardless of whether
+enrichment was requested. It is reused by the renderer to drive the enrichment
+output section.
+
+---
+
+## Reference extraction
+
+The bridge between registry findings and enrichment input is in
+`internal/security/types/types.go`.
+
+### `Finding.CWEReferences() ReferenceExtraction`
+
+Iterates `Finding.References`, normalizes every entry with `Type == "CWE"` via
+`enrichment.NormalizeCWEID`, deduplicates by canonical ID, and separates
+non-CWE references into `ReferenceExtraction.Other`. Normalization failures are
+collected into `ReferenceExtraction.Errors`.
+
+### `AuditResult.AllCWEReferences() ReferenceExtraction`
+
+Aggregates `CWEReferences()` across all findings in one `AuditResult`.
+Deduplication is applied across the full set; order matches first occurrence.
+Errors from all findings are concatenated.
+
+### `ReferenceExtraction`
+
+```go
+type ReferenceExtraction struct {
+    CWEs   []string
+    Errors []error
+    Other  []ClassifiedReference
+}
+```
+
+`CWEs` is the input to `EnrichRequest.CWEs`. `Errors` are surfaced in the
+rendered output's reference parsing errors section. `Other` is available for
+future use.
+
+### `ClassifiedReference`
+
+```go
+type ClassifiedReference struct {
+    Type  string
+    Value string
+}
+```
+
+A non-CWE reference from a finding, annotated with its `RefType*` classification.
+
+---
+
+## Registry integration
+
+`Finding.References` is populated in every checker via
+`registry.FindingDefinition.ToReferences()`. Checkers call `registry.Lookup` to
+retrieve the `FindingDefinition` for a key, then assign the return of
+`ToReferences()` to the `Finding.References` field.
+
+### `FindingDefinition.ToReferences() []types.Reference`
+
+Converts the flat `[]string` YAML `references` field into `[]types.Reference`.
+Each string is classified by `classifyReference` using the following rules (in
+priority order):
+
+| Prefix / pattern                                  | Assigned `Type`  |
+|---------------------------------------------------|------------------|
+| `CWE-` or `https://cwe.mitre.org/`               | `RefTypeCWE`     |
+| `CVE-` or `https://nvd.nist.gov/vuln/detail/CVE-`| `RefTypeCVE`     |
+| `CIS `                                            | `RefTypeCIS`     |
+| `NIST `                                           | `RefTypeNIST`    |
+| `MITRE `                                          | `RefTypeMITRE`   |
+| `https://` or `http://`                           | `RefTypeURL`     |
+| anything else                                     | `RefTypeOther`   |
+
+CWE references get a generated MITRE URL in `Reference.URL`. CVE references get
+a generated NVD URL. Other types populate only `Title`.
+
+---
+
+## Rendering
+
+Rendering lives in two places.
+
+**`internal/security/formatter/formatter.go`** handles JSON and YAML output
+via `prepareOutput`, which populates the following template keys when
+`enrichment_requested` is true:
+
+| Key                   | Source                                          |
+|-----------------------|-------------------------------------------------|
+| `enrichment_requested`| `audit.Result.EnrichmentRequested`             |
+| `enrichment_error`    | `audit.Result.EnrichmentError.Error()` or `""` |
+| `reference_cwes`      | `audit.Result.References.CWEs`                 |
+| `reference_errors`    | `formatReferenceErrors(result.References.Errors)` |
+| `enrichment_entries`  | `buildEnrichmentEntries(result)`               |
+| `enrichment_failures` | `buildEnrichmentFailures(result)`              |
+
+**`cmd/commands/security/security.go`** handles plain-text output via
+`renderEnrichmentBlock` and `renderReferenceErrors`. These are called from
+`formatText` (the text-mode output path) and implement the six rendering states
+described in the output design.
+
+### Rendering states (text mode)
+
+| Condition                                          | Output                                              |
+|----------------------------------------------------|-----------------------------------------------------|
+| `EnrichmentError != nil`                           | `Unavailable: <error>`                              |
+| `References.CWEs` empty                            | `No CWE references found in current findings.`      |
+| `Enrichment == nil`                                | `No enrichment data returned.`                      |
+| CWE present in `Successes`, status `NO_MATCHES`    | `No CVE matches in queried sources.`                |
+| CWE present in `Successes` with matches            | CVE list with severity symbol, score, source        |
+| `Enrichment.Failures` non-empty                    | Per-CWE failure with retryable indicator            |
+
+`References.Errors` (reference parsing errors) always render when non-empty,
+regardless of which enrichment state applies.
+
+---
+
+## Adapter authoring guide
+
+Adapters are not yet implemented. When writing the first adapter, follow these
+requirements.
+
+### Location
+
+Each adapter gets its own subdirectory under `internal/security/enrichment/`:
+
+```
+internal/security/enrichment/nvd/
+    nvd.go
+```
+
+The adapter package must not import `types`, `registry`, `audit`, or any other
+internal orkowatch package. The enrichment package is a leaf; adapters extend it
+as siblings, not dependents.
+
+### Interface
+
+The adapter type must satisfy `enrichment.Enricher`:
+
+```go
+func (a *NVDAdapter) Enrich(ctx context.Context, req enrichment.EnrichRequest) (enrichment.Result, error)
+func (a *NVDAdapter) Source() enrichment.Source
+```
+
+### Validation
+
+Call `enrichment.NormalizeCWEIDs(req.CWEs)` at the start of `Enrich`. Return
+`enrichment.ErrEmptyRequest` if the normalized slice is empty after validation.
+Record per-CWE normalization errors as `Failure` entries in the result.
+
+### API keys
+
+Read API keys from environment variables only. Never log, serialize, or return
+key material. Return `enrichment.ErrMissingAPIKey` when a required key is absent.
+Document the expected environment variable name in the adapter's package comment.
+
+### Caching
+
+Implement caching inside the adapter. Cache freshness rules differ per source;
+the adapter owns that logic. `EnrichRequest.BypassCache` must skip the cache
+when true.
+
+### Rate limiting
+
+Implement rate limiting inside the adapter. Do not rely on callers to throttle.
+
+### Concurrency
+
+Adapters must be safe for concurrent invocation. The orchestrator may call
+`Enrich` from multiple goroutines.
+
+### Result population
+
+For each CWE that returns results, populate a `CWEEnrichment` entry in
+`Result.Successes` with the canonical CWE ID as the key. Set `Status` to the
+appropriate constant. For each failure, populate `Result.Failures` with the
+canonical CWE ID as the key. Set `Retryable` accurately -- it is displayed to
+the user and used to decide whether a retry is appropriate.
+
+### Registering the adapter
+
+Update `NewEnricher` in `enricher.go` to return the configured adapter once at
+least one is available. Multi-adapter orchestration (concurrent fan-out via
+`errgroup`) is the planned model; `NewEnricher` will evolve accordingly.
+
+---
+
+## YAML registry -- adding references
+
+The reference strings in each YAML file are the source of all CWE input to the
+enrichment subsystem. The classifier in `ToReferences` determines what gets
+extracted as a CWE.
+
+To add a CWE reference to an existing finding, add an entry to the `references`
+list in the relevant YAML file using canonical form:
+
+```yaml
+ssh.weak_algorithms:
+  title: Weak SSH Key Exchange Algorithms Enabled
+  severity: HIGH
+  references:
+    - CWE-326
+    - CWE-327
+    - NIST SP 800-57
+```
+
+Both `CWE-N` and the full MITRE URL are accepted. The classifier normalizes
+both to canonical form before extraction. Only strings that pass CWE validation
+will appear in `EnrichRequest.CWEs`; malformed entries are collected into
+`ReferenceExtraction.Errors` and surfaced in the rendered output.
+
+YAML files are embedded at compile time via `go:embed`. Changes take effect on
+the next build.

--- a/docs/dev_guide/enrichment.md
+++ b/docs/dev_guide/enrichment.md
@@ -1,0 +1,183 @@
+# Enrichment Subsystem
+
+## Overview
+
+The enrichment subsystem annotates local audit findings with live data from external CVE intelligence sources. It is invoked when the user
+passes the `--enrich` flag to `security_audit` or `all`. Enrichment runs after the local audit completes, leaving baseline audit latency
+unaffected when the flag is not set.
+
+The subsystem lives at `internal/security/enrichment/`. Source-specific adapters implement the `Enricher` interface, and the orchestrator in
+`internal/security/audit/audit.go` invokes them with the deduplicated list of CVE references collected from local findings.
+
+This document describes the iniital design decisions made for the scaffolding of the enrichment feature. Any future updates to the
+implementation design, or feature enhancements will be outlined within this document.
+
+## Design Decisions
+
+### 1. Normalized type with per-field source attribution
+
+`CVEEnrichment` is a normalized structure shared across all enrichment sources. Each field that can carry data from an external source is
+paired with a source tag identifying which adapter provided the value.
+
+When multiple sources contribute data for the same CVE, conflicts are visible to the analyst rather than silently resolved by overwrite. This matters for security work — different sources can disagree on CVSS scoring, affected versions, or exploitation status, and an analyst
+needs to see those disagreements to make informed decisions.
+
+### 2. Adapter pattern for source pluggability
+
+The `Enricher` interface defines what an enrichment source must do. Each source is an independent implementation of the interface. The
+orchestrator does not know which sources are configured — it works against the interface.
+
+Adding a new source requires implementing the interface and registering the implementation in the constructor. No changes to orchestration,
+rendering, or audit code are required.
+
+### 3. Batch orchestration model
+
+Local audit checks run first and complete fully before any enrichment is attempted. The full audit result is assembled, the CVE references
+across all findings are collected and deduplicated, and the enrichment call is made once with the complete CVE list.
+
+This isolates network-dependent work from local diagnostic work. A network failure cannot affect the local audit result. A slow enrichment
+source cannot delay local results from being computed.
+
+### 4. Partial results with typed failures
+
+`EnrichmentResult` carries both `Successes` (a map of successfully enriched CVEs to their data) and `Failures` (a map of CVEs that could
+not be enriched along with the reason). The renderer surfaces both.
+
+A future `Retry` operation can re-run enrichment for only the failed CVEs without re-querying ones that already succeeded. The
+`EnrichmentFailure` type carries a `Retryable` boolean so the retry operation can skip permanent failures (malformed CVE IDs, sources
+declaring the CVE does not exist).
+
+### 5. Adapter-side caching
+
+Each adapter is responsible for its own caching. NVD updates daily, CISA KEV updates weekly, and EPSS updates daily — different sources
+have different freshness rules, and a single cache TTL at the orchestrator level cannot honor all of them correctly.
+
+Adapters may cache, must honor explicit cache bypass via `EnrichRequest.BypassCache`, and must treat cache state as a performance optimization rather than a correctness guarantee.
+ 
+### 6. Adapter-side rate limiting
+
+Each adapter is responsible for honoring its source's rate limits. NVD's public API permits 5 requests per 30 seconds without an API
+key and 50 requests per 30 seconds with one. CISA KEV is a single bulk download. Each adapter manages its own throttling internally
+and respects context cancellation while waiting.
+
+### 7. Concurrency safety expectations
+
+The orchestrator may invoke adapters concurrently when multiple sources are configured. Adapter implementations must therefore be
+safe to call concurrently. Adapters that maintain internal state (rate limiters, caches, connection pools) must protect that state.
+
+### 8. CVE ID validation
+
+CVE identifiers are validated against `^CVE-\d{4}-\d{4,}$` at three points: when extracted from registry references, when added to an
+`EnrichRequest`, and when an adapter constructs URLs or query strings. Invalid identifiers are rejected before any network call or string
+construction occurs.
+
+This belt-and-suspenders validation prevents injection of crafted identifiers into URLs, query strings, or downstream parsing logic.
+
+### 9. API key handling
+
+API keys are read only from environment variables. Keys are never read from configuration files committed to disk, never written to logs,
+and never serialized into audit results or rendered output. Adapters that require keys but cannot find them in the environment return an
+initialization error.
+
+### 10. Local audit independence
+
+Enrichment failures never affect local audit results. The audit `Result` is fully populated by local checks before enrichment is
+invoked. If enrichment fails entirely, the result still contains complete local findings and the failure is surfaced separately to
+the user with guidance on how to investigate.
+
+### 11. Error returned when no enricher is configured
+
+In the scaffolding branch, no adapter implementations are shipped. `NewEnricher` returns `ErrNoEnricherConfigured`. The orchestrator
+detects this condition and surfaces a clear message to the user explaining that enrichment is not yet available, while still
+completing the local audit normally.
+
+A no-op implementation that silently returns empty results was not shipped because it would hide from the user that enrichment did
+nothing. Returning a typed error makes the system's current capability honest to the user.
+
+## Implementing a New Enrichment Source
+
+This section is for contributors adding a new adapter.
+
+### Package placement
+
+Each adapter lives in its own file within `internal/security/enrichment/`. The file is named after the source: `nvd.go` for the NVD adapter, `kev.go` for CISA KEV, and so on. The type implementing the `Enricher` interface follows the same convention: `nvdEnricher`, `kevEnricher`.
+
+### Interface conformance
+
+The adapter type must satisfy the `Enricher` interface defined in `enricher.go`. Both `Enrich` and any required initialization functions
+must be implemented. The constructor for the adapter returns the interface type, not the concrete type, to keep the orchestrator
+decoupled from implementations.
+
+### Validation requirements
+
+CVE identifiers received in an `EnrichRequest` must be re-validated inside the adapter before being used in any network call or string
+construction. The orchestrator validates at the boundary, but adapters are responsible for their own input safety.
+
+### Caching expectations
+
+If the adapter caches results, the cache must honor the `BypassCache` field on `EnrichRequest`. Cache invalidation rules must
+match the source's freshness guarantees. The cache must not be the sole source of truth — a cache miss must always fall back to the
+live source.
+
+### Rate limiting expectations
+
+The adapter must enforce the source's published rate limits internally. Waiting for rate limit windows must respect context
+cancellation so the orchestrator can cancel the operation if the overall audit times out.
+
+### Error handling
+
+Errors that affect specific CVEs go into `EnrichmentFailure` entries in the `Failures` map of the result. Errors that prevent the adapter
+from functioning at all (initialization failure, missing API key, total network failure) are returned as the function's error value.
+Partial success is the normal case — an adapter that successfully enriches some CVEs and fails on others should return both the
+successes and the failures.
+
+### Source attribution
+
+When the adapter populates a field on `CVEEnrichment`, it must also populate the corresponding source tag identifying itself. This is
+how analysts trace which source provided which data point. Adapter implementations use a stable source identifier (the exported package
+constant `SourceNVD`, `SourceKEV`, etc.) rather than free-form strings.
+
+### Testing
+
+Each adapter ships with unit tests covering the success path, partial failure path, total failure path, rate limit behavior under context
+cancellation, and validation rejection of malformed input. Network calls in tests are mocked. Integration tests against the live source
+live in a build-tagged file and are not run in CI by default.
+
+## Future Enrichment Sources
+
+The following sources are candidates for future adapter implementation, in approximate priority order.
+
+NVD (National Vulnerability Database) provides the foundational CVE data including current CVSS scoring, affected configurations,
+references, and publication metadata. The first adapter implementation targets NVD v2 API.
+
+CISA KEV (Known Exploited Vulnerabilities catalog) identifies CVEs with confirmed exploitation in the wild. Adds a critical signal for
+prioritization beyond CVSS scoring alone.
+
+EPSS (Exploit Prediction Scoring System) provides probability scores for likelihood of exploitation within 30 days. Complements KEV by
+offering forward-looking risk signal for CVEs not yet exploited.
+
+GHSA (GitHub Security Advisories) provides curated advisory data with detailed remediation guidance, often with patch availability and
+affected version ranges more precise than NVD.
+
+## Documentation Format for Future Updates
+
+Files under `docs/dev_guide/` follow this structure:
+
+1. **Overview** — what the subsystem does, where it lives, when it runs. Keep to a few paragraphs.
+
+2. **Design Decisions** — numbered list of decisions made during implementation. Each decision gets a brief heading and a few
+   paragraphs of rationale. Rationale describes why the decision was made and what it achieves. Decisions that were considered and
+   rejected are not documented unless the contrast is necessary to explain the current behavior.
+
+3. **Implementing a New X** — contributor guide for extending the subsystem. Step-by-step instructions for adding new
+   implementations, with subsections covering placement, interface conformance, validation, error handling, and testing.
+
+4. **Future X** — candidates discussed for future implementation in approximate priority order. Brief descriptions only; full design
+   decisions for each future item are documented when that item is actually implemented.
+
+5. **Documentation Format for Future Updates** — only the first subsystem document includes this section, to establish the
+   pattern. Subsequent documents follow the established format without repeating these instructions.
+
+Section headers use `##` for top-level sections and `###` for subsections. Code blocks use language tags when the language is
+unambiguous. Line wrapping is at 72 columns to keep diffs readable. File names, type names, and function names use inline code
+formatting. Cross-references to other documents in `docs/dev_guide/` use relative paths.

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -2,6 +2,7 @@
 package audit
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/papa0four/orkowatch/internal/security/checker"
+	"github.com/papa0four/orkowatch/internal/security/enrichment"
 	"github.com/papa0four/orkowatch/internal/security/registry"
 	"github.com/papa0four/orkowatch/internal/security/types"
 )
@@ -34,16 +36,21 @@ type Options struct {
 	SkipChecks     []string
 	MinSeverity    string
 	Timeout        time.Duration
+	Enrich         bool
 }
 
 // Result represents the complete audit results
 type Result struct {
-	StartTime  time.Time
-	EndTime    time.Time
-	Duration   time.Duration
-	Results    []types.AuditResult
-	SystemInfo SystemInfo
-	Summary    Summary
+	StartTime           time.Time
+	EndTime             time.Time
+	Duration            time.Duration
+	Results             []types.AuditResult
+	SystemInfo          SystemInfo
+	Summary             Summary
+	EnrichmentRequested bool
+	EnrichmentError     error
+	Enrichment          *enrichment.Result
+	References          types.ReferenceExtraction
 }
 
 // SystemInfo contains basic system information
@@ -94,9 +101,10 @@ func NewSecurityAuditor(opts Options) *SecurityAuditor {
 // RunAudit performs the security audit with the specified options
 func (sa *SecurityAuditor) RunAudit() (*Result, error) {
 	result := &Result{
-		StartTime:  time.Now(),
-		SystemInfo: getSystemInfo(),
-		Results:    make([]types.AuditResult, 0),
+		StartTime:           time.Now(),
+		SystemInfo:          getSystemInfo(),
+		Results:             make([]types.AuditResult, 0),
+		EnrichmentRequested: sa.options.Enrich,
 	}
 
 	if len(sa.options.SpecificChecks) > 0 {
@@ -121,15 +129,11 @@ func (sa *SecurityAuditor) RunAudit() (*Result, error) {
 				result.Results = append(result.Results, checkResult)
 			}
 		}
-	} else {
-		return sa.runAllChecks(result)
+		sa.finalize(result)
+		return result, nil
 	}
 
-	result.EndTime = time.Now()
-	result.Duration = result.EndTime.Sub(result.StartTime)
-	result.Summary = sa.calculateSummary(result.Results)
-
-	return result, nil
+	return sa.runAllChecks(result)
 }
 
 func (sa *SecurityAuditor) runAllChecks(result *Result) (*Result, error) {
@@ -186,11 +190,62 @@ func (sa *SecurityAuditor) runAllChecks(result *Result) (*Result, error) {
 		result.Results = append(result.Results, checkResult)
 	}
 
+	sa.finalize(result)
+	return result, nil
+}
+
+func (sa *SecurityAuditor) finalize(result *Result) {
 	result.EndTime = time.Now()
 	result.Duration = result.EndTime.Sub(result.StartTime)
 	result.Summary = sa.calculateSummary(result.Results)
+	result.References = aggregateReferences(result.Results)
 
-	return result, nil
+	if !sa.options.Enrich {
+		return
+	}
+
+	enricher, err := enrichment.NewEnricher()
+	if err != nil {
+		result.EnrichmentError = err
+		return
+	}
+
+	if len(result.References.CWEs) == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), sa.options.Timeout)
+	defer cancel()
+
+	req := enrichment.EnrichRequest{
+		CWEs:        result.References.CWEs,
+		MinSeverity: sa.options.MinSeverity,
+	}
+
+	enrichResult, err := enricher.Enrich(ctx, req)
+	if err != nil {
+		result.EnrichmentError = err
+		return
+	}
+	result.Enrichment = &enrichResult
+}
+
+func aggregateReferences(results []types.AuditResult) types.ReferenceExtraction {
+	var ext types.ReferenceExtraction
+	seen := make(map[string]struct{})
+	for i := range results {
+		sub := results[i].AllCWEReferences()
+		for _, id := range sub.CWEs {
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			ext.CWEs = append(ext.CWEs, id)
+		}
+		ext.Errors = append(ext.Errors, sub.Errors...)
+		ext.Other = append(ext.Other, sub.Other...)
+	}
+	return ext
 }
 
 func (sa *SecurityAuditor) calculateSummary(results []types.AuditResult) Summary {

--- a/internal/security/checker/firewall.go
+++ b/internal/security/checker/firewall.go
@@ -153,6 +153,7 @@ func (f *WindowsFirewallChecker) Check() types.AuditResult {
 				Description: def.Description,
 				Impact:      def.Impact,
 				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
 			})
 		}
 	}
@@ -184,6 +185,7 @@ func (f *WindowsFirewallChecker) Check() types.AuditResult {
 				Description: def.Description,
 				Impact:      def.Impact,
 				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
 			})
 		}
 	} else {

--- a/internal/security/checker/permissions.go
+++ b/internal/security/checker/permissions.go
@@ -321,6 +321,7 @@ func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, result *
 						Description: def.Description,
 						Impact:      def.Impact,
 						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
 					})
 				}
 				everyoneFindingAdded = true
@@ -338,6 +339,7 @@ func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, result *
 						Description: def.Description,
 						Impact:      def.Impact,
 						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
 					})
 				}
 				usersFindingAdded = true
@@ -386,6 +388,7 @@ func (p *WindowsPermissionChecker) checkNetworkShares(result *types.AuditResult)
 						Description: def.Description,
 						Impact:      def.Impact,
 						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
 					})
 				}
 				adminShareFindingAdded = true

--- a/internal/security/checker/ssh.go
+++ b/internal/security/checker/ssh.go
@@ -90,6 +90,7 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 				Description: def.Description,
 				Impact:      def.Impact,
 				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
 			})
 		}
 		return result
@@ -143,6 +144,7 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 					Description: def.Description,
 					Impact:      def.Impact,
 					Resolution:  def.Resolution,
+					References:  def.ToReferences(),
 				})
 			}
 		} else {
@@ -159,6 +161,7 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 				Description: def.Description,
 				Impact:      def.Impact,
 				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
 			})
 		}
 	}
@@ -175,6 +178,7 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 					Description: def.Description,
 					Impact:      def.Impact,
 					Resolution:  def.Resolution,
+					References:  def.ToReferences(),
 				})
 			}
 		} else {
@@ -191,6 +195,7 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 				Description: def.Description,
 				Impact:      def.Impact,
 				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
 			})
 		}
 	}
@@ -233,6 +238,7 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 					Description: def.Description,
 					Impact:      def.Impact,
 					Resolution:  def.Resolution,
+					References:  def.ToReferences(),
 				})
 			}
 		default:
@@ -305,6 +311,7 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 								Description: def.Description,
 								Impact:      def.Impact,
 								Resolution:  def.Resolution,
+								References:  def.ToReferences(),
 							})
 						}
 					} else {
@@ -324,6 +331,7 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 								Description: def.Description,
 								Impact:      def.Impact,
 								Resolution:  def.Resolution,
+								References:  def.ToReferences(),
 							})
 						}
 					} else {
@@ -342,6 +350,7 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 					Description: def.Description,
 					Impact:      def.Impact,
 					Resolution:  def.Resolution,
+					References:  def.ToReferences(),
 				})
 			}
 		}

--- a/internal/security/checker/users.go
+++ b/internal/security/checker/users.go
@@ -129,6 +129,7 @@ func (u *UnixUserChecker) Check() types.AuditResult {
 				Description: def.Description,
 				Impact:      def.Impact,
 				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
 			})
 		}
 	}
@@ -534,6 +535,7 @@ func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
 							Description: def.Description,
 							Impact:      def.Impact,
 							Resolution:  def.Resolution,
+							References:  def.ToReferences(),
 						})
 					}
 				}
@@ -561,6 +563,7 @@ func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
 						Description: def.Description,
 						Impact:      def.Impact,
 						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
 					})
 				}
 			}
@@ -586,6 +589,7 @@ func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
 								Description: def.Description,
 								Impact:      def.Impact,
 								Resolution:  def.Resolution,
+								References:  def.ToReferences(),
 							})
 						}
 					}
@@ -700,6 +704,7 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 					Description: def.Description,
 					Impact:      def.Impact,
 					Resolution:  def.Resolution,
+					References:  def.ToReferences(),
 				})
 			}
 		} else if !user.Enabled {
@@ -719,6 +724,7 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 						Description: def.Description,
 						Impact:      def.Impact,
 						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
 					})
 				}
 				noPasswordFindingAdded = true
@@ -761,6 +767,7 @@ func (w *WindowsUserChecker) checkSecurityPolicies(result *types.AuditResult) {
 					Description: def.Description,
 					Impact:      def.Impact,
 					Resolution:  def.Resolution,
+					References:  def.ToReferences(),
 				})
 			}
 		}

--- a/internal/security/enrichment/enricher.go
+++ b/internal/security/enrichment/enricher.go
@@ -1,0 +1,16 @@
+// internal/security/enrichment/enricher.go
+package enrichment
+
+import "context"
+
+// Enricher is the interface every enrichment source adapter
+// satisfies. Implementations must be safe for concurrent use.
+type Enricher interface {
+	Enrich(ctx context.Context, req EnrichRequest) (Result, error)
+	Source() Source
+}
+
+// NewEnricher returns the configured enricher.
+func NewEnricher() (Enricher, error) {
+	return nil, ErrNoEnricherConfigured
+}

--- a/internal/security/enrichment/errors.go
+++ b/internal/security/enrichment/errors.go
@@ -1,0 +1,17 @@
+// internal/security/enrichment/errors.go
+package enrichment
+
+import "errors"
+
+// ErrNoEnricherConfigured indicates that no enrichment source adapter has been registered.
+var ErrNoEnricherConfigured = errors.New("no enrichment source configured")
+
+// ErrInvalidCWEID indicates a CWE identifier failed format validation.
+// Returned when input does not match CWE-N+
+var ErrInvalidCWEID = errors.New("invalid CWE identifier")
+
+// ErrEmptyRequest indicates an EnrichRequest contained no CVE identifiers to enrich.
+var ErrEmptyRequest = errors.New("enrichment request contains no CVE identifiers")
+
+// ErrMissingAPIKey indicates an adapter that requires an API key could not find the required credential
+var ErrMissingAPIKey = errors.New("required API key not found in environment")

--- a/internal/security/enrichment/types.go
+++ b/internal/security/enrichment/types.go
@@ -1,0 +1,92 @@
+// internal/security/enrichment/types.go
+package enrichment
+
+import "time"
+
+// Source identifies which enrichment adapter contributed a field
+// value.
+type Source string
+
+// Enrichment adapter source identifiers.
+const (
+	SourceNVD   Source = "NVD"
+	SourceKEV   Source = "CISA-KEV"
+	SourceEPSS  Source = "EPSS"
+	SourceGHSA  Source = "GHSA"
+	SourceMITRE Source = "MITRE-CWE"
+)
+
+// Status reports the terminal state of an enrichment attempt for a single CVE.
+type Status string
+
+// Enrichment status values.
+const (
+	StatusEnriched         Status = "ENRICHED"
+	StatusFailed           Status = "FAILED"
+	StatusNoMatches        Status = "NO_MATCHES"
+	StatusNoSourcesQueried Status = "NO_SOURCES_QUERIED"
+)
+
+// CWEEnrichment is per-CWE enrichment data with per-field source
+// attribution.
+type CWEEnrichment struct {
+	CWEID  string
+	Status Status
+
+	WeaknessName       string
+	WeaknessNameSource Source
+
+	WeaknessDescription       string
+	WeaknessDescriptionSource Source
+
+	MatchedCVEs       []CVEMatch
+	MatchedCVEsSource Source
+
+	LastQueried time.Time
+}
+
+// CVEMatch is a single CVE returned by an enrichment source as
+// associated with a CWE.
+type CVEMatch struct {
+	CVEID         string
+	Source        Source
+	CVSSBaseScore float64
+	CVSSSeverity  string
+	CVSSVector    string
+
+	Published    time.Time
+	LastModified time.Time
+
+	KnownExploited         bool
+	ExploitPredictionScore float64
+	PatchAvailable         bool
+
+	Description string
+	References  []string
+}
+
+// Failure records why enrichment for a specific CWE failed.
+type Failure struct {
+	CWEID     string
+	Source    Source
+	Reason    string
+	Err       error
+	Retryable bool
+}
+
+// Result is the aggregate output of an enrichment run.
+type Result struct {
+	Successes      map[string]CWEEnrichment
+	Failures       map[string]Failure
+	AdapterErrors  []error
+	SourcesQueried []Source
+	Duration       time.Duration
+}
+
+// EnrichRequest is the input to Enricher.Enrich.
+type EnrichRequest struct {
+	CWEs        []string
+	BypassCache bool
+	Sources     []Source
+	MinSeverity string
+}

--- a/internal/security/enrichment/validate.go
+++ b/internal/security/enrichment/validate.go
@@ -1,0 +1,102 @@
+// internal/security/enrichment/validate.go
+package enrichment
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	cweIDPrefix          = "CWE-"
+	cweIDPrefixLength    = 4
+	cweIDMinLength       = 5 // CWE- plus at least one digit
+	cweURLPrefix         = "https://cwe.mitre.org/data/definitions/"
+	cweURLSuffix         = ".html"
+	maxBulkValidateInput = 10000
+)
+
+// NormalizeCWEID returns the canonical CWE-N form for an identifier
+// supplied in canonical or URL form. Returns an error wrapping
+// ErrInvalidCWEID for input that does not match either form.
+func NormalizeCWEID(input string) (string, error) {
+	if id, ok := extractCWEFromURL(input); ok {
+		return validateCanonicalCWE(id)
+	}
+	return validateCanonicalCWE(input)
+}
+
+// ValidateCWEID returns nil if input is a valid CWE identifier in
+// canonical or URL form. Use NormalizeCWEID when the canonical form
+// is needed for downstream use.
+func ValidateCWEID(input string) error {
+	_, err := NormalizeCWEID(input)
+	return err
+}
+
+// NormalizeCWEIDs normalizes a slice of CWE identifiers. Returns the
+// canonical IDs that validated successfully and errors for the rest.
+// Rejects bulk input above the documented limit. Does not deduplicate.
+func NormalizeCWEIDs(inputs []string) (valid []string, errs []error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	if len(inputs) > maxBulkValidateInput {
+		return nil, []error{
+			fmt.Errorf("%w: input size %d exceeds limit %d",
+				ErrInvalidCWEID, len(inputs), maxBulkValidateInput),
+		}
+	}
+
+	valid = make([]string, 0, len(inputs))
+	for _, input := range inputs {
+		id, err := NormalizeCWEID(input)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		valid = append(valid, id)
+	}
+	return valid, errs
+}
+
+func extractCWEFromURL(input string) (string, bool) {
+	if !strings.HasPrefix(input, cweURLPrefix) {
+		return "", false
+	}
+	if !strings.HasSuffix(input, cweURLSuffix) {
+		return "", false
+	}
+	num := strings.TrimPrefix(input, cweURLPrefix)
+	num = strings.TrimSuffix(num, cweURLSuffix)
+	if num == "" {
+		return "", false
+	}
+	for i := 0; i < len(num); i++ {
+		if !isASCIIDigit(num[i]) {
+			return "", false
+		}
+	}
+	return cweIDPrefix + num, true
+}
+
+func validateCanonicalCWE(id string) (string, error) {
+	if len(id) < cweIDMinLength {
+		return "", fmt.Errorf("%w: length %d below minimum %d: %q",
+			ErrInvalidCWEID, len(id), cweIDMinLength, id)
+	}
+	if !strings.HasPrefix(id, cweIDPrefix) {
+		return "", fmt.Errorf("%w: missing %q prefix: %q",
+			ErrInvalidCWEID, cweIDPrefix, id)
+	}
+	for i := cweIDPrefixLength; i < len(id); i++ {
+		if !isASCIIDigit(id[i]) {
+			return "", fmt.Errorf("%w: non-digit byte 0x%02x at position %d: %q",
+				ErrInvalidCWEID, id[i], i, id)
+		}
+	}
+	return id, nil
+}
+
+func isASCIIDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}

--- a/internal/security/formatter/formatter.go
+++ b/internal/security/formatter/formatter.go
@@ -142,6 +142,15 @@ func (f *Formatter) prepareOutput(result *audit.Result) map[string]interface{} {
 		}
 	}
 	output["has_findings"] = hasFindings
+	output["enrichment_requested"] = result.EnrichmentRequested
+	output["enrichment_error"] = ""
+	if result.EnrichmentError != nil {
+		output["enrichment_error"] = result.EnrichmentError.Error()
+	}
+	output["reference_cwes"] = result.References.CWEs
+	output["reference_errors"] = formatReferenceErrors(result.References.Errors)
+	output["enrichment_entries"] = buildEnrichmentEntries(result)
+	output["enrichment_failures"] = buildEnrichmentFailures(result)
 
 	return output
 }
@@ -212,6 +221,65 @@ func isSeverityRelevant(findingSeverity, minSeverity string) bool {
 	return findingLevel >= minLevel
 }
 
+func formatReferenceErrors(errs []error) []string {
+	out := make([]string, 0, len(errs))
+	for _, e := range errs {
+		out = append(out, e.Error())
+	}
+	return out
+}
+
+func buildEnrichmentEntries(result *audit.Result) []map[string]interface{} {
+	if result.Enrichment == nil {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(result.References.CWEs))
+	for _, cwe := range result.References.CWEs {
+		entry, ok := result.Enrichment.Successes[cwe]
+		if !ok {
+			continue
+		}
+		matches := make([]map[string]interface{}, 0, len(entry.MatchedCVEs))
+		for _, match := range entry.MatchedCVEs {
+			symbol, label := types.SeverityFormat(match.CVSSSeverity)
+			matches = append(matches, map[string]interface{}{
+				"cve_id":          match.CVEID,
+				"source":          string(match.Source),
+				"cvss_base_score": match.CVSSBaseScore,
+				"cvss_severity":   match.CVSSSeverity,
+				"symbol":          symbol,
+				"label":           label,
+				"description":     match.Description,
+				"known_exploited": match.KnownExploited,
+				"patch_available": match.PatchAvailable,
+			})
+		}
+		out = append(out, map[string]interface{}{
+			"cwe_id":        cwe,
+			"weakness_name": entry.WeaknessName,
+			"no_matches":    string(entry.Status) == "NO_MATCHES" || len(matches) == 0,
+			"matches":       matches,
+		})
+	}
+	return out
+}
+
+func buildEnrichmentFailures(result *audit.Result) []map[string]interface{} {
+	if result.Enrichment == nil || len(result.Enrichment.Failures) == 0 {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(result.Enrichment.Failures))
+	for cwe, failure := range result.Enrichment.Failures {
+		out = append(out, map[string]interface{}{
+			"cwe_id":    cwe,
+			"source":    string(failure.Source),
+			"reason":    failure.Reason,
+			"retryable": failure.Retryable,
+		})
+	}
+	return out
+}
+
 // Default text template
 const defaultTemplate = `Security Audit Report
 ====================
@@ -239,7 +307,23 @@ Duration: {{.duration}}
 {{end}}{{end}}{{end}}{{end}}{{if and $.verbose .details}}Raw Diagnostic Output:
 {{range .details}}  {{.}}
 {{end}}{{end}}
-{{end}}
+{{end}}{{if .enrichment_requested}}
+Enrichment:
+{{if .enrichment_error}}  Unavailable: {{.enrichment_error}}
+{{else if not .reference_cwes}}  No CWE references found in current findings.
+{{else if not .enrichment_entries}}  No enrichment data returned.
+{{else}}{{range .enrichment_entries}}  {{.cwe_id}}{{if .weakness_name}} - {{.weakness_name}}{{end}}
+{{if .no_matches}}    No CVE matches in queried sources.
+{{else}}{{range .matches}}    {{.symbol}} {{.label}}  {{.cve_id}} ({{printf "%.1f" .cvss_base_score}}) [{{.source}}]
+{{if $.verbose}}{{if .description}}      Description: {{.description}}
+{{end}}{{if .known_exploited}}      Known Exploited: yes
+{{end}}{{if .patch_available}}      Patch Available: yes
+{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .enrichment_failures}}
+  Failed enrichments:
+{{range .enrichment_failures}}    {{.cwe_id}} [{{.source}}]: {{.reason}}{{if .retryable}} (retryable){{end}}
+{{end}}{{end}}{{if .reference_errors}}  Reference parsing errors:
+{{range .reference_errors}}    {{.}}
+{{end}}{{end}}{{end}}
 Summary:
 Checks Run: {{.summary.total_checks}}
 Passed:     {{.summary.passed_checks}}

--- a/internal/security/registry/registry.go
+++ b/internal/security/registry/registry.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/papa0four/orkowatch/internal/security/types"
 )
 
 // Platform identifies the host OS family
@@ -47,6 +49,17 @@ const (
 	// Non-Linux Platforms
 	DistroNone    Distro = ""
 	DistroUnknown Distro = "uknown"
+)
+
+// Reference type classifications produced by ToReferences.
+const (
+	RefTypeCVE   = "CVE"
+	RefTypeCWE   = "CWE"
+	RefTypeCIS   = "CIS"
+	RefTypeNIST  = "NIST"
+	RefTypeMITRE = "MITRE"
+	RefTypeURL   = "URL"
+	RefTypeOther = "OTHER"
 )
 
 // OSContext obtains full platform and distro info to pass to auditor before registry lookups
@@ -301,4 +314,60 @@ func containsDistro(families []Distro, d Distro) bool {
 		}
 	}
 	return false
+}
+
+// ToReferences classifies flat YAML reference strings into
+// structured types.Reference entries by kind.
+func (d FindingDefinition) ToReferences() []types.Reference {
+	if len(d.References) == 0 {
+		return nil
+	}
+	out := make([]types.Reference, 0, len(d.References))
+	for _, raw := range d.References {
+		out = append(out, classifyReference(raw))
+	}
+	return out
+}
+
+func classifyReference(raw string) types.Reference {
+	trimmed := strings.TrimSpace(raw)
+
+	switch {
+	case isCWEReference(trimmed):
+		return types.Reference{Title: trimmed, URL: cweURL(trimmed), Type: RefTypeCWE}
+	case isCVEReference(trimmed):
+		return types.Reference{Title: trimmed, URL: cveURL(trimmed), Type: RefTypeCVE}
+	case strings.HasPrefix(trimmed, "CIS "):
+		return types.Reference{Title: trimmed, Type: RefTypeCIS}
+	case strings.HasPrefix(trimmed, "NIST "):
+		return types.Reference{Title: trimmed, Type: RefTypeNIST}
+	case strings.HasPrefix(trimmed, "MITRE "):
+		return types.Reference{Title: trimmed, Type: RefTypeMITRE}
+	case strings.HasPrefix(trimmed, "https://") || strings.HasPrefix(trimmed, "http://"):
+		return types.Reference{Title: trimmed, URL: trimmed, Type: RefTypeURL}
+	default:
+		return types.Reference{Title: trimmed, Type: RefTypeOther}
+	}
+}
+
+func isCWEReference(s string) bool {
+	return strings.HasPrefix(s, "CWE-") || strings.HasPrefix(s, "https://cwe.mitre.org/")
+}
+
+func isCVEReference(s string) bool {
+	return strings.HasPrefix(s, "CVE-") || strings.HasPrefix(s, "https://nvd.nist.gov/vuln/detail/CVE-")
+}
+
+func cweURL(s string) string {
+	if strings.HasPrefix(s, "https://") {
+		return s
+	}
+	return "https://cwe.mitre.org/data/definitions/" + strings.TrimPrefix(s, "CWE-") + ".html"
+}
+
+func cveURL(s string) string {
+	if strings.HasPrefix(s, "https://") {
+		return s
+	}
+	return "https://nvd.nist.gov/vuln/detail/" + s
 }

--- a/internal/security/types/types.go
+++ b/internal/security/types/types.go
@@ -4,6 +4,8 @@ package types
 import (
 	"fmt"
 	"time"
+
+	"github.com/papa0four/orkowatch/internal/security/enrichment"
 )
 
 // Status symbols for check results
@@ -71,6 +73,20 @@ type ValidationError struct {
 	Message string
 }
 
+// ClassifiedReference is a non-CWE reference annotated by type.
+type ClassifiedReference struct {
+	Type  string
+	Value string
+}
+
+// ReferenceExtraction separates valid CWEs from malformed CWE attempts
+// and non-CWE references.
+type ReferenceExtraction struct {
+	CWEs   []string
+	Errors []error
+	Other  []ClassifiedReference
+}
+
 func (e *ValidationError) Error() string {
 	return fmt.Sprintf("validation error in %s: %s - %s", e.Checker, e.Field, e.Message)
 }
@@ -89,4 +105,60 @@ func SeverityFormat(severity string) (symbol, label string) {
 	default:
 		return SymbolInfo, severity
 	}
+}
+
+// CWEReferences returns the CWE IDs referenced by this
+// finding, deduplicated. Order matches first occurrence.
+func (f *Finding) CWEReferences() ReferenceExtraction {
+	var ext ReferenceExtraction
+	if len(f.References) == 0 {
+		return ext
+	}
+	seen := make(map[string]struct{}, len(f.References))
+	for _, ref := range f.References {
+		if ref.Type == "CWE" {
+			id, err := enrichment.NormalizeCWEID(ref.URL)
+			if err != nil {
+				id, err = enrichment.NormalizeCWEID(ref.Title)
+			}
+			if err != nil {
+				ext.Errors = append(ext.Errors, err)
+				continue
+			}
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			ext.CWEs = append(ext.CWEs, id)
+			continue
+		}
+		ext.Other = append(ext.Other, ClassifiedReference{
+			Type:  ref.Type,
+			Value: ref.Title,
+		})
+	}
+	return ext
+}
+
+// AllCWEReferences returns the canonical CWE IDs across all findings
+// in this result, deduplicated. Order matches first occurrence.
+func (r *AuditResult) AllCWEReferences() ReferenceExtraction {
+	var ext ReferenceExtraction
+	if len(r.Findings) == 0 {
+		return ext
+	}
+	seen := make(map[string]struct{})
+	for i := range r.Findings {
+		sub := r.Findings[i].CWEReferences()
+		for _, id := range sub.CWEs {
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			ext.CWEs = append(ext.CWEs, id)
+		}
+		ext.Errors = append(ext.Errors, sub.Errors...)
+		ext.Other = append(ext.Other, sub.Other...)
+	}
+	return ext
 }


### PR DESCRIPTION
## Summary

Scaffolds the enrichment subsystem end-to-end and wires the `--enrich` / `-e` flag into both the `security_audit` and `all` commands. No adapter is shipped -- `NewEnricher` returns `ErrNoEnricherConfigured` until adapters land in follow-on
branches. The local audit is fully independent; enrichment failures never affect local results.

## What was added

### `internal/security/enrichment/`

New leaf package. Depends on stdlib only.

- `errors.go` -- sentinel error values: `ErrNoEnricherConfigured`, `ErrInvalidCWEID`, `ErrEmptyRequest`, `ErrMissingAPIKey`
- `types.go` -- `Source`, `Status`, `CWEEnrichment`, `CVEMatch`, `Failure`, `Result`, `EnrichRequest`
- `validate.go` -- `NormalizeCWEID`, `ValidateCWEID`, `NormalizeCWEIDs`; accepts canonical (`CWE-N`) and MITRE URL forms; ASCII-only digit check; bulk input limit of 10,000
- `enricher.go` -- `Enricher` interface; `NewEnricher` returning `ErrNoEnricherConfigured`

### `internal/security/registry/registry.go`

- Added `RefType*` classification constants (`CVE`, `CWE`, `CIS`, `NIST`, `MITRE`, `URL`, `OTHER`)
- Added `FindingDefinition.ToReferences()` classifying flat YAML reference strings into `[]types.Reference`

### `internal/security/types/types.go`

- Added `ClassifiedReference` and `ReferenceExtraction` types
- Added `Finding.CWEReferences()` -- normalizes, deduplicates, and separates CWE references from non-CWE references per finding
- Added `AuditResult.AllCWEReferences()` -- aggregates across all findings in a result with full deduplication

### Checkers updated to populate `Finding.References`

Six checkers now call `def.ToReferences()` and assign the result to `Finding.References` in every emitted `types.Finding` literal:

- `WindowsSSHChecker`, `UnixSSHChecker`
- `WindowsFirewallChecker`
- `WindowsUserChecker`, `UnixUserChecker`
- `WindowsPermissionChecker`

### `internal/security/audit/audit.go`

- Added `Options.Enrich bool`
- Added `Result.EnrichmentRequested`, `Result.EnrichmentError`, `Result.Enrichment`, `Result.References`
- Added `finalize()` shared by `RunAudit` and `runAllChecks` -- calculates summary, aggregates references, and conditionally runs enrichment
- Added `aggregateReferences()` helper

### CLI flag wiring

- `cmd/commands/security/security.go` -- `--enrich` / `-e` flag threaded through `audit.Options`
- `cmd/commands/all.go` -- `--enrich` / `-e` flag threaded through `audit.Options`

### Rendering

- `cmd/commands/security/security.go` -- `renderEnrichmentBlock` and `renderReferenceErrors` helpers integrated into the text output path
- `internal/security/formatter/formatter.go` -- `prepareOutput` extended with enrichment context; `buildEnrichmentEntries`, `buildEnrichmentFailures`, `formatReferenceErrors` helpers; `defaultTemplate` extended with enrichment section between Check Results and Summary

### Documentation

- `docs/dev_guide/enrichment.md` -- full contributor reference for the enrichment subsystem (merged from `docs/49`)

## Design decisions

- Input is CWE IDs; output is CVEs mapped to those CWEs by external sources
- Deduplicated CWE IDs are sent as a single batch -- one network round trip regardless of how many findings reference the same CWE
- Enrichment runs after local audit completes; local results are never blocked or modified by enrichment outcome
- `NewEnricher` returns `ErrNoEnricherConfigured` -- no no-op stub shipped
- API keys from environment only; never logged or serialized
- `--enrich` and `-v` compose independently

## Closes

Closes #48 