### PR TITLE
[bug] Fix non-verbose output, structured findings, and registry wiring across Unix and Windows checkers

### DIFF
--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -212,16 +212,16 @@ func convertToAuditResult(scan *ScanResult) *audit.Result {
 	}
 
 	return &audit.Result{
-		StartTime:            scan.Timestamp,
-		EndTime:              scan.Timestamp.Add(scan.Duration),
-		Duration:             scan.Duration,
-		Results:              scan.SecurityAudit.Results,
-		SystemInfo:           sysInfo,
-		Summary:              scan.SecurityAudit.Summary,
-		EnrichmentRequested:  scan.SecurityAudit.EnrichmentRequested,
-		EnrichmentError:      scan.SecurityAudit.EnrichmentError,
-		Enrichment:           scan.SecurityAudit.Enrichment,
-		References:           scan.SecurityAudit.References,
+		StartTime:           scan.Timestamp,
+		EndTime:             scan.Timestamp.Add(scan.Duration),
+		Duration:            scan.Duration,
+		Results:             scan.SecurityAudit.Results,
+		SystemInfo:          sysInfo,
+		Summary:             scan.SecurityAudit.Summary,
+		EnrichmentRequested: scan.SecurityAudit.EnrichmentRequested,
+		EnrichmentError:     scan.SecurityAudit.EnrichmentError,
+		Enrichment:          scan.SecurityAudit.Enrichment,
+		References:          scan.SecurityAudit.References,
 	}
 }
 

--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -13,7 +13,6 @@ import (
 	"github.com/papa0four/orkowatch/internal/osfingerprint"
 	"github.com/papa0four/orkowatch/internal/security/audit"
 	"github.com/papa0four/orkowatch/internal/security/formatter"
-	"github.com/papa0four/orkowatch/internal/security/types"
 	"github.com/papa0four/orkowatch/internal/softwarelist"
 )
 
@@ -250,10 +249,6 @@ func outputResults(result *ScanResult) error {
 		return fmt.Errorf("failed to format results: %w", err)
 	}
 
-	if result.SecurityAudit != nil {
-		printCriticalFindings(result.SecurityAudit)
-	}
-
 	return nil
 }
 
@@ -268,32 +263,6 @@ func isModuleSkipped(module string) bool {
 		}
 	}
 	return false
-}
-
-func printCriticalFindings(auditResult *audit.Result) {
-	var criticalCount, highCount int
-
-	for _, result := range auditResult.Results {
-		for _, finding := range result.Findings {
-			switch finding.Severity {
-			case types.SeverityCritical:
-				criticalCount++
-			case types.SeverityHigh:
-				highCount++
-			}
-		}
-	}
-
-	if criticalCount > 0 || highCount > 0 {
-		fmt.Printf("\n%s Critical Security Findings:\n", types.SymbolCritical)
-		if criticalCount > 0 {
-			fmt.Printf("  %d Critical severity issues found\n", criticalCount)
-		}
-		if highCount > 0 {
-			fmt.Printf("  %d High severity issues found\n", highCount)
-		}
-		fmt.Println("\nPlease review the detailed security audit section of the report.")
-	}
 }
 
 // isTerminal checks if the output is going to a terminal

--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -212,12 +212,16 @@ func convertToAuditResult(scan *ScanResult) *audit.Result {
 	}
 
 	return &audit.Result{
-		StartTime:  scan.Timestamp,
-		EndTime:    scan.Timestamp.Add(scan.Duration),
-		Duration:   scan.Duration,
-		Results:    scan.SecurityAudit.Results,
-		SystemInfo: sysInfo,
-		Summary:    scan.SecurityAudit.Summary,
+		StartTime:            scan.Timestamp,
+		EndTime:              scan.Timestamp.Add(scan.Duration),
+		Duration:             scan.Duration,
+		Results:              scan.SecurityAudit.Results,
+		SystemInfo:           sysInfo,
+		Summary:              scan.SecurityAudit.Summary,
+		EnrichmentRequested:  scan.SecurityAudit.EnrichmentRequested,
+		EnrichmentError:      scan.SecurityAudit.EnrichmentError,
+		Enrichment:           scan.SecurityAudit.Enrichment,
+		References:           scan.SecurityAudit.References,
 	}
 }
 

--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -22,6 +22,7 @@ var (
 	allReportFile   string
 	skipModules     []string
 	allTimeout      time.Duration
+	allEnrich       bool
 )
 
 // allCmd represents the all command that combines all scanning modules
@@ -60,6 +61,8 @@ func init() {
 		"Modules to skip (comma-separated: os,software,security)")
 	allCmd.Flags().DurationVar(&allTimeout, "timeout", 30*time.Minute,
 		"Maximum time to run all scans")
+	allCmd.Flags().BoolVarP(&allEnrich, "enrich", "e", false,
+		"Query external sources to annotate findings with CVEs mapped to referenced CWEs")
 
 	RootCmd.AddCommand(allCmd)
 }
@@ -182,6 +185,7 @@ func runSecurityAuditModule() (*audit.Result, error) {
 		Verbose:     allVerbose,
 		MinSeverity: "LOW",
 		Timeout:     allTimeout / 3,
+		Enrich:      allEnrich,
 	}
 
 	auditor := audit.NewSecurityAuditor(opts)

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -282,37 +282,7 @@ func outputResults(result *audit.Result) error {
 		fmt.Println(output)
 	}
 
-	if !verbose {
-		printCriticalFindings(result)
-	}
-
 	return nil
-}
-
-func printCriticalFindings(result *audit.Result) {
-	var criticalCount, highCount int
-
-	for _, checkResult := range result.Results {
-		for _, finding := range checkResult.Findings {
-			switch finding.Severity {
-			case types.SeverityCritical:
-				criticalCount++
-			case types.SeverityHigh:
-				highCount++
-			}
-		}
-	}
-
-	if criticalCount > 0 || highCount > 0 {
-		fmt.Printf("\n%s Security Issues Found:\n", types.SymbolCritical)
-		if criticalCount > 0 {
-			fmt.Printf("  %d Critical severity findings\n", criticalCount)
-		}
-		if highCount > 0 {
-			fmt.Printf("  %d High severity findings\n", highCount)
-		}
-		fmt.Println("\nPlease review the detailed report and take appropriate action.")
-	}
 }
 
 func formatJSON(result *audit.Result) (string, error) {
@@ -392,48 +362,52 @@ func formatText(result *audit.Result) (string, error) {
 		fmt.Fprintf(&builder, "Kernel: %s\n\n", result.SystemInfo.KernelVersion)
 	}
 
+	hasFindings := false
+
 	for _, checkResult := range result.Results {
 		fmt.Fprintf(&builder, "Check: %s\n", checkResult.Name)
 		fmt.Fprintf(&builder, "Status: %s\n", checkResult.Status)
-		if verbose {
-			fmt.Fprintf(&builder, "Duration: %v\n", checkResult.Duration)
-			if len(checkResult.Details) > 0 {
-				builder.WriteString("\nDetails:\n")
-				for _, detail := range checkResult.Details {
-					fmt.Fprintf(&builder, "  %s\n", detail)
+		fmt.Fprintf(&builder, "Duration: %v\n", checkResult.Duration)
+
+		if len(checkResult.Findings) > 0 {
+			hasFindings = true
+			builder.WriteString("Findings:\n")
+			for _, finding := range checkResult.Findings {
+				symbol, label := types.SeverityFormat(finding.Severity)
+				fmt.Fprintf(&builder, "%s %s  %s\n", symbol, label, finding.Title)
+				if verbose {
+					if finding.Description != "" {
+						fmt.Fprintf(&builder, "  Description: %s\n", finding.Description)
+					}
+					if finding.Impact != "" {
+						fmt.Fprintf(&builder, "  Impact: %s\n", finding.Impact)
+					}
+					if finding.Resolution != "" {
+						fmt.Fprintf(&builder, "  Resolution: %s\n", finding.Resolution)
+					}
 				}
 			}
 		}
 
-		if len(checkResult.Findings) > 0 {
-			builder.WriteString("\nFindings:\n")
-			for _, finding := range checkResult.Findings {
-				fmt.Fprintf(&builder, "  [%s] %s\n", finding.Severity, finding.Title)
-				if verbose {
-					if finding.Description != "" {
-						fmt.Fprintf(&builder, "    Description: %s\n", finding.Description)
-					}
-					if finding.Impact != "" {
-						fmt.Fprintf(&builder, "    Impact: %s\n", finding.Impact)
-					}
-					if finding.Resolution != "" {
-						fmt.Fprintf(&builder, "    Resolution: %s\n", finding.Resolution)
-					}
-				}
+		if verbose && len(checkResult.Details) > 0 {
+			builder.WriteString("Raw Diagnostic Output:\n")
+			for _, detail := range checkResult.Details {
+				fmt.Fprintf(&builder, "  %s\n", detail)
 			}
 		}
 
 		builder.WriteString("\n")
 	}
 
-	builder.WriteString("\nSummary:\n")
+	builder.WriteString("Summary:\n")
 	fmt.Fprintf(&builder, "Checks Run: %d\n", len(result.Results))
 	fmt.Fprintf(&builder, "Passed:     %d\n", result.Summary.PassedChecks)
 	fmt.Fprintf(&builder, "Warnings:   %d\n", result.Summary.WarningChecks)
 	fmt.Fprintf(&builder, "Failed:     %d\n", result.Summary.FailedChecks)
+	fmt.Fprintf(&builder, "Duration:   %v\n", result.Duration)
 
-	if verbose {
-		fmt.Fprintf(&builder, "Duration:   %v\n", result.Duration)
+	if !verbose && hasFindings {
+		builder.WriteString("\nRun with -v for full finding details, impact analysis, and remediation guidance.\n")
 	}
 
 	return builder.String(), nil

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -30,6 +30,9 @@ var (
 	checkFirewall  bool
 	checkUsers     bool
 	checkFilePerms string
+
+	// enrichment flag
+	enrich bool
 )
 
 // SecurityCmd represents the security audit command
@@ -132,6 +135,8 @@ func init() {
 		"Run user accounts check")
 	SecurityCmd.Flags().StringVar(&checkFilePerms, "file-permissions", "",
 		"Check permissions of specified file path")
+	SecurityCmd.Flags().BoolVarP(&enrich, "enrich", "e", false,
+		"Query external sources to annotate findings with CVEs mapped to referenced CWEs")
 }
 
 func buildChecks() []string {
@@ -221,6 +226,7 @@ func runAuditWithTimeout(checks []string) error {
 		MinSeverity:    minSeverity,
 		Timeout:        timeout,
 		SpecificChecks: checks,
+		Enrich:         enrich,
 	}
 
 	auditor := audit.NewSecurityAuditor(opts)
@@ -349,6 +355,97 @@ func convertToFormattedResult(result *audit.Result) formattedResult {
 
 	return formatted
 }
+func renderEnrichmentBlock(builder *strings.Builder, result *audit.Result) {
+	if !result.EnrichmentRequested {
+		return
+	}
+
+	builder.WriteString("Enrichment:\n")
+
+	if result.EnrichmentError != nil {
+		fmt.Fprintf(builder, "  Unavailable: %v\n\n", result.EnrichmentError)
+		renderReferenceErrors(builder, result.References)
+		return
+	}
+
+	if len(result.References.CWEs) == 0 {
+		builder.WriteString("  No CWE references found in current findings.\n\n")
+		renderReferenceErrors(builder, result.References)
+		return
+	}
+
+	if result.Enrichment == nil {
+		builder.WriteString("  No enrichment data returned.\n\n")
+		renderReferenceErrors(builder, result.References)
+		return
+	}
+
+	rendered := 0
+	for _, cwe := range result.References.CWEs {
+		entry, ok := result.Enrichment.Successes[cwe]
+		if !ok {
+			continue
+		}
+		rendered++
+		fmt.Fprintf(builder, "  %s", cwe)
+		if entry.WeaknessName != "" {
+			fmt.Fprintf(builder, " - %s", entry.WeaknessName)
+		}
+		fmt.Fprintln(builder)
+
+		if entry.Status == "NO_MATCHES" || len(entry.MatchedCVEs) == 0 {
+			builder.WriteString("    No CVE matches in queried sources.\n")
+			continue
+		}
+
+		for _, match := range entry.MatchedCVEs {
+			symbol, label := types.SeverityFormat(match.CVSSSeverity)
+			fmt.Fprintf(builder, "    %s %s  %s (%.1f) [%s]\n",
+				symbol, label, match.CVEID, match.CVSSBaseScore, match.Source)
+			if verbose {
+				if match.Description != "" {
+					fmt.Fprintf(builder, "      Description: %s\n", match.Description)
+				}
+				if match.KnownExploited {
+					builder.WriteString("      Known Exploited: yes\n")
+				}
+				if match.PatchAvailable {
+					builder.WriteString("      Patch Available: yes\n")
+				}
+			}
+		}
+	}
+
+	if rendered == 0 {
+		builder.WriteString("  No enrichment data returned.\n")
+	}
+
+	if len(result.Enrichment.Failures) > 0 {
+		builder.WriteString("\n  Failed enrichments:\n")
+		for cwe, failure := range result.Enrichment.Failures {
+			fmt.Fprintf(builder, "    %s [%s]: %s",
+				cwe, failure.Source, failure.Reason)
+			if failure.Retryable {
+				builder.WriteString(" (retryable)")
+			}
+			fmt.Fprintln(builder)
+		}
+	}
+
+	builder.WriteString("\n")
+	renderReferenceErrors(builder, result.References)
+}
+
+func renderReferenceErrors(builder *strings.Builder, refs types.ReferenceExtraction) {
+	if len(refs.Errors) == 0 {
+		return
+	}
+	builder.WriteString("  Reference parsing errors:\n")
+	for _, err := range refs.Errors {
+		fmt.Fprintf(builder, "    %v\n", err)
+	}
+	builder.WriteString("\n")
+}
 
 func formatText(result *audit.Result) (string, error) {
 	var builder strings.Builder
@@ -399,6 +496,7 @@ func formatText(result *audit.Result) (string, error) {
 		builder.WriteString("\n")
 	}
 
+	renderEnrichmentBlock(&builder, result)
 	builder.WriteString("Summary:\n")
 	fmt.Fprintf(&builder, "Checks Run: %d\n", len(result.Results))
 	fmt.Fprintf(&builder, "Passed:     %d\n", result.Summary.PassedChecks)

--- a/cmd/commands/security/security_unix.go
+++ b/cmd/commands/security/security_unix.go
@@ -18,11 +18,6 @@ func init() {
 func runUnixAudit(cmd *cobra.Command, args []string) error {
 	checks := buildChecks()
 
-	if len(checks) == 0 && !verbose {
-		fmt.Println("No checks specified. User --help to see available options.")
-		return cmd.Help()
-	}
-
 	if err := validateFlags(); err != nil {
 		return err
 	}

--- a/cmd/commands/security/security_windows.go
+++ b/cmd/commands/security/security_windows.go
@@ -18,11 +18,6 @@ func init() {
 func runWindowsAudit(cmd *cobra.Command, args []string) error {
 	checks := buildChecks()
 
-	if len(checks) == 0 && !verbose {
-		fmt.Println("No checks specified. User --help to see available options.")
-		return cmd.Help()
-	}
-
 	if err := validateFlags(); err != nil {
 		return err
 	}

--- a/docs/dev_guide/enrichment.md
+++ b/docs/dev_guide/enrichment.md
@@ -1,0 +1,490 @@
+# Enrichment Subsystem
+
+The enrichment subsystem adds external threat context to a completed local audit.
+It takes the CWE identifiers surfaced by the finding registry, queries one or more
+configured adapter sources, and returns matched CVEs grouped by the CWE that
+produced them. Enrichment is opt-in via `--enrich` / `-e` and always runs after
+the local audit completes. Enrichment failures never affect local audit results.
+
+---
+
+## Package location
+
+```
+internal/security/enrichment/
+  errors.go    -- sentinel error values
+  types.go     -- all exported types
+  validate.go  -- CWE ID normalization and validation
+  enricher.go  -- Enricher interface and NewEnricher constructor
+```
+
+---
+
+## Types
+
+### `Source`
+
+```go
+type Source string
+```
+
+Identifies which adapter contributed a field value. Defined constants:
+
+| Constant       | Value        |
+|----------------|--------------|
+| `SourceNVD`    | `"NVD"`      |
+| `SourceKEV`    | `"CISA-KEV"` |
+| `SourceEPSS`   | `"EPSS"`     |
+| `SourceGHSA`   | `"GHSA"`     |
+| `SourceMITRE`  | `"MITRE-CWE"`|
+
+Each field on `CWEEnrichment` that may be populated by different sources carries
+a parallel `*Source` field for attribution. Adapters set both the value and the
+source field together.
+
+### `Status`
+
+```go
+type Status string
+```
+
+Terminal state for an enrichment attempt on a single CWE.
+
+| Constant                | Value                  | Meaning                                      |
+|-------------------------|------------------------|----------------------------------------------|
+| `StatusEnriched`        | `"ENRICHED"`           | At least one CVE match was returned          |
+| `StatusFailed`          | `"FAILED"`             | All sources returned errors                  |
+| `StatusNoMatches`       | `"NO_MATCHES"`         | Sources responded but found no CVE matches   |
+| `StatusNoSourcesQueried`| `"NO_SOURCES_QUERIED"` | Request was valid but no sources were called |
+
+### `CWEEnrichment`
+
+```go
+type CWEEnrichment struct {
+    CWEID  string
+    Status Status
+
+    WeaknessName             string
+    WeaknessNameSource       Source
+
+    WeaknessDescription      string
+    WeaknessDescriptionSource Source
+
+    MatchedCVEs       []CVEMatch
+    MatchedCVEsSource Source
+
+    LastQueried time.Time
+}
+```
+
+Per-CWE enrichment data. `MatchedCVEs` is empty when `Status` is `NO_MATCHES`.
+`LastQueried` is set by the adapter; it informs cache expiry logic.
+
+### `CVEMatch`
+
+```go
+type CVEMatch struct {
+    CVEID         string
+    Source        Source
+    CVSSBaseScore float64
+    CVSSSeverity  string
+    CVSSVector    string
+
+    Published    time.Time
+    LastModified time.Time
+
+    KnownExploited         bool
+    ExploitPredictionScore float64
+    PatchAvailable         bool
+
+    Description string
+    References  []string
+}
+```
+
+A single CVE returned by an adapter as associated with a queried CWE.
+`KnownExploited` is populated from CISA KEV data. `ExploitPredictionScore` is
+populated from EPSS data. Adapters populate only the fields their source
+provides; zero values are valid for unset fields.
+
+### `Failure`
+
+```go
+type Failure struct {
+    CWEID     string
+    Source    Source
+    Reason    string
+    Err       error
+    Retryable bool
+}
+```
+
+Records why enrichment for a specific CWE from a specific source failed.
+`Retryable` signals that the failure is transient (network timeout, rate limit)
+and the caller may retry without changing input.
+
+### `Result`
+
+```go
+type Result struct {
+    Successes      map[string]CWEEnrichment
+    Failures       map[string]Failure
+    AdapterErrors  []error
+    SourcesQueried []Source
+    Duration       time.Duration
+}
+```
+
+Aggregate output of an enrichment run. Keys in `Successes` and `Failures` are
+canonical CWE IDs (`CWE-N`). A CWE key will appear in exactly one of the two
+maps. `AdapterErrors` holds errors that affected an entire adapter rather than
+a single CWE. `SourcesQueried` lists every source that was attempted regardless
+of outcome.
+
+### `EnrichRequest`
+
+```go
+type EnrichRequest struct {
+    CWEs        []string
+    BypassCache bool
+    Sources     []Source
+    MinSeverity string
+}
+```
+
+Input to `Enricher.Enrich`. `CWEs` must be canonical IDs (`CWE-N`); the
+adapter validates them on receipt. `BypassCache` forces a live fetch regardless
+of cached data. `Sources` restricts which adapters are called; an empty slice
+uses all configured adapters. `MinSeverity` filters CVE matches below a CVSS
+severity threshold.
+
+---
+
+## Errors
+
+All sentinels are in `errors.go` and are wrapped with `fmt.Errorf("%w", ...)` by
+callers that add context.
+
+| Sentinel                    | Meaning                                                                 |
+|-----------------------------|-------------------------------------------------------------------------|
+| `ErrNoEnricherConfigured`   | `NewEnricher` was called but no adapter is registered                   |
+| `ErrInvalidCWEID`           | A CWE identifier failed format validation                               |
+| `ErrEmptyRequest`           | `EnrichRequest.CWEs` was empty                                          |
+| `ErrMissingAPIKey`          | An adapter that requires an API key found none in the environment       |
+
+---
+
+## Validation
+
+`validate.go` exposes three functions. All three accept both canonical (`CWE-N`)
+and MITRE URL (`https://cwe.mitre.org/data/definitions/N.html`) forms and
+normalize to canonical.
+
+### `NormalizeCWEID(input string) (string, error)`
+
+Returns the canonical `CWE-N` form. Returns an error wrapping `ErrInvalidCWEID`
+if the input matches neither accepted form or contains non-digit characters in
+the numeric segment.
+
+### `ValidateCWEID(input string) error`
+
+Returns `nil` for valid input. Equivalent to calling `NormalizeCWEID` and
+discarding the normalized string. Use when only validity matters.
+
+### `NormalizeCWEIDs(inputs []string) (valid []string, errs []error)`
+
+Bulk normalization. Returns two slices: canonical IDs that passed validation and
+errors for those that did not. Rejects input slices larger than 10,000 entries
+with a single error. Does not deduplicate.
+
+**Validation rules enforced by all three functions:**
+
+- Input must have the prefix `CWE-` (canonical) or match the MITRE URL pattern.
+- The numeric segment following `CWE-` must be one or more ASCII digits only.
+- Minimum total length of the canonical form is 5 characters (`CWE-` + one digit).
+- No Unicode digits; only bytes `0x30`--`0x39` are accepted.
+
+---
+
+## Interface
+
+### `Enricher`
+
+```go
+type Enricher interface {
+    Enrich(ctx context.Context, req EnrichRequest) (Result, error)
+    Source() Source
+}
+```
+
+Every adapter implements this interface. Implementations must be safe for
+concurrent use. `Source()` returns the `Source` constant for that adapter,
+used by the orchestrator for attribution and logging.
+
+### `NewEnricher() (Enricher, error)`
+
+Returns the configured enricher. Until at least one adapter is registered,
+`NewEnricher` returns `nil, ErrNoEnricherConfigured`. This is the correct
+production state while no adapters exist.
+
+---
+
+## How enrichment is orchestrated
+
+The orchestration path lives in `internal/security/audit/audit.go`. The sequence
+is:
+
+1. `RunAudit` or `runAllChecks` completes all local checkers.
+2. `finalize` is called on the result.
+3. `finalize` calls `aggregateReferences` which calls `AllCWEReferences()` across
+   every `AuditResult.Findings` slice and stores the deduplicated extraction in
+   `audit.Result.References`.
+4. If `Options.Enrich` is false, `finalize` returns.
+5. `NewEnricher()` is called. If it returns `ErrNoEnricherConfigured`, the error
+   is stored in `audit.Result.EnrichmentError` and `finalize` returns. Local
+   results are unaffected.
+6. If `References.CWEs` is empty, `finalize` returns without calling the enricher.
+7. Otherwise `Enrich` is called with a context scoped to `Options.Timeout`.
+8. On success, `*enrichment.Result` is stored in `audit.Result.Enrichment`.
+9. On failure, the error is stored in `audit.Result.EnrichmentError`.
+
+`audit.Result.EnrichmentRequested` is always set from `Options.Enrich`
+regardless of outcome, so the renderer can distinguish "not requested" from
+"requested but failed."
+
+### `audit.Options.Enrich`
+
+```go
+type Options struct {
+    // ...
+    Enrich bool
+}
+```
+
+Set by `security_audit --enrich` / `-e` and `all --enrich` / `-e`.
+
+### `audit.Result` enrichment fields
+
+```go
+type Result struct {
+    // ...
+    EnrichmentRequested bool
+    EnrichmentError     error
+    Enrichment          *enrichment.Result
+    References          types.ReferenceExtraction
+}
+```
+
+`References` is always populated after `finalize` regardless of whether
+enrichment was requested. It is reused by the renderer to drive the enrichment
+output section.
+
+---
+
+## Reference extraction
+
+The bridge between registry findings and enrichment input is in
+`internal/security/types/types.go`.
+
+### `Finding.CWEReferences() ReferenceExtraction`
+
+Iterates `Finding.References`, normalizes every entry with `Type == "CWE"` via
+`enrichment.NormalizeCWEID`, deduplicates by canonical ID, and separates
+non-CWE references into `ReferenceExtraction.Other`. Normalization failures are
+collected into `ReferenceExtraction.Errors`.
+
+### `AuditResult.AllCWEReferences() ReferenceExtraction`
+
+Aggregates `CWEReferences()` across all findings in one `AuditResult`.
+Deduplication is applied across the full set; order matches first occurrence.
+Errors from all findings are concatenated.
+
+### `ReferenceExtraction`
+
+```go
+type ReferenceExtraction struct {
+    CWEs   []string
+    Errors []error
+    Other  []ClassifiedReference
+}
+```
+
+`CWEs` is the input to `EnrichRequest.CWEs`. `Errors` are surfaced in the
+rendered output's reference parsing errors section. `Other` is available for
+future use.
+
+### `ClassifiedReference`
+
+```go
+type ClassifiedReference struct {
+    Type  string
+    Value string
+}
+```
+
+A non-CWE reference from a finding, annotated with its `RefType*` classification.
+
+---
+
+## Registry integration
+
+`Finding.References` is populated in every checker via
+`registry.FindingDefinition.ToReferences()`. Checkers call `registry.Lookup` to
+retrieve the `FindingDefinition` for a key, then assign the return of
+`ToReferences()` to the `Finding.References` field.
+
+### `FindingDefinition.ToReferences() []types.Reference`
+
+Converts the flat `[]string` YAML `references` field into `[]types.Reference`.
+Each string is classified by `classifyReference` using the following rules (in
+priority order):
+
+| Prefix / pattern                                  | Assigned `Type`  |
+|---------------------------------------------------|------------------|
+| `CWE-` or `https://cwe.mitre.org/`               | `RefTypeCWE`     |
+| `CVE-` or `https://nvd.nist.gov/vuln/detail/CVE-`| `RefTypeCVE`     |
+| `CIS `                                            | `RefTypeCIS`     |
+| `NIST `                                           | `RefTypeNIST`    |
+| `MITRE `                                          | `RefTypeMITRE`   |
+| `https://` or `http://`                           | `RefTypeURL`     |
+| anything else                                     | `RefTypeOther`   |
+
+CWE references get a generated MITRE URL in `Reference.URL`. CVE references get
+a generated NVD URL. Other types populate only `Title`.
+
+---
+
+## Rendering
+
+Rendering lives in two places.
+
+**`internal/security/formatter/formatter.go`** handles JSON and YAML output
+via `prepareOutput`, which populates the following template keys when
+`enrichment_requested` is true:
+
+| Key                   | Source                                          |
+|-----------------------|-------------------------------------------------|
+| `enrichment_requested`| `audit.Result.EnrichmentRequested`             |
+| `enrichment_error`    | `audit.Result.EnrichmentError.Error()` or `""` |
+| `reference_cwes`      | `audit.Result.References.CWEs`                 |
+| `reference_errors`    | `formatReferenceErrors(result.References.Errors)` |
+| `enrichment_entries`  | `buildEnrichmentEntries(result)`               |
+| `enrichment_failures` | `buildEnrichmentFailures(result)`              |
+
+**`cmd/commands/security/security.go`** handles plain-text output via
+`renderEnrichmentBlock` and `renderReferenceErrors`. These are called from
+`formatText` (the text-mode output path) and implement the six rendering states
+described in the output design.
+
+### Rendering states (text mode)
+
+| Condition                                          | Output                                              |
+|----------------------------------------------------|-----------------------------------------------------|
+| `EnrichmentError != nil`                           | `Unavailable: <error>`                              |
+| `References.CWEs` empty                            | `No CWE references found in current findings.`      |
+| `Enrichment == nil`                                | `No enrichment data returned.`                      |
+| CWE present in `Successes`, status `NO_MATCHES`    | `No CVE matches in queried sources.`                |
+| CWE present in `Successes` with matches            | CVE list with severity symbol, score, source        |
+| `Enrichment.Failures` non-empty                    | Per-CWE failure with retryable indicator            |
+
+`References.Errors` (reference parsing errors) always render when non-empty,
+regardless of which enrichment state applies.
+
+---
+
+## Adapter authoring guide
+
+Adapters are not yet implemented. When writing the first adapter, follow these
+requirements.
+
+### Location
+
+Each adapter gets its own subdirectory under `internal/security/enrichment/`:
+
+```
+internal/security/enrichment/nvd/
+    nvd.go
+```
+
+The adapter package must not import `types`, `registry`, `audit`, or any other
+internal orkowatch package. The enrichment package is a leaf; adapters extend it
+as siblings, not dependents.
+
+### Interface
+
+The adapter type must satisfy `enrichment.Enricher`:
+
+```go
+func (a *NVDAdapter) Enrich(ctx context.Context, req enrichment.EnrichRequest) (enrichment.Result, error)
+func (a *NVDAdapter) Source() enrichment.Source
+```
+
+### Validation
+
+Call `enrichment.NormalizeCWEIDs(req.CWEs)` at the start of `Enrich`. Return
+`enrichment.ErrEmptyRequest` if the normalized slice is empty after validation.
+Record per-CWE normalization errors as `Failure` entries in the result.
+
+### API keys
+
+Read API keys from environment variables only. Never log, serialize, or return
+key material. Return `enrichment.ErrMissingAPIKey` when a required key is absent.
+Document the expected environment variable name in the adapter's package comment.
+
+### Caching
+
+Implement caching inside the adapter. Cache freshness rules differ per source;
+the adapter owns that logic. `EnrichRequest.BypassCache` must skip the cache
+when true.
+
+### Rate limiting
+
+Implement rate limiting inside the adapter. Do not rely on callers to throttle.
+
+### Concurrency
+
+Adapters must be safe for concurrent invocation. The orchestrator may call
+`Enrich` from multiple goroutines.
+
+### Result population
+
+For each CWE that returns results, populate a `CWEEnrichment` entry in
+`Result.Successes` with the canonical CWE ID as the key. Set `Status` to the
+appropriate constant. For each failure, populate `Result.Failures` with the
+canonical CWE ID as the key. Set `Retryable` accurately -- it is displayed to
+the user and used to decide whether a retry is appropriate.
+
+### Registering the adapter
+
+Update `NewEnricher` in `enricher.go` to return the configured adapter once at
+least one is available. Multi-adapter orchestration (concurrent fan-out via
+`errgroup`) is the planned model; `NewEnricher` will evolve accordingly.
+
+---
+
+## YAML registry -- adding references
+
+The reference strings in each YAML file are the source of all CWE input to the
+enrichment subsystem. The classifier in `ToReferences` determines what gets
+extracted as a CWE.
+
+To add a CWE reference to an existing finding, add an entry to the `references`
+list in the relevant YAML file using canonical form:
+
+```yaml
+ssh.weak_algorithms:
+  title: Weak SSH Key Exchange Algorithms Enabled
+  severity: HIGH
+  references:
+    - CWE-326
+    - CWE-327
+    - NIST SP 800-57
+```
+
+Both `CWE-N` and the full MITRE URL are accepted. The classifier normalizes
+both to canonical form before extraction. Only strings that pass CWE validation
+will appear in `EnrichRequest.CWEs`; malformed entries are collected into
+`ReferenceExtraction.Errors` and surfaced in the rendered output.
+
+YAML files are embedded at compile time via `go:embed`. Changes take effect on
+the next build.

--- a/docs/dev_guide/enrichment.md
+++ b/docs/dev_guide/enrichment.md
@@ -1,0 +1,183 @@
+# Enrichment Subsystem
+
+## Overview
+
+The enrichment subsystem annotates local audit findings with live data from external CVE intelligence sources. It is invoked when the user
+passes the `--enrich` flag to `security_audit` or `all`. Enrichment runs after the local audit completes, leaving baseline audit latency
+unaffected when the flag is not set.
+
+The subsystem lives at `internal/security/enrichment/`. Source-specific adapters implement the `Enricher` interface, and the orchestrator in
+`internal/security/audit/audit.go` invokes them with the deduplicated list of CVE references collected from local findings.
+
+This document describes the iniital design decisions made for the scaffolding of the enrichment feature. Any future updates to the
+implementation design, or feature enhancements will be outlined within this document.
+
+## Design Decisions
+
+### 1. Normalized type with per-field source attribution
+
+`CVEEnrichment` is a normalized structure shared across all enrichment sources. Each field that can carry data from an external source is
+paired with a source tag identifying which adapter provided the value.
+
+When multiple sources contribute data for the same CVE, conflicts are visible to the analyst rather than silently resolved by overwrite. This matters for security work — different sources can disagree on CVSS scoring, affected versions, or exploitation status, and an analyst
+needs to see those disagreements to make informed decisions.
+
+### 2. Adapter pattern for source pluggability
+
+The `Enricher` interface defines what an enrichment source must do. Each source is an independent implementation of the interface. The
+orchestrator does not know which sources are configured — it works against the interface.
+
+Adding a new source requires implementing the interface and registering the implementation in the constructor. No changes to orchestration,
+rendering, or audit code are required.
+
+### 3. Batch orchestration model
+
+Local audit checks run first and complete fully before any enrichment is attempted. The full audit result is assembled, the CVE references
+across all findings are collected and deduplicated, and the enrichment call is made once with the complete CVE list.
+
+This isolates network-dependent work from local diagnostic work. A network failure cannot affect the local audit result. A slow enrichment
+source cannot delay local results from being computed.
+
+### 4. Partial results with typed failures
+
+`EnrichmentResult` carries both `Successes` (a map of successfully enriched CVEs to their data) and `Failures` (a map of CVEs that could
+not be enriched along with the reason). The renderer surfaces both.
+
+A future `Retry` operation can re-run enrichment for only the failed CVEs without re-querying ones that already succeeded. The
+`EnrichmentFailure` type carries a `Retryable` boolean so the retry operation can skip permanent failures (malformed CVE IDs, sources
+declaring the CVE does not exist).
+
+### 5. Adapter-side caching
+
+Each adapter is responsible for its own caching. NVD updates daily, CISA KEV updates weekly, and EPSS updates daily — different sources
+have different freshness rules, and a single cache TTL at the orchestrator level cannot honor all of them correctly.
+
+Adapters may cache, must honor explicit cache bypass via `EnrichRequest.BypassCache`, and must treat cache state as a performance optimization rather than a correctness guarantee.
+ 
+### 6. Adapter-side rate limiting
+
+Each adapter is responsible for honoring its source's rate limits. NVD's public API permits 5 requests per 30 seconds without an API
+key and 50 requests per 30 seconds with one. CISA KEV is a single bulk download. Each adapter manages its own throttling internally
+and respects context cancellation while waiting.
+
+### 7. Concurrency safety expectations
+
+The orchestrator may invoke adapters concurrently when multiple sources are configured. Adapter implementations must therefore be
+safe to call concurrently. Adapters that maintain internal state (rate limiters, caches, connection pools) must protect that state.
+
+### 8. CVE ID validation
+
+CVE identifiers are validated against `^CVE-\d{4}-\d{4,}$` at three points: when extracted from registry references, when added to an
+`EnrichRequest`, and when an adapter constructs URLs or query strings. Invalid identifiers are rejected before any network call or string
+construction occurs.
+
+This belt-and-suspenders validation prevents injection of crafted identifiers into URLs, query strings, or downstream parsing logic.
+
+### 9. API key handling
+
+API keys are read only from environment variables. Keys are never read from configuration files committed to disk, never written to logs,
+and never serialized into audit results or rendered output. Adapters that require keys but cannot find them in the environment return an
+initialization error.
+
+### 10. Local audit independence
+
+Enrichment failures never affect local audit results. The audit `Result` is fully populated by local checks before enrichment is
+invoked. If enrichment fails entirely, the result still contains complete local findings and the failure is surfaced separately to
+the user with guidance on how to investigate.
+
+### 11. Error returned when no enricher is configured
+
+In the scaffolding branch, no adapter implementations are shipped. `NewEnricher` returns `ErrNoEnricherConfigured`. The orchestrator
+detects this condition and surfaces a clear message to the user explaining that enrichment is not yet available, while still
+completing the local audit normally.
+
+A no-op implementation that silently returns empty results was not shipped because it would hide from the user that enrichment did
+nothing. Returning a typed error makes the system's current capability honest to the user.
+
+## Implementing a New Enrichment Source
+
+This section is for contributors adding a new adapter.
+
+### Package placement
+
+Each adapter lives in its own file within `internal/security/enrichment/`. The file is named after the source: `nvd.go` for the NVD adapter, `kev.go` for CISA KEV, and so on. The type implementing the `Enricher` interface follows the same convention: `nvdEnricher`, `kevEnricher`.
+
+### Interface conformance
+
+The adapter type must satisfy the `Enricher` interface defined in `enricher.go`. Both `Enrich` and any required initialization functions
+must be implemented. The constructor for the adapter returns the interface type, not the concrete type, to keep the orchestrator
+decoupled from implementations.
+
+### Validation requirements
+
+CVE identifiers received in an `EnrichRequest` must be re-validated inside the adapter before being used in any network call or string
+construction. The orchestrator validates at the boundary, but adapters are responsible for their own input safety.
+
+### Caching expectations
+
+If the adapter caches results, the cache must honor the `BypassCache` field on `EnrichRequest`. Cache invalidation rules must
+match the source's freshness guarantees. The cache must not be the sole source of truth — a cache miss must always fall back to the
+live source.
+
+### Rate limiting expectations
+
+The adapter must enforce the source's published rate limits internally. Waiting for rate limit windows must respect context
+cancellation so the orchestrator can cancel the operation if the overall audit times out.
+
+### Error handling
+
+Errors that affect specific CVEs go into `EnrichmentFailure` entries in the `Failures` map of the result. Errors that prevent the adapter
+from functioning at all (initialization failure, missing API key, total network failure) are returned as the function's error value.
+Partial success is the normal case — an adapter that successfully enriches some CVEs and fails on others should return both the
+successes and the failures.
+
+### Source attribution
+
+When the adapter populates a field on `CVEEnrichment`, it must also populate the corresponding source tag identifying itself. This is
+how analysts trace which source provided which data point. Adapter implementations use a stable source identifier (the exported package
+constant `SourceNVD`, `SourceKEV`, etc.) rather than free-form strings.
+
+### Testing
+
+Each adapter ships with unit tests covering the success path, partial failure path, total failure path, rate limit behavior under context
+cancellation, and validation rejection of malformed input. Network calls in tests are mocked. Integration tests against the live source
+live in a build-tagged file and are not run in CI by default.
+
+## Future Enrichment Sources
+
+The following sources are candidates for future adapter implementation, in approximate priority order.
+
+NVD (National Vulnerability Database) provides the foundational CVE data including current CVSS scoring, affected configurations,
+references, and publication metadata. The first adapter implementation targets NVD v2 API.
+
+CISA KEV (Known Exploited Vulnerabilities catalog) identifies CVEs with confirmed exploitation in the wild. Adds a critical signal for
+prioritization beyond CVSS scoring alone.
+
+EPSS (Exploit Prediction Scoring System) provides probability scores for likelihood of exploitation within 30 days. Complements KEV by
+offering forward-looking risk signal for CVEs not yet exploited.
+
+GHSA (GitHub Security Advisories) provides curated advisory data with detailed remediation guidance, often with patch availability and
+affected version ranges more precise than NVD.
+
+## Documentation Format for Future Updates
+
+Files under `docs/dev_guide/` follow this structure:
+
+1. **Overview** — what the subsystem does, where it lives, when it runs. Keep to a few paragraphs.
+
+2. **Design Decisions** — numbered list of decisions made during implementation. Each decision gets a brief heading and a few
+   paragraphs of rationale. Rationale describes why the decision was made and what it achieves. Decisions that were considered and
+   rejected are not documented unless the contrast is necessary to explain the current behavior.
+
+3. **Implementing a New X** — contributor guide for extending the subsystem. Step-by-step instructions for adding new
+   implementations, with subsections covering placement, interface conformance, validation, error handling, and testing.
+
+4. **Future X** — candidates discussed for future implementation in approximate priority order. Brief descriptions only; full design
+   decisions for each future item are documented when that item is actually implemented.
+
+5. **Documentation Format for Future Updates** — only the first subsystem document includes this section, to establish the
+   pattern. Subsequent documents follow the established format without repeating these instructions.
+
+Section headers use `##` for top-level sections and `###` for subsections. Code blocks use language tags when the language is
+unambiguous. Line wrapping is at 72 columns to keep diffs readable. File names, type names, and function names use inline code
+formatting. Cross-references to other documents in `docs/dev_guide/` use relative paths.

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/papa0four/orkowatch/internal/security/checker"
-	"github.com/papa0four/orkowatch/internal/security/types"
 	"github.com/papa0four/orkowatch/internal/security/registry"
+	"github.com/papa0four/orkowatch/internal/security/types"
 )
 
 // SecurityAuditor handles the orchestration of security checks
@@ -70,17 +70,17 @@ func NewSecurityAuditor(opts Options) *SecurityAuditor {
 	ctx := registry.DetectOS()
 
 	auditor := &SecurityAuditor{
-		verbose: opts.Verbose,
-		options: opts,
+		verbose:   opts.Verbose,
+		options:   opts,
 		osContext: ctx,
 	}
 
 	switch runtime.GOOS {
 	case "windows":
-		auditor.sshChecker = checker.NewWindowsSSHChecker()
-		auditor.firewallChecker = checker.NewWindowsFirewallChecker()
-		auditor.userChecker = checker.NewWindowsUserChecker()
-		auditor.permissionChecker = checker.NewWindowsPermissionChecker()
+		auditor.sshChecker = checker.NewWindowsSSHChecker(ctx)
+		auditor.firewallChecker = checker.NewWindowsFirewallChecker(ctx)
+		auditor.userChecker = checker.NewWindowsUserChecker(ctx)
+		auditor.permissionChecker = checker.NewWindowsPermissionChecker(ctx)
 	default:
 		auditor.sshChecker = checker.NewUnixSSHChecker()
 		auditor.firewallChecker = checker.NewUnixFirewallChecker()

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -82,9 +82,9 @@ func NewSecurityAuditor(opts Options) *SecurityAuditor {
 		auditor.userChecker = checker.NewWindowsUserChecker(ctx)
 		auditor.permissionChecker = checker.NewWindowsPermissionChecker(ctx)
 	default:
-		auditor.sshChecker = checker.NewUnixSSHChecker()
+		auditor.sshChecker = checker.NewUnixSSHChecker(ctx)
 		auditor.firewallChecker = checker.NewUnixFirewallChecker()
-		auditor.userChecker = checker.NewUnixUserChecker()
+		auditor.userChecker = checker.NewUnixUserChecker(ctx)
 		auditor.permissionChecker = checker.NewUnixPermissionChecker()
 	}
 

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -90,7 +90,7 @@ func NewSecurityAuditor(opts Options) *SecurityAuditor {
 		auditor.permissionChecker = checker.NewWindowsPermissionChecker(ctx)
 	default:
 		auditor.sshChecker = checker.NewUnixSSHChecker(ctx)
-		auditor.firewallChecker = checker.NewUnixFirewallChecker()
+		auditor.firewallChecker = checker.NewUnixFirewallChecker(ctx)
 		auditor.userChecker = checker.NewUnixUserChecker(ctx)
 		auditor.permissionChecker = checker.NewUnixPermissionChecker()
 	}

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -2,6 +2,7 @@
 package audit
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/papa0four/orkowatch/internal/security/checker"
+	"github.com/papa0four/orkowatch/internal/security/enrichment"
 	"github.com/papa0four/orkowatch/internal/security/registry"
 	"github.com/papa0four/orkowatch/internal/security/types"
 )
@@ -34,16 +36,21 @@ type Options struct {
 	SkipChecks     []string
 	MinSeverity    string
 	Timeout        time.Duration
+	Enrich         bool
 }
 
 // Result represents the complete audit results
 type Result struct {
-	StartTime  time.Time
-	EndTime    time.Time
-	Duration   time.Duration
-	Results    []types.AuditResult
-	SystemInfo SystemInfo
-	Summary    Summary
+	StartTime           time.Time
+	EndTime             time.Time
+	Duration            time.Duration
+	Results             []types.AuditResult
+	SystemInfo          SystemInfo
+	Summary             Summary
+	EnrichmentRequested bool
+	EnrichmentError     error
+	Enrichment          *enrichment.Result
+	References          types.ReferenceExtraction
 }
 
 // SystemInfo contains basic system information
@@ -94,9 +101,10 @@ func NewSecurityAuditor(opts Options) *SecurityAuditor {
 // RunAudit performs the security audit with the specified options
 func (sa *SecurityAuditor) RunAudit() (*Result, error) {
 	result := &Result{
-		StartTime:  time.Now(),
-		SystemInfo: getSystemInfo(),
-		Results:    make([]types.AuditResult, 0),
+		StartTime:           time.Now(),
+		SystemInfo:          getSystemInfo(),
+		Results:             make([]types.AuditResult, 0),
+		EnrichmentRequested: sa.options.Enrich,
 	}
 
 	if len(sa.options.SpecificChecks) > 0 {
@@ -121,15 +129,11 @@ func (sa *SecurityAuditor) RunAudit() (*Result, error) {
 				result.Results = append(result.Results, checkResult)
 			}
 		}
-	} else {
-		return sa.runAllChecks(result)
+		sa.finalize(result)
+		return result, nil
 	}
 
-	result.EndTime = time.Now()
-	result.Duration = result.EndTime.Sub(result.StartTime)
-	result.Summary = sa.calculateSummary(result.Results)
-
-	return result, nil
+	return sa.runAllChecks(result)
 }
 
 func (sa *SecurityAuditor) runAllChecks(result *Result) (*Result, error) {
@@ -186,11 +190,62 @@ func (sa *SecurityAuditor) runAllChecks(result *Result) (*Result, error) {
 		result.Results = append(result.Results, checkResult)
 	}
 
+	sa.finalize(result)
+	return result, nil
+}
+
+func (sa *SecurityAuditor) finalize(result *Result) {
 	result.EndTime = time.Now()
 	result.Duration = result.EndTime.Sub(result.StartTime)
 	result.Summary = sa.calculateSummary(result.Results)
+	result.References = aggregateReferences(result.Results)
 
-	return result, nil
+	if !sa.options.Enrich {
+		return
+	}
+
+	enricher, err := enrichment.NewEnricher()
+	if err != nil {
+		result.EnrichmentError = err
+		return
+	}
+
+	if len(result.References.CWEs) == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), sa.options.Timeout)
+	defer cancel()
+
+	req := enrichment.EnrichRequest{
+		CWEs:        result.References.CWEs,
+		MinSeverity: sa.options.MinSeverity,
+	}
+
+	enrichResult, err := enricher.Enrich(ctx, req)
+	if err != nil {
+		result.EnrichmentError = err
+		return
+	}
+	result.Enrichment = &enrichResult
+}
+
+func aggregateReferences(results []types.AuditResult) types.ReferenceExtraction {
+	var ext types.ReferenceExtraction
+	seen := make(map[string]struct{})
+	for i := range results {
+		sub := results[i].AllCWEReferences()
+		for _, id := range sub.CWEs {
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			ext.CWEs = append(ext.CWEs, id)
+		}
+		ext.Errors = append(ext.Errors, sub.Errors...)
+		ext.Other = append(ext.Other, sub.Other...)
+	}
+	return ext
 }
 
 func (sa *SecurityAuditor) calculateSummary(results []types.AuditResult) Summary {

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/papa0four/orkowatch/internal/security/checker"
 	"github.com/papa0four/orkowatch/internal/security/types"
+	"github.com/papa0four/orkowatch/internal/security/registry"
 )
 
 // SecurityAuditor handles the orchestration of security checks
@@ -22,6 +23,7 @@ type SecurityAuditor struct {
 	permissionChecker checker.PermissionChecker
 	verbose           bool
 	options           Options
+	osContext         registry.OSContext
 }
 
 // Options configures the audit process
@@ -65,9 +67,12 @@ type Summary struct {
 
 // NewSecurityAuditor creates a new security auditor based on the OS
 func NewSecurityAuditor(opts Options) *SecurityAuditor {
+	ctx := registry.DetectOS()
+
 	auditor := &SecurityAuditor{
 		verbose: opts.Verbose,
 		options: opts,
+		osContext: ctx,
 	}
 
 	switch runtime.GOOS {

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -200,12 +200,12 @@ func (sa *SecurityAuditor) calculateSummary(results []types.AuditResult) Summary
 
 	for _, result := range results {
 		switch {
-		case result.Status == "COMPLETED" && !containsWarning(result.Details):
-			summary.PassedChecks++
-		case result.Status == "WARNING" || containsWarning(result.Details):
-			summary.WarningChecks++
 		case result.Status == "ERROR":
 			summary.FailedChecks++
+		case len(result.Findings) > 0:
+			summary.WarningChecks++
+		case result.Status == "COMPLETED":
+			summary.PassedChecks++
 		default:
 			summary.SkippedChecks++
 		}
@@ -254,14 +254,4 @@ func timeCheck(fn func() types.AuditResult) types.AuditResult {
 	result.EndTime = end
 	result.Duration = end.Sub(start)
 	return result
-}
-
-func containsWarning(details []string) bool {
-	for _, detail := range details {
-		if strings.Contains(detail, "WARNING") ||
-			strings.Contains(detail, types.SymbolWarning) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/security/checker/firewall.go
+++ b/internal/security/checker/firewall.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/papa0four/orkowatch/internal/security/registry"
 	"github.com/papa0four/orkowatch/internal/security/types"
 )
 
@@ -18,7 +19,9 @@ type FirewallChecker interface {
 type UnixFirewallChecker struct{}
 
 // WindowsFirewallChecker implements FirewallChecker for Windows systems
-type WindowsFirewallChecker struct{}
+type WindowsFirewallChecker struct {
+	ctx registry.OSContext
+}
 
 // NewUnixFirewallChecker creates a new Unix firewall checker
 func NewUnixFirewallChecker() *UnixFirewallChecker {
@@ -26,8 +29,8 @@ func NewUnixFirewallChecker() *UnixFirewallChecker {
 }
 
 // NewWindowsFirewallChecker creates a new Windows firewall checker
-func NewWindowsFirewallChecker() *WindowsFirewallChecker {
-	return &WindowsFirewallChecker{}
+func NewWindowsFirewallChecker(ctx registry.OSContext) *WindowsFirewallChecker {
+	return &WindowsFirewallChecker{ctx: ctx}
 }
 
 // firewallTool represents a firewall management tool
@@ -111,6 +114,7 @@ func (f *WindowsFirewallChecker) Check() types.AuditResult {
 		Status:      "CHECKING",
 		Description: "Analyzing Windows Firewall Configuration",
 		Details:     make([]string, 0),
+		Findings:    make([]types.Finding, 0),
 	}
 
 	// Check firewall status for all profiles
@@ -127,20 +131,35 @@ func (f *WindowsFirewallChecker) Check() types.AuditResult {
 	// Parse firewall profiles status
 	profiles := parseWindowsFirewallStatus(string(output))
 	activeProfiles := 0
+	inactiveProfiles := 0
 	for profile, state := range profiles {
 		if state {
 			activeProfiles++
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s profile is active", types.SymbolOK, profile))
 		} else {
+			inactiveProfiles++
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: %s profile is inactive", types.SymbolWarning, profile))
 		}
 	}
 
+	// One finding per inactive profile
+	if inactiveProfiles > 0 && activeProfiles > 0 {
+		if def, ok := registry.Lookup(f.ctx, "firewall.profile_inactive"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+			})
+		}
+	}
+
 	// Check firewall rules if at least one profile is active
 	if activeProfiles > 0 {
-		cmd = exec.Command("netsh", "advfirewall", "firewall", "show", "rule", "name-all", "verbose")
+		cmd = exec.Command("netsh", "advfirewall", "firewall", "show", "rule", "name=all", "verbose")
 		output, err := cmd.CombinedOutput()
 		if err == nil {
 			rules := parseWindowsFirewallRules(string(output))
@@ -158,6 +177,15 @@ func (f *WindowsFirewallChecker) Check() types.AuditResult {
 		result.Description = "Windows Firewall is disabled for all profiles"
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s CRITICAL: Windows Firewall is completely disabled", types.SymbolCritical))
+		if def, ok := registry.Lookup(f.ctx, "firewall.all_profiles_disabled"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+			})
+		}
 	} else {
 		result.Status = "COMPLETED"
 		result.Description = fmt.Sprintf("Windows Firewall is active on %d profile(s)", activeProfiles)

--- a/internal/security/checker/firewall.go
+++ b/internal/security/checker/firewall.go
@@ -153,6 +153,7 @@ func (f *WindowsFirewallChecker) Check() types.AuditResult {
 				Description: def.Description,
 				Impact:      def.Impact,
 				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
 			})
 		}
 	}
@@ -184,6 +185,7 @@ func (f *WindowsFirewallChecker) Check() types.AuditResult {
 				Description: def.Description,
 				Impact:      def.Impact,
 				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
 			})
 		}
 	} else {

--- a/internal/security/checker/firewall.go
+++ b/internal/security/checker/firewall.go
@@ -16,7 +16,9 @@ type FirewallChecker interface {
 }
 
 // UnixFirewallChecker implements FirewallChecker for Unix-like systems
-type UnixFirewallChecker struct{}
+type UnixFirewallChecker struct {
+	ctx registry.OSContext
+}
 
 // WindowsFirewallChecker implements FirewallChecker for Windows systems
 type WindowsFirewallChecker struct {
@@ -24,8 +26,8 @@ type WindowsFirewallChecker struct {
 }
 
 // NewUnixFirewallChecker creates a new Unix firewall checker
-func NewUnixFirewallChecker() *UnixFirewallChecker {
-	return &UnixFirewallChecker{}
+func NewUnixFirewallChecker(ctx registry.OSContext) *UnixFirewallChecker {
+	return &UnixFirewallChecker{ctx: ctx}
 }
 
 // NewWindowsFirewallChecker creates a new Windows firewall checker
@@ -94,6 +96,16 @@ func (f *UnixFirewallChecker) Check() types.AuditResult {
 		result.Description = "No active firewall detected"
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s WARNING: No active firewall detected", types.SymbolWarning))
+		if def, ok := registry.Lookup(f.ctx, "firewall.no_active_manager"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
+			})
+		}
 	} else {
 		result.Status = "COMPLETED"
 		result.Description = fmt.Sprintf("Found %d active firewall(s)", activeFirewalls)

--- a/internal/security/checker/permissions.go
+++ b/internal/security/checker/permissions.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/papa0four/orkowatch/internal/security/registry"
 	"github.com/papa0four/orkowatch/internal/security/types"
 )
 
@@ -49,6 +50,7 @@ type UnixPermissionChecker struct {
 // WindowsPermissionChecker implements PermissionChecker for Windows systems
 type WindowsPermissionChecker struct {
 	Paths []string
+	ctx   registry.OSContext
 }
 
 // criticalPath represents a path that needs permission checking
@@ -71,7 +73,7 @@ func NewUnixPermissionChecker() *UnixPermissionChecker {
 }
 
 // NewWindowsPermissionChecker creates a new Windows permission checker
-func NewWindowsPermissionChecker() *WindowsPermissionChecker {
+func NewWindowsPermissionChecker(ctx registry.OSContext) *WindowsPermissionChecker {
 	return &WindowsPermissionChecker{
 		Paths: []string{
 			"C:\\Windows\\System32",
@@ -80,6 +82,7 @@ func NewWindowsPermissionChecker() *WindowsPermissionChecker {
 			"C:\\ProgramData",
 			"C:\\Users",
 		},
+		ctx: ctx,
 	}
 }
 
@@ -269,6 +272,7 @@ func (p *WindowsPermissionChecker) Check() types.AuditResult {
 		Status:      "CHECKING",
 		Description: "Analyzing Windows file and directory permissions",
 		Details:     make([]string, 0),
+		Findings:    make([]types.Finding, 0),
 	}
 
 	for _, path := range p.Paths {
@@ -293,6 +297,9 @@ func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, result *
 		return fmt.Errorf("failed to check permissions: %v", err)
 	}
 
+	everyoneFindingAdded := false
+	usersFindingAdded := false
+
 	// Analyze permissions
 	lines := strings.Split(string(output), "\n")
 	for _, line := range lines {
@@ -301,17 +308,40 @@ func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, result *
 			continue
 		}
 
-		// Check for potentially dangerous permissions
 		if strings.Contains(line, "Everyone:(OI)(CI)(F)") ||
 			strings.Contains(line, "Everyone:(F)") {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: Full control granted to Everyone group on %s",
 					types.SymbolWarning, line))
+			if !everyoneFindingAdded {
+				if def, ok := registry.Lookup(p.ctx, "permissions.everyone_full_control"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+					})
+				}
+				everyoneFindingAdded = true
+			}
 		} else if strings.Contains(line, "Users:(OI)(CI)(F)") ||
 			strings.Contains(line, "Users:(F)") {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: Full control granted to Users group on %s",
 					types.SymbolWarning, line))
+			if !usersFindingAdded {
+				if def, ok := registry.Lookup(p.ctx, "permissions.users_full_control"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+					})
+				}
+				usersFindingAdded = true
+			}
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolInfo, line))
@@ -334,6 +364,8 @@ func (p *WindowsPermissionChecker) checkNetworkShares(result *types.AuditResult)
 	shares := strings.Split(string(output), "\n")
 	result.Details = append(result.Details, "\nNetwork Shares:")
 
+	adminShareFindingAdded := false
+
 	for _, share := range shares {
 		share = strings.TrimSpace(share)
 		if share == "" || strings.HasPrefix(share, "Share name") ||
@@ -341,12 +373,23 @@ func (p *WindowsPermissionChecker) checkNetworkShares(result *types.AuditResult)
 			continue
 		}
 
-		// Check share permissions
 		shareName := strings.Fields(share)[0]
 		if shareName == "ADMIN$" || shareName == "C$" || shareName == "IPC$" {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s Administrative share: %s",
 					types.SymbolWarning, share))
+			if !adminShareFindingAdded {
+				if def, ok := registry.Lookup(p.ctx, "permissions.admin_share_present"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+					})
+				}
+				adminShareFindingAdded = true
+			}
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolInfo, share))

--- a/internal/security/checker/permissions.go
+++ b/internal/security/checker/permissions.go
@@ -321,6 +321,7 @@ func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, result *
 						Description: def.Description,
 						Impact:      def.Impact,
 						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
 					})
 				}
 				everyoneFindingAdded = true
@@ -338,6 +339,7 @@ func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, result *
 						Description: def.Description,
 						Impact:      def.Impact,
 						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
 					})
 				}
 				usersFindingAdded = true
@@ -386,6 +388,7 @@ func (p *WindowsPermissionChecker) checkNetworkShares(result *types.AuditResult)
 						Description: def.Description,
 						Impact:      def.Impact,
 						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
 					})
 				}
 				adminShareFindingAdded = true

--- a/internal/security/checker/ssh.go
+++ b/internal/security/checker/ssh.go
@@ -25,7 +25,7 @@ type UnixSSHChecker struct {
 // WindowsSSHChecker implements SSHChecker for Windows systems
 type WindowsSSHChecker struct {
 	ConfigPath string
-	ctx  	   registry.OSContext
+	ctx  	     registry.OSContext
 }
 
 // NewUnixSSHChecker creates a new Unix SSH checker with default paths
@@ -42,6 +42,7 @@ func NewUnixSSHChecker() *UnixSSHChecker {
 func NewWindowsSSHChecker() *WindowsSSHChecker {
 	return &WindowsSSHChecker{
 		ConfigPath: "C:\\ProgramData\\ssh\\sshd_config",
+		ctx:        ctx,
 	}
 }
 
@@ -159,6 +160,7 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 		Status:      "CHECKING",
 		Description: "Analyzing Windows SSH configuration",
 		Details:     make([]string, 0),
+		Findings:    make([]types.Finding, 0)
 	}
 
 	sshdInstalled := false
@@ -177,6 +179,15 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 		case "Stopped":
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s OpenSSH Server is installed but not running", types.SymbolWarning))
+			if def, ok := registry.Lookup(s.ctx, "ssh.server_not_running"); ok {
+				result.Findings = append(result.Findings, types.Finding{
+					Title:       def.Title,
+					Severity:    def.Severity,
+					Description: def.Description,
+					Impact:      def.Impact,
+					Resolution:  def.Resolution,
+				})
+			}
 		default:
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s OpenSSH Server service state: %s", types.SymbolInfo, serviceStatus))
@@ -240,6 +251,15 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 					if config.rootLogin {
 						result.Details = append(result.Details,
 							fmt.Sprintf("%s WARNING: Root login is permitted", types.SymbolWarning))
+						if def, ok := registry.Lookup(s.ctx, "ssh.root_login_permitted"); ok {
+							result.Findings = append(result.Findings, types.Finding{
+								Title:       def.Title,
+								Severity:    def.Severity,
+								Description: def.Description,
+								Impact:      def.Impact,
+								Resolution:  def.Resolution,
+							})
+						}
 					} else {
 						result.Details = append(result.Details,
 							fmt.Sprintf("%s Root login is disabled", types.SymbolOK))
@@ -250,6 +270,15 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 					if config.passwordAuth {
 						result.Details = append(result.Details,
 							fmt.Sprintf("%s WARNING: Password authentication is enabled", types.SymbolWarning))
+						if def, ok := registry.Lookup(s.ctx, "ssh.password_auth_enabled"); ok {
+							result.Findings = append(result.Findings, types.Finding{
+								Title:       def.Title,
+								Severity:    def.Severity,
+								Description: def.Description,
+								Impact:      def.Impact,
+								Resolution:  def.Resolution,
+							})
+						}
 					} else {
 						result.Details = append(result.Details,
 							fmt.Sprintf("%s Password authentication is disabled", types.SymbolOK))
@@ -259,6 +288,15 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: OpenSSH configuration file not found", types.SymbolWarning))
+			if def, ok := registry.Lookup(s.ctx, "ssh.config_missing"); ok {
+				result.Findings = append(result.Findings, types.Finding{
+					Title:       def.Title,
+					Severity:    def.Severity,
+					Description: def.Description,
+					Impact:      def.Impact,
+					Resolution:  def.Resolution,
+				})
+			}
 		}
 	}
 

--- a/internal/security/checker/ssh.go
+++ b/internal/security/checker/ssh.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/papa0four/orkowatch/internal/security/types"
+	"github.com/papa0four/orkowatch/internal/security/registry"
 )
 
 // SSHChecker defines interface for SSH configuration checking
@@ -24,6 +25,7 @@ type UnixSSHChecker struct {
 // WindowsSSHChecker implements SSHChecker for Windows systems
 type WindowsSSHChecker struct {
 	ConfigPath string
+	ctx  	   registry.OSContext
 }
 
 // NewUnixSSHChecker creates a new Unix SSH checker with default paths

--- a/internal/security/checker/ssh.go
+++ b/internal/security/checker/ssh.go
@@ -32,6 +32,7 @@ type WindowsSSHChecker struct {
 // NewUnixSSHChecker creates a new Unix SSH checker with default paths
 func NewUnixSSHChecker(ctx registry.OSContext) *UnixSSHChecker {
 	return &UnixSSHChecker{
+		ctx: ctx,
 		ConfigPaths: []string{
 			"/etc/ssh/sshd_config",
 			"/private/etc/ssh/sshd_config", // macOS path

--- a/internal/security/checker/ssh.go
+++ b/internal/security/checker/ssh.go
@@ -8,8 +8,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/papa0four/orkowatch/internal/security/types"
 	"github.com/papa0four/orkowatch/internal/security/registry"
+	"github.com/papa0four/orkowatch/internal/security/types"
 )
 
 // SSHChecker defines interface for SSH configuration checking
@@ -25,7 +25,7 @@ type UnixSSHChecker struct {
 // WindowsSSHChecker implements SSHChecker for Windows systems
 type WindowsSSHChecker struct {
 	ConfigPath string
-	ctx  	     registry.OSContext
+	ctx        registry.OSContext
 }
 
 // NewUnixSSHChecker creates a new Unix SSH checker with default paths
@@ -39,7 +39,7 @@ func NewUnixSSHChecker() *UnixSSHChecker {
 }
 
 // NewWindowsSSHChecker creates a new Windows SSH checker
-func NewWindowsSSHChecker() *WindowsSSHChecker {
+func NewWindowsSSHChecker(ctx registry.OSContext) *WindowsSSHChecker {
 	return &WindowsSSHChecker{
 		ConfigPath: "C:\\ProgramData\\ssh\\sshd_config",
 		ctx:        ctx,
@@ -160,7 +160,7 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 		Status:      "CHECKING",
 		Description: "Analyzing Windows SSH configuration",
 		Details:     make([]string, 0),
-		Findings:    make([]types.Finding, 0)
+		Findings:    make([]types.Finding, 0),
 	}
 
 	sshdInstalled := false

--- a/internal/security/checker/ssh.go
+++ b/internal/security/checker/ssh.go
@@ -90,6 +90,7 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 				Description: def.Description,
 				Impact:      def.Impact,
 				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
 			})
 		}
 		return result
@@ -143,6 +144,7 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 					Description: def.Description,
 					Impact:      def.Impact,
 					Resolution:  def.Resolution,
+					References:  def.ToReferences(),
 				})
 			}
 		} else {
@@ -159,6 +161,7 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 				Description: def.Description,
 				Impact:      def.Impact,
 				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
 			})
 		}
 	}
@@ -175,6 +178,7 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 					Description: def.Description,
 					Impact:      def.Impact,
 					Resolution:  def.Resolution,
+					References:  def.ToReferences(),
 				})
 			}
 		} else {
@@ -191,6 +195,7 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 				Description: def.Description,
 				Impact:      def.Impact,
 				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
 			})
 		}
 	}
@@ -233,6 +238,7 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 					Description: def.Description,
 					Impact:      def.Impact,
 					Resolution:  def.Resolution,
+					References:  def.ToReferences(),
 				})
 			}
 		default:
@@ -305,6 +311,7 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 								Description: def.Description,
 								Impact:      def.Impact,
 								Resolution:  def.Resolution,
+								References:  def.ToReferences(),
 							})
 						}
 					} else {
@@ -324,6 +331,7 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 								Description: def.Description,
 								Impact:      def.Impact,
 								Resolution:  def.Resolution,
+								References:  def.ToReferences(),
 							})
 						}
 					} else {
@@ -342,6 +350,7 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 					Description: def.Description,
 					Impact:      def.Impact,
 					Resolution:  def.Resolution,
+					References:  def.ToReferences(),
 				})
 			}
 		}

--- a/internal/security/checker/ssh.go
+++ b/internal/security/checker/ssh.go
@@ -20,6 +20,7 @@ type SSHChecker interface {
 // UnixSSHChecker implements SSHChecker for Unix-like systems
 type UnixSSHChecker struct {
 	ConfigPaths []string
+	ctx         registry.OSContext
 }
 
 // WindowsSSHChecker implements SSHChecker for Windows systems
@@ -29,7 +30,7 @@ type WindowsSSHChecker struct {
 }
 
 // NewUnixSSHChecker creates a new Unix SSH checker with default paths
-func NewUnixSSHChecker() *UnixSSHChecker {
+func NewUnixSSHChecker(ctx registry.OSContext) *UnixSSHChecker {
 	return &UnixSSHChecker{
 		ConfigPaths: []string{
 			"/etc/ssh/sshd_config",
@@ -61,6 +62,7 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 		Status:      "CHECKING",
 		Description: "Analyzing SSH Configuration settings",
 		Details:     make([]string, 0),
+		Findings:    make([]types.Finding, 0),
 	}
 
 	var file *os.File
@@ -81,6 +83,15 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 		result.Description = fmt.Sprintf("SSH configuration file not found in any of: %v", s.ConfigPaths)
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s ERROR: No SSH configuration file found", types.SymbolError))
+		if def, ok := registry.Lookup(s.ctx, "ssh.config_not_found"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+			})
+		}
 		return result
 	}
 
@@ -125,6 +136,15 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 		if config.rootLogin {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: Root login is permitted", types.SymbolWarning))
+			if def, ok := registry.Lookup(s.ctx, "ssh.root_login_permitted"); ok {
+				result.Findings = append(result.Findings, types.Finding{
+					Title:       def.Title,
+					Severity:    def.Severity,
+					Description: def.Description,
+					Impact:      def.Impact,
+					Resolution:  def.Resolution,
+				})
+			}
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s Root login is disabled", types.SymbolOK))
@@ -132,6 +152,15 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 	} else {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s WARNING: PermitRootLogin setting not found (defaults may apply)", types.SymbolWarning))
+		if def, ok := registry.Lookup(s.ctx, "ssh.permit_root_login_not_set"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+			})
+		}
 	}
 
 	// Check password authentication
@@ -139,6 +168,15 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 		if config.passwordAuth {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: Password authentication is enabled", types.SymbolWarning))
+			if def, ok := registry.Lookup(s.ctx, "ssh.password_auth_enabled"); ok {
+				result.Findings = append(result.Findings, types.Finding{
+					Title:       def.Title,
+					Severity:    def.Severity,
+					Description: def.Description,
+					Impact:      def.Impact,
+					Resolution:  def.Resolution,
+				})
+			}
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s Password authentication is disabled", types.SymbolOK))
@@ -146,6 +184,15 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 	} else {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s WARNING: PasswordAuthentication setting not found (defaults may apply)", types.SymbolWarning))
+		if def, ok := registry.Lookup(s.ctx, "ssh.password_auth_not_set"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+			})
+		}
 	}
 
 	result.Status = "COMPLETED"

--- a/internal/security/checker/users.go
+++ b/internal/security/checker/users.go
@@ -33,6 +33,7 @@ type platformConfig struct {
 type UnixUserChecker struct {
 	config platformConfig
 	osType string
+	ctx    registry.OSContext
 }
 
 // WindowsUserChecker implements UserChecker for Windows systems
@@ -51,6 +52,12 @@ type userAccount struct {
 	isLocked   bool
 	isAdmin    bool
 	isDisabled bool
+}
+
+// authConfigResult holds the outcome of auth configuration detection.
+type authConfigResult struct {
+	Details []string
+	Keys    []registry.FindingKey
 }
 
 // getPlatformConfig returns the appropriate configuration for the current OS
@@ -89,10 +96,11 @@ func getPlatformConfig() platformConfig {
 }
 
 // NewUnixUserChecker creates a new Unix user checker with OS-specific settings
-func NewUnixUserChecker() *UnixUserChecker {
+func NewUnixUserChecker(ctx registry.OSContext) *UnixUserChecker {
 	return &UnixUserChecker{
 		config: getPlatformConfig(),
 		osType: runtime.GOOS,
+		ctx:    ctx,
 	}
 }
 
@@ -108,9 +116,22 @@ func (u *UnixUserChecker) Check() types.AuditResult {
 		Status:      "CHECKING",
 		Description: fmt.Sprintf("Analyzing user accounts on %s", u.osType),
 		Details:     make([]string, 0),
+		Findings:    make([]types.Finding, 0),
 	}
 
-	result.Details = append(result.Details, u.checkAuthConfig()...)
+	authResult := u.checkAuthConfig()
+	result.Details = append(result.Details, authResult.Details...)
+	for _, key := range authResult.Keys {
+		if def, ok := registry.Lookup(u.ctx, key); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+			})
+		}
+	}
 
 	users, err := u.getUsers()
 	if err != nil {
@@ -431,10 +452,12 @@ func (u *UnixUserChecker) analyzeUsers(users []userAccount, result *types.AuditR
 	}
 }
 
-func (u *UnixUserChecker) checkAuthConfig() []string {
-	var details []string
+// checkAuthConfig detects authentication mechanisms configured on the system.
+func (u *UnixUserChecker) checkAuthConfig() authConfigResult {
+	var r authConfigResult
+
 	if _, err := os.Stat("/etc/pam.d"); err == nil {
-		details = append(details,
+		r.Details = append(r.Details,
 			fmt.Sprintf("%s PAM authentication is configured", types.SymbolInfo))
 
 		// Use os.DirFS to scope file reads to /etc/pam.d,
@@ -460,12 +483,12 @@ func (u *UnixUserChecker) checkAuthConfig() []string {
 				}
 				return nil
 			}); err != nil {
-				details = append(details,
+				r.Details = append(r.Details,
 					fmt.Sprintf("%s Could not scan PAM configuration: %v",
 						types.SymbolInfo, err))
 			}
 			if found {
-				details = append(details,
+				r.Details = append(r.Details,
 					fmt.Sprintf("%s Found authentication module: %s",
 						types.SymbolInfo, module))
 			}
@@ -473,21 +496,24 @@ func (u *UnixUserChecker) checkAuthConfig() []string {
 	}
 
 	if _, err := os.Stat("/etc/ldap.conf"); err == nil {
-		details = append(details,
+		r.Details = append(r.Details,
 			fmt.Sprintf("%s LDAP authentication is configured", types.SymbolWarning))
+		r.Keys = append(r.Keys, "users.ldap_configured")
 	}
 
 	if _, err := os.Stat("/etc/krb5.conf"); err == nil {
-		details = append(details,
+		r.Details = append(r.Details,
 			fmt.Sprintf("%s Kerberos authentication is configured", types.SymbolWarning))
+		r.Keys = append(r.Keys, "users.kerberos_configured")
 	}
 
 	if _, err := os.Stat("/etc/sssd/sssd.conf"); err == nil {
-		details = append(details,
+		r.Details = append(r.Details,
 			fmt.Sprintf("%s SSSD authentication is configured", types.SymbolWarning))
+		r.Keys = append(r.Keys, "users.sssd_configured")
 	}
 
-	return details
+	return r
 }
 
 func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
@@ -501,6 +527,15 @@ func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
 					result.Details = append(result.Details,
 						fmt.Sprintf("%s CRITICAL: User %s has no password set",
 							types.SymbolCritical, fields[passwdFieldUsername]))
+					if def, ok := registry.Lookup(u.ctx, "users.empty_password_hash"); ok {
+						result.Findings = append(result.Findings, types.Finding{
+							Title:       def.Title,
+							Severity:    def.Severity,
+							Description: def.Description,
+							Impact:      def.Impact,
+							Resolution:  def.Resolution,
+						})
+					}
 				}
 			}
 
@@ -519,6 +554,15 @@ func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
 			} else {
 				result.Details = append(result.Details,
 					fmt.Sprintf("%s WARNING: Root account is unlocked", types.SymbolWarning))
+				if def, ok := registry.Lookup(u.ctx, "users.root_account_unlocked"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+					})
+				}
 			}
 		}
 	}
@@ -535,6 +579,15 @@ func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
 						result.Details = append(result.Details,
 							fmt.Sprintf("%s CRITICAL: User %s has UID 0",
 								types.SymbolCritical, fields[0]))
+						if def, ok := registry.Lookup(u.ctx, "users.uid_zero_non_root"); ok {
+							result.Findings = append(result.Findings, types.Finding{
+								Title:       def.Title,
+								Severity:    def.Severity,
+								Description: def.Description,
+								Impact:      def.Impact,
+								Resolution:  def.Resolution,
+							})
+						}
 					}
 				}
 			}

--- a/internal/security/checker/users.go
+++ b/internal/security/checker/users.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/papa0four/orkowatch/internal/security/registry"
 	"github.com/papa0four/orkowatch/internal/security/types"
 )
 
@@ -35,7 +36,9 @@ type UnixUserChecker struct {
 }
 
 // WindowsUserChecker implements UserChecker for Windows systems
-type WindowsUserChecker struct{}
+type WindowsUserChecker struct {
+	ctx registry.OSContext
+}
 
 // userAccount represents a parsed user account
 type userAccount struct {
@@ -94,8 +97,8 @@ func NewUnixUserChecker() *UnixUserChecker {
 }
 
 // NewWindowsUserChecker creates a new Windows user checker
-func NewWindowsUserChecker() *WindowsUserChecker {
-	return &WindowsUserChecker{}
+func NewWindowsUserChecker(ctx registry.OSContext) *WindowsUserChecker {
+	return &WindowsUserChecker{ctx: ctx}
 }
 
 // Check implements UserChecker interface for Unix systems
@@ -552,6 +555,7 @@ func (w *WindowsUserChecker) Check() types.AuditResult {
 		Status:      "CHECKING",
 		Description: "Analyzing Windows user accounts and security settings",
 		Details:     make([]string, 0),
+		Findings:    make([]types.Finding, 0),
 	}
 
 	users, err := w.getWindowsUsers()
@@ -627,6 +631,8 @@ func (w *WindowsUserChecker) getWindowsUsers() ([]windowsUserInfo, error) {
 }
 
 func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result *types.AuditResult) {
+	noPasswordFindingAdded := false
+
 	for _, user := range users {
 		details := user.Name
 
@@ -634,6 +640,15 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 			details += " (Administrator)"
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolWarning, details))
+			if def, ok := registry.Lookup(w.ctx, "users.administrator_account_active"); ok {
+				result.Findings = append(result.Findings, types.Finding{
+					Title:       def.Title,
+					Severity:    def.Severity,
+					Description: def.Description,
+					Impact:      def.Impact,
+					Resolution:  def.Resolution,
+				})
+			}
 		} else if !user.Enabled {
 			details += " (Disabled)"
 			result.Details = append(result.Details,
@@ -642,6 +657,19 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 			details += " (No Password Required)"
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolWarning, details))
+			// One finding for the class of violation, not one per user account
+			if !noPasswordFindingAdded {
+				if def, ok := registry.Lookup(w.ctx, "users.no_password_required"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+					})
+				}
+				noPasswordFindingAdded = true
+			}
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolOK, details))
@@ -673,6 +701,15 @@ func (w *WindowsUserChecker) checkSecurityPolicies(result *types.AuditResult) {
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: User Account Control (UAC) is disabled", types.SymbolWarning))
+			if def, ok := registry.Lookup(w.ctx, "users.uac_disabled"); ok {
+				result.Findings = append(result.Findings, types.Finding{
+					Title:       def.Title,
+					Severity:    def.Severity,
+					Description: def.Description,
+					Impact:      def.Impact,
+					Resolution:  def.Resolution,
+				})
+			}
 		}
 	}
 }

--- a/internal/security/checker/users.go
+++ b/internal/security/checker/users.go
@@ -129,6 +129,7 @@ func (u *UnixUserChecker) Check() types.AuditResult {
 				Description: def.Description,
 				Impact:      def.Impact,
 				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
 			})
 		}
 	}
@@ -534,6 +535,7 @@ func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
 							Description: def.Description,
 							Impact:      def.Impact,
 							Resolution:  def.Resolution,
+							References:  def.ToReferences(),
 						})
 					}
 				}
@@ -561,6 +563,7 @@ func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
 						Description: def.Description,
 						Impact:      def.Impact,
 						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
 					})
 				}
 			}
@@ -586,6 +589,7 @@ func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
 								Description: def.Description,
 								Impact:      def.Impact,
 								Resolution:  def.Resolution,
+								References:  def.ToReferences(),
 							})
 						}
 					}
@@ -700,6 +704,7 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 					Description: def.Description,
 					Impact:      def.Impact,
 					Resolution:  def.Resolution,
+					References:  def.ToReferences(),
 				})
 			}
 		} else if !user.Enabled {
@@ -719,6 +724,7 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 						Description: def.Description,
 						Impact:      def.Impact,
 						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
 					})
 				}
 				noPasswordFindingAdded = true
@@ -761,6 +767,7 @@ func (w *WindowsUserChecker) checkSecurityPolicies(result *types.AuditResult) {
 					Description: def.Description,
 					Impact:      def.Impact,
 					Resolution:  def.Resolution,
+					References:  def.ToReferences(),
 				})
 			}
 		}

--- a/internal/security/enrichment/enricher.go
+++ b/internal/security/enrichment/enricher.go
@@ -1,0 +1,16 @@
+// internal/security/enrichment/enricher.go
+package enrichment
+
+import "context"
+
+// Enricher is the interface every enrichment source adapter
+// satisfies. Implementations must be safe for concurrent use.
+type Enricher interface {
+	Enrich(ctx context.Context, req EnrichRequest) (Result, error)
+	Source() Source
+}
+
+// NewEnricher returns the configured enricher.
+func NewEnricher() (Enricher, error) {
+	return nil, ErrNoEnricherConfigured
+}

--- a/internal/security/enrichment/errors.go
+++ b/internal/security/enrichment/errors.go
@@ -1,0 +1,17 @@
+// internal/security/enrichment/errors.go
+package enrichment
+
+import "errors"
+
+// ErrNoEnricherConfigured indicates that no enrichment source adapter has been registered.
+var ErrNoEnricherConfigured = errors.New("no enrichment source configured")
+
+// ErrInvalidCWEID indicates a CWE identifier failed format validation.
+// Returned when input does not match CWE-N+
+var ErrInvalidCWEID = errors.New("invalid CWE identifier")
+
+// ErrEmptyRequest indicates an EnrichRequest contained no CVE identifiers to enrich.
+var ErrEmptyRequest = errors.New("enrichment request contains no CVE identifiers")
+
+// ErrMissingAPIKey indicates an adapter that requires an API key could not find the required credential
+var ErrMissingAPIKey = errors.New("required API key not found in environment")

--- a/internal/security/enrichment/types.go
+++ b/internal/security/enrichment/types.go
@@ -1,0 +1,92 @@
+// internal/security/enrichment/types.go
+package enrichment
+
+import "time"
+
+// Source identifies which enrichment adapter contributed a field
+// value.
+type Source string
+
+// Enrichment adapter source identifiers.
+const (
+	SourceNVD   Source = "NVD"
+	SourceKEV   Source = "CISA-KEV"
+	SourceEPSS  Source = "EPSS"
+	SourceGHSA  Source = "GHSA"
+	SourceMITRE Source = "MITRE-CWE"
+)
+
+// Status reports the terminal state of an enrichment attempt for a single CVE.
+type Status string
+
+// Enrichment status values.
+const (
+	StatusEnriched         Status = "ENRICHED"
+	StatusFailed           Status = "FAILED"
+	StatusNoMatches        Status = "NO_MATCHES"
+	StatusNoSourcesQueried Status = "NO_SOURCES_QUERIED"
+)
+
+// CWEEnrichment is per-CWE enrichment data with per-field source
+// attribution.
+type CWEEnrichment struct {
+	CWEID  string
+	Status Status
+
+	WeaknessName       string
+	WeaknessNameSource Source
+
+	WeaknessDescription       string
+	WeaknessDescriptionSource Source
+
+	MatchedCVEs       []CVEMatch
+	MatchedCVEsSource Source
+
+	LastQueried time.Time
+}
+
+// CVEMatch is a single CVE returned by an enrichment source as
+// associated with a CWE.
+type CVEMatch struct {
+	CVEID         string
+	Source        Source
+	CVSSBaseScore float64
+	CVSSSeverity  string
+	CVSSVector    string
+
+	Published    time.Time
+	LastModified time.Time
+
+	KnownExploited         bool
+	ExploitPredictionScore float64
+	PatchAvailable         bool
+
+	Description string
+	References  []string
+}
+
+// Failure records why enrichment for a specific CWE failed.
+type Failure struct {
+	CWEID     string
+	Source    Source
+	Reason    string
+	Err       error
+	Retryable bool
+}
+
+// Result is the aggregate output of an enrichment run.
+type Result struct {
+	Successes      map[string]CWEEnrichment
+	Failures       map[string]Failure
+	AdapterErrors  []error
+	SourcesQueried []Source
+	Duration       time.Duration
+}
+
+// EnrichRequest is the input to Enricher.Enrich.
+type EnrichRequest struct {
+	CWEs        []string
+	BypassCache bool
+	Sources     []Source
+	MinSeverity string
+}

--- a/internal/security/enrichment/validate.go
+++ b/internal/security/enrichment/validate.go
@@ -1,0 +1,102 @@
+// internal/security/enrichment/validate.go
+package enrichment
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	cweIDPrefix          = "CWE-"
+	cweIDPrefixLength    = 4
+	cweIDMinLength       = 5 // CWE- plus at least one digit
+	cweURLPrefix         = "https://cwe.mitre.org/data/definitions/"
+	cweURLSuffix         = ".html"
+	maxBulkValidateInput = 10000
+)
+
+// NormalizeCWEID returns the canonical CWE-N form for an identifier
+// supplied in canonical or URL form. Returns an error wrapping
+// ErrInvalidCWEID for input that does not match either form.
+func NormalizeCWEID(input string) (string, error) {
+	if id, ok := extractCWEFromURL(input); ok {
+		return validateCanonicalCWE(id)
+	}
+	return validateCanonicalCWE(input)
+}
+
+// ValidateCWEID returns nil if input is a valid CWE identifier in
+// canonical or URL form. Use NormalizeCWEID when the canonical form
+// is needed for downstream use.
+func ValidateCWEID(input string) error {
+	_, err := NormalizeCWEID(input)
+	return err
+}
+
+// NormalizeCWEIDs normalizes a slice of CWE identifiers. Returns the
+// canonical IDs that validated successfully and errors for the rest.
+// Rejects bulk input above the documented limit. Does not deduplicate.
+func NormalizeCWEIDs(inputs []string) (valid []string, errs []error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	if len(inputs) > maxBulkValidateInput {
+		return nil, []error{
+			fmt.Errorf("%w: input size %d exceeds limit %d",
+				ErrInvalidCWEID, len(inputs), maxBulkValidateInput),
+		}
+	}
+
+	valid = make([]string, 0, len(inputs))
+	for _, input := range inputs {
+		id, err := NormalizeCWEID(input)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		valid = append(valid, id)
+	}
+	return valid, errs
+}
+
+func extractCWEFromURL(input string) (string, bool) {
+	if !strings.HasPrefix(input, cweURLPrefix) {
+		return "", false
+	}
+	if !strings.HasSuffix(input, cweURLSuffix) {
+		return "", false
+	}
+	num := strings.TrimPrefix(input, cweURLPrefix)
+	num = strings.TrimSuffix(num, cweURLSuffix)
+	if num == "" {
+		return "", false
+	}
+	for i := 0; i < len(num); i++ {
+		if !isASCIIDigit(num[i]) {
+			return "", false
+		}
+	}
+	return cweIDPrefix + num, true
+}
+
+func validateCanonicalCWE(id string) (string, error) {
+	if len(id) < cweIDMinLength {
+		return "", fmt.Errorf("%w: length %d below minimum %d: %q",
+			ErrInvalidCWEID, len(id), cweIDMinLength, id)
+	}
+	if !strings.HasPrefix(id, cweIDPrefix) {
+		return "", fmt.Errorf("%w: missing %q prefix: %q",
+			ErrInvalidCWEID, cweIDPrefix, id)
+	}
+	for i := cweIDPrefixLength; i < len(id); i++ {
+		if !isASCIIDigit(id[i]) {
+			return "", fmt.Errorf("%w: non-digit byte 0x%02x at position %d: %q",
+				ErrInvalidCWEID, id[i], i, id)
+		}
+	}
+	return id, nil
+}
+
+func isASCIIDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}

--- a/internal/security/formatter/formatter.go
+++ b/internal/security/formatter/formatter.go
@@ -107,6 +107,8 @@ func (f *Formatter) prepareOutput(result *audit.Result) map[string]interface{} {
 	// Add metadata
 	output["timestamp"] = time.Now().UTC().Format(time.RFC3339)
 	output["duration"] = result.Duration.String()
+	output["verbose"] = f.options.Verbose
+	output["non_verbose"] = !f.options.Verbose
 
 	// Add system information if requested
 	if f.options.IncludeSystem {
@@ -132,6 +134,15 @@ func (f *Formatter) prepareOutput(result *audit.Result) map[string]interface{} {
 		"duration":       result.Duration.String(),
 	}
 
+	hasFindings := false
+	for _, r := range formattedResults {
+		if _, ok := r["findings"]; ok {
+			hasFindings = true
+			break
+		}
+	}
+	output["has_findings"] = hasFindings
+
 	return output
 }
 
@@ -148,10 +159,13 @@ func (f *Formatter) formatCheck(check types.AuditResult) map[string]interface{} 
 	var relevantFindings []map[string]interface{}
 	for _, finding := range check.Findings {
 		if isSeverityRelevant(finding.Severity, f.options.MinSeverity) {
+			symbol, label := types.SeverityFormat(finding.Severity)
 			formattedFinding := map[string]interface{}{
 				"title":    finding.Title,
 				"severity": finding.Severity,
 				"category": finding.Category,
+				"symbol":   symbol,
+				"label":    label,
 			}
 
 			if f.options.Verbose {
@@ -199,11 +213,9 @@ func isSeverityRelevant(findingSeverity, minSeverity string) bool {
 }
 
 // Default text template
-const defaultTemplate = `
-Security Audit Report
+const defaultTemplate = `Security Audit Report
 ====================
 Generated: {{.timestamp}}
-
 {{if .system}}
 System Information
 -----------------
@@ -213,36 +225,27 @@ Hostname: {{.system.Hostname}}
 Kernel Version: {{.system.KernelVersion}}
 Software Count: {{.system.SoftwareCount}}
 {{end}}
-
 Check Results
 ------------
 {{range .results}}
 Check: {{.name}}
 Status: {{.status}}
-Description: {{.description}}
 Duration: {{.duration}}
-
-{{if .findings}}
-Findings:
-{{range .findings}}
-  - [{{.severity}}] {{.title}}
+{{if .findings}}Findings:
+{{range .findings}}{{.symbol}} {{.label}}  {{.title}}
+{{if $.verbose}}{{if .description}}  Description: {{.description}}
+{{end}}{{if .impact}}  Impact: {{.impact}}
+{{end}}{{if .resolution}}  Resolution: {{.resolution}}
+{{end}}{{end}}{{end}}{{end}}{{if and $.verbose .details}}Raw Diagnostic Output:
+{{range .details}}  {{.}}
+{{end}}{{end}}
 {{end}}
-{{end}}
-
-{{if .details}}
-Details:
-{{range .details}}
-  {{.}}
-{{end}}
-{{end}}
-{{end}}
-
-Summary
--------
-Total Checks: {{.summary.total_checks}}
-Passed: {{.summary.passed_checks}}
-Warnings: {{.summary.warning_checks}}
-Failed: {{.summary.failed_checks}}
-Skipped: {{.summary.skipped_checks}}
-Duration: {{.summary.duration}}
-`
+Summary:
+Checks Run: {{.summary.total_checks}}
+Passed:     {{.summary.passed_checks}}
+Warnings:   {{.summary.warning_checks}}
+Failed:     {{.summary.failed_checks}}
+Duration:   {{.summary.duration}}
+{{if and .non_verbose .has_findings}}
+Run with -v for full finding details, impact analysis, and remediation guidance.
+{{end}}`

--- a/internal/security/formatter/formatter.go
+++ b/internal/security/formatter/formatter.go
@@ -306,8 +306,7 @@ Duration: {{.duration}}
 {{end}}{{if .resolution}}  Resolution: {{.resolution}}
 {{end}}{{end}}{{end}}{{end}}{{if and $.verbose .details}}Raw Diagnostic Output:
 {{range .details}}  {{.}}
-{{end}}{{end}}
-{{end}}{{if .enrichment_requested}}
+{{end}}{{end}}{{end}}{{if .enrichment_requested}}
 Enrichment:
 {{if .enrichment_error}}  Unavailable: {{.enrichment_error}}
 {{else if not .reference_cwes}}  No CWE references found in current findings.

--- a/internal/security/formatter/formatter.go
+++ b/internal/security/formatter/formatter.go
@@ -142,6 +142,15 @@ func (f *Formatter) prepareOutput(result *audit.Result) map[string]interface{} {
 		}
 	}
 	output["has_findings"] = hasFindings
+	output["enrichment_requested"] = result.EnrichmentRequested
+	output["enrichment_error"] = ""
+	if result.EnrichmentError != nil {
+		output["enrichment_error"] = result.EnrichmentError.Error()
+	}
+	output["reference_cwes"] = result.References.CWEs
+	output["reference_errors"] = formatReferenceErrors(result.References.Errors)
+	output["enrichment_entries"] = buildEnrichmentEntries(result)
+	output["enrichment_failures"] = buildEnrichmentFailures(result)
 
 	return output
 }
@@ -212,6 +221,65 @@ func isSeverityRelevant(findingSeverity, minSeverity string) bool {
 	return findingLevel >= minLevel
 }
 
+func formatReferenceErrors(errs []error) []string {
+	out := make([]string, 0, len(errs))
+	for _, e := range errs {
+		out = append(out, e.Error())
+	}
+	return out
+}
+
+func buildEnrichmentEntries(result *audit.Result) []map[string]interface{} {
+	if result.Enrichment == nil {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(result.References.CWEs))
+	for _, cwe := range result.References.CWEs {
+		entry, ok := result.Enrichment.Successes[cwe]
+		if !ok {
+			continue
+		}
+		matches := make([]map[string]interface{}, 0, len(entry.MatchedCVEs))
+		for _, match := range entry.MatchedCVEs {
+			symbol, label := types.SeverityFormat(match.CVSSSeverity)
+			matches = append(matches, map[string]interface{}{
+				"cve_id":          match.CVEID,
+				"source":          string(match.Source),
+				"cvss_base_score": match.CVSSBaseScore,
+				"cvss_severity":   match.CVSSSeverity,
+				"symbol":          symbol,
+				"label":           label,
+				"description":     match.Description,
+				"known_exploited": match.KnownExploited,
+				"patch_available": match.PatchAvailable,
+			})
+		}
+		out = append(out, map[string]interface{}{
+			"cwe_id":        cwe,
+			"weakness_name": entry.WeaknessName,
+			"no_matches":    string(entry.Status) == "NO_MATCHES" || len(matches) == 0,
+			"matches":       matches,
+		})
+	}
+	return out
+}
+
+func buildEnrichmentFailures(result *audit.Result) []map[string]interface{} {
+	if result.Enrichment == nil || len(result.Enrichment.Failures) == 0 {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(result.Enrichment.Failures))
+	for cwe, failure := range result.Enrichment.Failures {
+		out = append(out, map[string]interface{}{
+			"cwe_id":    cwe,
+			"source":    string(failure.Source),
+			"reason":    failure.Reason,
+			"retryable": failure.Retryable,
+		})
+	}
+	return out
+}
+
 // Default text template
 const defaultTemplate = `Security Audit Report
 ====================
@@ -239,7 +307,23 @@ Duration: {{.duration}}
 {{end}}{{end}}{{end}}{{end}}{{if and $.verbose .details}}Raw Diagnostic Output:
 {{range .details}}  {{.}}
 {{end}}{{end}}
-{{end}}
+{{end}}{{if .enrichment_requested}}
+Enrichment:
+{{if .enrichment_error}}  Unavailable: {{.enrichment_error}}
+{{else if not .reference_cwes}}  No CWE references found in current findings.
+{{else if not .enrichment_entries}}  No enrichment data returned.
+{{else}}{{range .enrichment_entries}}  {{.cwe_id}}{{if .weakness_name}} - {{.weakness_name}}{{end}}
+{{if .no_matches}}    No CVE matches in queried sources.
+{{else}}{{range .matches}}    {{.symbol}} {{.label}}  {{.cve_id}} ({{printf "%.1f" .cvss_base_score}}) [{{.source}}]
+{{if $.verbose}}{{if .description}}      Description: {{.description}}
+{{end}}{{if .known_exploited}}      Known Exploited: yes
+{{end}}{{if .patch_available}}      Patch Available: yes
+{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .enrichment_failures}}
+  Failed enrichments:
+{{range .enrichment_failures}}    {{.cwe_id}} [{{.source}}]: {{.reason}}{{if .retryable}} (retryable){{end}}
+{{end}}{{end}}{{if .reference_errors}}  Reference parsing errors:
+{{range .reference_errors}}    {{.}}
+{{end}}{{end}}{{end}}
 Summary:
 Checks Run: {{.summary.total_checks}}
 Passed:     {{.summary.passed_checks}}

--- a/internal/security/registry/data/darwin.yaml
+++ b/internal/security/registry/data/darwin.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/linux_alpine.yaml
+++ b/internal/security/registry/data/linux_alpine.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/linux_arch.yaml
+++ b/internal/security/registry/data/linux_arch.yaml
@@ -1,1 +1,273 @@
-# stub: findings for this platform/family are pending implementation
+# Arch family finding definitions for the orkowatch registry.
+# Covers Arch Linux, Manjaro, EndeavourOS, Garuda, Artix, and derivatives
+# identified via ID_LIKE=arch in /etc/os-release.
+# Severity tiers follow CVSS v3.1 base score ranges:
+#   CRITICAL 9.0-10.0 | HIGH 7.0-8.9 | MEDIUM 4.0-6.9 | LOW 0.1-3.9
+# All entries sourced from Arch Linux Security wiki, CIS Distribution
+# Independent Linux Benchmark v2.0.0, NIST SP 800-53 Rev 5, and
+# CVSS v3.1 scoring methodology.
+# Note: Arch Linux has no official CIS benchmark. Entries reference
+# the Arch Security wiki and CIS Distribution Independent where applicable.
+
+# -------------------------
+# Firewall checker findings
+# -------------------------
+
+firewall.no_firewall_installed:
+  title: "No firewall manager is installed or active"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-284"
+  description: >
+    Arch Linux does not install a firewall manager by default. Neither
+    iptables, nftables, ufw, nor firewalld was detected as active on
+    this system. The host has no host-based packet filtering in place.
+    Unlike Debian or RHEL family systems, Arch ships with no default
+    firewall configuration and requires explicit installation and
+    configuration by the administrator.
+  impact: >
+    All services bound to any network interface are directly reachable
+    without restriction. Any service started on the host — including
+    development servers, databases, or remote desktop tools — is
+    immediately network-accessible without explicit firewall rules.
+  resolution: >
+    Install and configure nftables, which is the modern kernel-level
+    replacement for iptables and the recommended choice on Arch:
+    pacman -S nftables && systemctl enable --now nftables. Create a
+    base ruleset in /etc/nftables.conf with a default drop policy and
+    explicit allow rules for required services.
+  references:
+    - "Arch Linux Security Wiki: https://wiki.archlinux.org/title/Security#Firewalls"
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §3.5"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+firewall.nftables_no_rules:
+  title: "nftables is active but has no rules configured"
+  severity: "HIGH"
+  cvss_score: 8.2
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H"
+  cwe: "CWE-284"
+  description: >
+    nftables is the active firewall manager but no rules are loaded.
+    An nftables instance with no ruleset provides no packet filtering —
+    all traffic is permitted by default. This is equivalent to having
+    no firewall active despite the service running.
+  impact: >
+    All listening services remain fully accessible on all interfaces.
+    The presence of a running nftables service may create a false
+    sense of security. Traffic filtering requires an explicit ruleset
+    to be loaded — an empty ruleset enforces nothing.
+  resolution: >
+    Create a base ruleset in /etc/nftables.conf with a default drop
+    policy on the input chain and explicit allow rules for required
+    services. Load the ruleset: nft -f /etc/nftables.conf. Enable
+    the service to persist across reboots: systemctl enable nftables.
+  references:
+    - "Arch Linux Wiki nftables: https://wiki.archlinux.org/title/nftables"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+firewall.iptables_default_accept:
+  title: "iptables default policy is ACCEPT on INPUT chain"
+  severity: "HIGH"
+  cvss_score: 8.6
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:H"
+  cwe: "CWE-284"
+  description: >
+    The iptables INPUT chain has a default policy of ACCEPT, meaning
+    any traffic not matched by an explicit rule is permitted through.
+    A secure firewall posture requires a default DROP or REJECT policy
+    with explicit allow rules for required traffic only.
+  impact: >
+    Any service listening on any interface is reachable unless explicitly
+    blocked by a rule. New services started on the host are automatically
+    network-accessible without any firewall change required. This inverts
+    the intended security model of deny-by-default.
+  resolution: >
+    Set a default DROP policy on the INPUT chain: iptables -P INPUT DROP.
+    Add explicit ACCEPT rules for required traffic before applying the
+    default drop to avoid lockout. Persist rules across reboots via
+    iptables-save > /etc/iptables/iptables.rules and enable the
+    iptables systemd service.
+  references:
+    - "Arch Linux Wiki iptables: https://wiki.archlinux.org/title/iptables"
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §3.5.3"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+# -------------------------
+# User checker findings
+# -------------------------
+
+users.sudo_nopasswd:
+  title: "Sudoers entry permits privilege escalation without password"
+  severity: "HIGH"
+  cvss_score: 8.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+  cwe: "CWE-269"
+  description: >
+    A sudoers rule contains the NOPASSWD tag, allowing one or more users
+    to execute commands with elevated privileges without providing a
+    password. On Arch-family systems this is commonly added during
+    initial setup for convenience and frequently left in place.
+  impact: >
+    Any attacker or process that gains access to the affected user account
+    can immediately escalate to root without any additional credential.
+    This is particularly significant on Arch systems where the primary
+    user account is commonly the sole administrator and frequently
+    targeted for NOPASSWD configuration during installation.
+  resolution: >
+    Remove NOPASSWD tags from sudoers rules: visudo. If passwordless
+    sudo is required for specific automation tasks, scope it to the
+    minimum required commands rather than ALL. Require password
+    confirmation for interactive administrative work.
+  references:
+    - "Arch Linux Security Wiki: https://wiki.archlinux.org/title/Security#sudo"
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.3.7"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/269.html"
+
+users.wheel_group_unrestricted:
+  title: "wheel group has unrestricted sudo access"
+  severity: "MEDIUM"
+  cvss_score: 6.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-269"
+  description: >
+    The wheel group is configured with unrestricted sudo access to all
+    commands. On Arch Linux this is the default sudoers configuration
+    when the wheel group line is uncommented during setup. Every member
+    of the wheel group can run any command as root.
+  impact: >
+    Compromise of any wheel group member account yields full root access
+    via sudo. If multiple user accounts are in the wheel group, the
+    attack surface for privilege escalation is multiplied. Unrestricted
+    wheel access provides no command-level containment.
+  resolution: >
+    Audit wheel group membership: getent group wheel. Remove accounts
+    that do not require administrative access. Consider restricting
+    sudo access to specific commands for accounts that only need
+    limited elevation rather than full wheel membership.
+  references:
+    - "Arch Linux Security Wiki: https://wiki.archlinux.org/title/Security#sudo"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/269.html"
+
+users.aur_helper_installed:
+  title: "AUR helper is installed"
+  severity: "LOW"
+  cvss_score: 3.3
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+  cwe: "CWE-829"
+  description: >
+    An AUR (Arch User Repository) helper such as yay, paru, or trizen
+    is installed. AUR packages are community-maintained PKGBUILDs that
+    are not reviewed or signed by Arch Linux maintainers. AUR helpers
+    automate the download and build of these packages, which execute
+    arbitrary build scripts with user privileges.
+  impact: >
+    AUR packages execute PKGBUILD scripts during installation that can
+    contain arbitrary commands. Malicious or compromised AUR packages
+    have historically been used to deliver malware. The risk is
+    proportional to the number of AUR packages installed and the
+    diligence with which PKGBUILDs are reviewed before installation.
+  resolution: >
+    Review all installed AUR packages and their PKGBUILDs. Remove AUR
+    packages that are available in the official repositories. Always
+    read PKGBUILDs before installing AUR packages. Consider using
+    an isolated build environment for AUR package compilation.
+  references:
+    - "Arch Linux AUR Security: https://wiki.archlinux.org/title/AUR#Safety"
+    - "NIST SP 800-53 Rev 5 CM-7 (Least Functionality)"
+    - "https://cwe.mitre.org/data/definitions/829.html"
+
+# -------------------------
+# Permissions checker findings
+# -------------------------
+
+permissions.shadow_world_readable:
+  title: "/etc/shadow is readable by non-root users"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:N"
+  cwe: "CWE-732"
+  description: >
+    /etc/shadow has permissions that allow non-root users to read its
+    contents. On Arch Linux the expected permission is 640 with ownership
+    root:shadow. Any deviation allows password hash extraction by
+    unprivileged users or processes.
+  impact: >
+    Any local user or process that can read /etc/shadow gains access to
+    all local password hashes for offline cracking. On Arch systems
+    where the primary user account is commonly the only human account,
+    cracking this hash yields full system access via sudo.
+  resolution: >
+    Restore correct permissions: chmod 640 /etc/shadow && chown
+    root:shadow /etc/shadow. Verify: ls -la /etc/shadow. Rotate
+    passwords for all accounts as a precaution if the file was
+    readable for an unknown period.
+  references:
+    - "Arch Linux Security Wiki: https://wiki.archlinux.org/title/Security"
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §6.1.3"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.pacman_cache_world_writable:
+  title: "pacman cache directory is world-writable"
+  severity: "HIGH"
+  cvss_score: 7.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-732"
+  description: >
+    The pacman package cache directory (/var/cache/pacman/pkg) is
+    world-writable. Package files in this directory are used by pacman
+    during installation and upgrades. A world-writable cache allows
+    any local user to replace cached package files with malicious
+    versions that will be installed on the next pacman operation.
+  impact: >
+    A local attacker can replace a cached package tarball with a
+    backdoored version. The next time pacman installs or upgrades
+    that package, the malicious version is installed with root
+    privileges. This enables persistent privilege escalation and
+    backdoor installation without exploiting any software vulnerability.
+  resolution: >
+    Restore correct permissions: chmod 755 /var/cache/pacman/pkg &&
+    chown root:root /var/cache/pacman/pkg. Verify no unexpected files
+    are present in the cache. Clear and repopulate the cache if
+    tampering is suspected: pacman -Scc.
+  references:
+    - "Arch Linux Wiki pacman: https://wiki.archlinux.org/title/pacman"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.ssh_dir_permissions:
+  title: "SSH directory or authorized_keys has incorrect permissions"
+  severity: "HIGH"
+  cvss_score: 7.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-732"
+  description: >
+    A user's ~/.ssh directory or ~/.ssh/authorized_keys file has
+    permissions that exceed the expected mode. On Arch Linux, OpenSSH
+    enforces StrictModes by default and will refuse to use keys from
+    directories or files with overly permissive modes. Misconfigured
+    permissions also enable unauthorized key injection by other local
+    users.
+  impact: >
+    World or group writable ~/.ssh directories allow other local users
+    to inject authorized keys, granting themselves SSH access as the
+    target user. On Arch systems where the primary user commonly has
+    full sudo access, this enables complete system compromise via
+    key injection alone.
+  resolution: >
+    Set correct permissions: chmod 700 ~/.ssh && chmod 600
+    ~/.ssh/authorized_keys. Verify ownership: chown -R <user>:<user>
+    ~/.ssh. Audit authorized_keys for unexpected entries. Verify
+    StrictModes yes is set or absent (default) in sshd_config.
+  references:
+    - "Arch Linux Security Wiki: https://wiki.archlinux.org/title/Security"
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.2.19"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"

--- a/internal/security/registry/data/linux_arch.yaml
+++ b/internal/security/registry/data/linux_arch.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/linux_common.yaml
+++ b/internal/security/registry/data/linux_common.yaml
@@ -1,0 +1,431 @@
+# Linux common finding definitions for the orkowatch registry.
+# These findings apply across all Linux distributions regardless of family.
+# Severity tiers follow CVSS v3.1 base score ranges:
+#   CRITICAL 9.0-10.0 | HIGH 7.0-8.9 | MEDIUM 4.0-6.9 | LOW 0.1-3.9
+# All entries sourced from CIS Distribution Independent Linux Benchmark v2.0.0,
+# NIST SP 800-53 Rev 5, and CVSS v3.1 scoring methodology.
+
+# -------------------------
+# SSH checker findings
+# -------------------------
+
+ssh.config_not_found:
+  title: "SSH daemon configuration file not found"
+  severity: "MEDIUM"
+  cvss_score: 5.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L"
+  cwe: "CWE-16"
+  description: >
+    No sshd_config file was found at any expected path. Without an explicit
+    configuration file, sshd falls back to compiled-in defaults which vary
+    by distribution and OpenSSH version. Default configurations frequently
+    permit password authentication and may not restrict root login.
+  impact: >
+    An SSH daemon running without an explicit configuration file may permit
+    password-based authentication, weak ciphers, or root login depending on
+    compiled defaults. The security posture of the service cannot be verified
+    without a configuration file present.
+  resolution: >
+    Create /etc/ssh/sshd_config with explicit directives for
+    PasswordAuthentication, PermitRootLogin, AllowUsers, and cipher
+    suites. Restart sshd after making changes: systemctl restart sshd.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.2"
+    - "NIST SP 800-53 Rev 5 CM-6 (Configuration Settings)"
+    - "https://cwe.mitre.org/data/definitions/16.html"
+
+ssh.root_login_permitted:
+  title: "SSH PermitRootLogin is not explicitly disabled"
+  severity: "CRITICAL"
+  cvss_score: 9.8
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-250"
+  description: >
+    PermitRootLogin is not set to no in sshd_config. Direct root login
+    over SSH gives an attacker full system control upon credential compromise
+    with no privilege escalation step required. OpenSSH defaults vary by
+    version — absence of this directive is not safe.
+  impact: >
+    A successful brute-force, credential stuffing, or key theft attack
+    against the root account yields immediate full control of the host.
+    No additional exploitation step is required post-authentication.
+    Combined with password authentication, this represents maximum SSH
+    exposure.
+  resolution: >
+    Set PermitRootLogin no in /etc/ssh/sshd_config and restart sshd.
+    Administrative access should use key-based authentication to a
+    non-privileged account followed by explicit privilege escalation
+    via sudo.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.2.8"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "NIST SP 800-53 Rev 5 IA-2 (Identification and Authentication)"
+    - "https://cwe.mitre.org/data/definitions/250.html"
+
+ssh.password_auth_enabled:
+  title: "SSH password authentication is enabled"
+  severity: "HIGH"
+  cvss_score: 7.5
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-521"
+  description: >
+    PasswordAuthentication is set to yes in sshd_config. Password-based
+    SSH authentication is susceptible to brute-force and credential stuffing
+    attacks. Any account reachable via SSH with a weak or reused password
+    is directly at risk.
+  impact: >
+    Automated brute-force tools can systematically attempt credentials
+    against the SSH service. Credential exposure from unrelated data
+    breaches directly translates to SSH access risk for any account
+    with a matching password.
+  resolution: >
+    Set PasswordAuthentication no in /etc/ssh/sshd_config and configure
+    key-based authentication exclusively. Distribute authorized_keys to
+    required users before disabling password auth to avoid lockout.
+    Restart sshd after changes.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.2.11"
+    - "NIST SP 800-53 Rev 5 IA-5(1) (Authenticator Management)"
+    - "https://cwe.mitre.org/data/definitions/521.html"
+
+ssh.permit_root_login_not_set:
+  title: "PermitRootLogin directive is absent from SSH configuration"
+  severity: "MEDIUM"
+  cvss_score: 5.9
+  cvss_vector: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-16"
+  description: >
+    The PermitRootLogin directive was not found in sshd_config. OpenSSH
+    compiled defaults vary by distribution and version. On some systems
+    the default permits root login; on others it does not. Absence of
+    an explicit setting leaves the behavior undefined and
+    distribution-dependent.
+  impact: >
+    Without an explicit PermitRootLogin directive, the effective policy
+    depends on the OpenSSH build configuration for the installed version.
+    System updates or package replacements may silently change the
+    effective default.
+  resolution: >
+    Add PermitRootLogin no explicitly to /etc/ssh/sshd_config regardless
+    of the assumed default. Explicit configuration is always safer than
+    relying on compiled-in defaults.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.2.8"
+    - "NIST SP 800-53 Rev 5 CM-6 (Configuration Settings)"
+    - "https://cwe.mitre.org/data/definitions/16.html"
+
+ssh.password_auth_not_set:
+  title: "PasswordAuthentication directive is absent from SSH configuration"
+  severity: "MEDIUM"
+  cvss_score: 5.9
+  cvss_vector: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-16"
+  description: >
+    The PasswordAuthentication directive was not found in sshd_config.
+    OpenSSH defaults to permitting password authentication when this
+    directive is absent, meaning the service may accept password-based
+    logins even without explicit configuration.
+  impact: >
+    Password authentication may be silently active. Any account accessible
+    via SSH with a weak or reused password is exposed to brute-force
+    attacks without the operator being aware that password auth is enabled.
+  resolution: >
+    Add PasswordAuthentication no explicitly to /etc/ssh/sshd_config.
+    Configure key-based authentication before disabling password auth
+    to prevent lockout. Restart sshd after changes.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.2.11"
+    - "NIST SP 800-53 Rev 5 CM-6 (Configuration Settings)"
+    - "https://cwe.mitre.org/data/definitions/16.html"
+
+# -------------------------
+# Firewall checker findings
+# -------------------------
+
+firewall.no_active_manager:
+  title: "No active firewall manager detected"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-284"
+  description: >
+    None of the recognized firewall managers (iptables, ufw, firewalld,
+    pfctl) are active on this system. The host has no detected host-based
+    packet filtering in place. All listening services are reachable on
+    all interfaces without network-level access control.
+  impact: >
+    Every service bound to a network interface is directly reachable without
+    restriction. This eliminates host-based network controls as a
+    defense-in-depth layer against exploitation, lateral movement, and
+    unauthorized access to internal services.
+  resolution: >
+    Install and enable an appropriate firewall manager for the distribution.
+    On Debian/Ubuntu: ufw enable. On RHEL/Fedora: systemctl enable --now
+    firewalld. Configure rules to permit only required traffic and deny
+    all else by default.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §3.5"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+# -------------------------
+# User checker findings
+# -------------------------
+
+users.empty_password_hash:
+  title: "User account has no password set in /etc/shadow"
+  severity: "CRITICAL"
+  cvss_score: 9.8
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-258"
+  description: >
+    One or more user accounts have an empty password hash field in
+    /etc/shadow. An empty hash means the account has no password and
+    can be accessed without any credential on systems where password
+    authentication is permitted.
+  impact: >
+    Any local or remote attacker can authenticate as this user without
+    providing a password. If the account has sudo access or elevated
+    privileges, this represents an immediate critical compromise path
+    requiring no exploitation.
+  resolution: >
+    Set a strong password immediately: passwd <username>. If the account
+    is a service account that should not allow interactive login, lock it:
+    passwd -l <username> and set the shell to /usr/sbin/nologin in
+    /etc/passwd.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §6.2.1"
+    - "NIST SP 800-53 Rev 5 IA-5 (Authenticator Management)"
+    - "https://cwe.mitre.org/data/definitions/258.html"
+
+users.uid_zero_non_root:
+  title: "Non-root account has UID 0"
+  severity: "CRITICAL"
+  cvss_score: 9.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+  cwe: "CWE-250"
+  description: >
+    A user account other than root has been assigned UID 0. On Linux and
+    Unix systems, UID 0 confers full superuser privileges regardless of
+    the account name. Any account with UID 0 is effectively root.
+  impact: >
+    Compromise of any UID 0 account yields complete system control
+    identical to compromising the root account. Multiple UID 0 accounts
+    expand the attack surface for privilege escalation and make audit
+    trails ambiguous — actions appear to come from different accounts
+    but carry identical privileges.
+  resolution: >
+    Immediately reassign a non-zero UID to the affected account or
+    remove it if it is not required: usermod -u <new_uid> <username>.
+    Investigate how UID 0 was assigned and whether unauthorized access
+    occurred. Only the root account should have UID 0.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §6.2.5"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/250.html"
+
+users.root_account_unlocked:
+  title: "Root account is not locked"
+  severity: "MEDIUM"
+  cvss_score: 6.7
+  cvss_vector: "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-284"
+  description: >
+    The root account is not in a locked state. On systems where
+    administrative access is managed via sudo, the root account itself
+    should be locked to prevent direct root login via password
+    authentication while preserving sudo-based escalation.
+  impact: >
+    An unlocked root account with a password can be targeted directly
+    via SSH brute-force if PermitRootLogin is not explicitly disabled,
+    or via local authentication bypass techniques. Locking root forces
+    all privileged access through auditable sudo paths.
+  resolution: >
+    Lock the root account password: passwd -l root. Ensure sudo is
+    configured to provide necessary administrative access before locking.
+    Verify PermitRootLogin no is set in sshd_config independently.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.4.1"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+users.ldap_configured:
+  title: "LDAP authentication is configured"
+  severity: "LOW"
+  cvss_score: 2.3
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N"
+  cwe: "CWE-287"
+  description: >
+    /etc/ldap.conf is present, indicating LDAP-based authentication is
+    configured. LDAP authentication introduces a network dependency for
+    local login and may expose credentials if the LDAP connection is
+    not encrypted.
+  impact: >
+    If LDAP is configured without TLS/LDAPS, credentials are transmitted
+    in cleartext over the network. An LDAP server outage may prevent
+    local login. Misconfigured LDAP referrals can expose the system to
+    authentication bypass.
+  resolution: >
+    Verify LDAP is configured with TLS (ldaps:// or StartTLS).
+    Ensure a local fallback authentication method exists for system
+    recovery. Review /etc/ldap.conf for cleartext bind credentials.
+  references:
+    - "NIST SP 800-53 Rev 5 IA-3 (Device Identification and Authentication)"
+    - "https://cwe.mitre.org/data/definitions/287.html"
+
+users.kerberos_configured:
+  title: "Kerberos authentication is configured"
+  severity: "LOW"
+  cvss_score: 2.3
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N"
+  cwe: "CWE-287"
+  description: >
+    /etc/krb5.conf is present, indicating Kerberos authentication is
+    configured. Kerberos introduces a KDC dependency for authentication
+    and requires time synchronization within 5 minutes to function
+    correctly.
+  impact: >
+    KDC unavailability or clock skew may prevent authentication. Weak
+    Kerberos encryption types (DES, RC4) in krb5.conf expose ticket
+    traffic to offline cracking. Misconfigured realms may permit
+    cross-realm authentication abuse.
+  resolution: >
+    Review /etc/krb5.conf for deprecated encryption types and remove
+    DES and RC4 entries. Ensure time synchronization is configured.
+    Verify KDC redundancy for availability.
+  references:
+    - "NIST SP 800-53 Rev 5 IA-3 (Device Identification and Authentication)"
+    - "https://cwe.mitre.org/data/definitions/287.html"
+
+users.sssd_configured:
+  title: "SSSD authentication is configured"
+  severity: "LOW"
+  cvss_score: 2.3
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N"
+  cwe: "CWE-287"
+  description: >
+    /etc/sssd/sssd.conf is present, indicating the System Security
+    Services Daemon is configured for centralized identity management.
+    SSSD introduces external identity provider dependencies for
+    authentication.
+  impact: >
+    SSSD misconfiguration or identity provider unavailability may prevent
+    login. Overly permissive SSSD filter configurations may allow
+    unauthorized accounts to authenticate. Cache poisoning is possible
+    if SSSD offline caching is misconfigured.
+  resolution: >
+    Review /etc/sssd/sssd.conf for access_provider and ldap_access_filter
+    settings. Ensure the identity provider connection uses TLS. Test
+    offline authentication behavior to verify local fallback functions
+    correctly.
+  references:
+    - "NIST SP 800-53 Rev 5 IA-3 (Device Identification and Authentication)"
+    - "https://cwe.mitre.org/data/definitions/287.html"
+
+# -------------------------
+# Permissions checker findings
+# -------------------------
+
+permissions.path_exceeds_expected_mode:
+  title: "File or directory permissions exceed expected mode"
+  severity: "MEDIUM"
+  cvss_score: 5.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-732"
+  description: >
+    A critical system file or directory has permissions that exceed the
+    expected mode defined by CIS benchmarks. Overly permissive settings
+    on files such as /etc/passwd, /etc/shadow, or /etc/sudoers allow
+    unauthorized users to read or modify sensitive system data.
+  impact: >
+    World-readable shadow files expose password hashes to offline cracking.
+    World-writable configuration files allow unauthorized modification of
+    authentication, sudo, or service configuration. The specific impact
+    depends on which path is affected.
+  resolution: >
+    Restore expected permissions using chmod. For common critical files:
+    chmod 644 /etc/passwd, chmod 000 /etc/shadow, chmod 440 /etc/sudoers.
+    Use the CIS benchmark for the specific distribution to verify
+    expected modes for all critical paths.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §6.1"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.world_writable_file:
+  title: "World-writable file found in monitored path"
+  severity: "HIGH"
+  cvss_score: 7.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-732"
+  description: >
+    A file with world-writable permissions (mode includes 0002) was found
+    within a monitored directory. World-writable files can be modified by
+    any local user regardless of ownership, enabling content injection,
+    configuration tampering, or script replacement.
+  impact: >
+    Any local user or process can overwrite the file contents. On executable
+    files or scripts run by privileged processes, this enables direct
+    privilege escalation. On configuration files, this enables service
+    manipulation or credential injection.
+  resolution: >
+    Remove world-writable permission immediately: chmod o-w <path>.
+    Investigate why the permission was set and whether the file was
+    modified. Audit cron jobs, service scripts, and init files that
+    reference the affected path.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §6.1.10"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.suid_sgid_binary:
+  title: "SUID or SGID binary found"
+  severity: "MEDIUM"
+  cvss_score: 6.7
+  cvss_vector: "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-250"
+  description: >
+    A binary with the SUID or SGID bit set was found. SUID binaries
+    execute with the file owner's privileges rather than the calling
+    user's privileges. Unexpected SUID binaries may have been planted
+    for privilege escalation or left from misconfigured software
+    installation.
+  impact: >
+    Exploitation of a vulnerable SUID binary allows a low-privileged
+    user to execute code as root or another privileged user without
+    sudo access. SUID binaries with known vulnerabilities are a common
+    local privilege escalation vector.
+  resolution: >
+    Audit all SUID/SGID binaries: find / -perm /6000 -type f. Remove
+    the SUID bit from any binary that does not require it: chmod u-s
+    <path>. Compare against a known-good baseline for the distribution
+    to identify unexpected additions.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §6.1.11, §6.1.12"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/250.html"
+
+permissions.unowned_file:
+  title: "File with no valid owner or group found"
+  severity: "MEDIUM"
+  cvss_score: 4.4
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
+  cwe: "CWE-732"
+  description: >
+    A file with no valid owning user or group was found. Unowned files
+    typically result from user account deletion without cleaning up
+    associated files, or from improper software installation. They
+    represent an ownership gap that may be exploitable.
+  impact: >
+    Unowned files can be claimed by any user who creates an account with
+    the matching numeric UID or GID. If the file is a binary, script,
+    or configuration file in a sensitive location, the new owner gains
+    control over it, potentially enabling privilege escalation.
+  resolution: >
+    Assign appropriate ownership: chown <user>:<group> <path>. If the
+    file is not needed, remove it. Audit recently deleted accounts to
+    identify the source of orphaned files.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §6.1.13, §6.1.14"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"

--- a/internal/security/registry/data/linux_debian.yaml
+++ b/internal/security/registry/data/linux_debian.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/linux_debian.yaml
+++ b/internal/security/registry/data/linux_debian.yaml
@@ -1,1 +1,197 @@
-# stub: findings for this platform/family are pending implementation
+# Debian family finding definitions for the orkowatch registry.
+# Covers Debian, Ubuntu, Kali, Parrot, Pop!_OS, Mint, and derivatives
+# identified via ID_LIKE=debian in /etc/os-release.
+# Severity tiers follow CVSS v3.1 base score ranges:
+#   CRITICAL 9.0-10.0 | HIGH 7.0-8.9 | MEDIUM 4.0-6.9 | LOW 0.1-3.9
+# All entries sourced from CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0,
+# NIST SP 800-53 Rev 5, and CVSS v3.1 scoring methodology.
+
+# -------------------------
+# Firewall checker findings
+# -------------------------
+
+firewall.ufw_inactive:
+  title: "UFW firewall is installed but not active"
+  severity: "HIGH"
+  cvss_score: 8.2
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H"
+  cwe: "CWE-284"
+  description: >
+    Uncomplicated Firewall (UFW) is the default firewall management tool
+    on Debian and Ubuntu systems. UFW is installed but reported as inactive,
+    meaning no host-based packet filtering is enforced on any network
+    interface despite the tool being present.
+  impact: >
+    All listening services are reachable on all interfaces without
+    restriction. UFW being inactive despite installation suggests the
+    firewall was intentionally disabled or never enabled after installation,
+    leaving the host without a host-based network control layer.
+  resolution: >
+    Enable UFW and configure a default-deny policy: ufw default deny
+    incoming && ufw default allow outgoing && ufw enable. Add explicit
+    allow rules for required services before enabling to avoid lockout:
+    ufw allow ssh.
+  references:
+    - "CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0 §3.5.1"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+firewall.ufw_not_installed:
+  title: "No recognized firewall manager is installed"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-284"
+  description: >
+    Neither UFW nor any other recognized firewall manager (iptables,
+    nftables, firewalld) was detected on this Debian-family system.
+    The host has no host-based packet filtering installed or active.
+  impact: >
+    All services bound to network interfaces are directly reachable without
+    any network-level access control. This eliminates host-based boundary
+    protection entirely and maximizes exposure of all listening services
+    to the network.
+  resolution: >
+    Install and enable UFW: apt install ufw && ufw default deny incoming
+    && ufw default allow outgoing && ufw allow ssh && ufw enable. Verify
+    status with: ufw status verbose.
+  references:
+    - "CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0 §3.5.1"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+# -------------------------
+# User checker findings
+# -------------------------
+
+users.sudo_nopasswd:
+  title: "Sudoers entry permits privilege escalation without password"
+  severity: "HIGH"
+  cvss_score: 8.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+  cwe: "CWE-269"
+  description: >
+    A sudoers rule contains the NOPASSWD tag, allowing one or more users
+    to execute commands with elevated privileges without providing a
+    password. This is commonly found in /etc/sudoers or files under
+    /etc/sudoers.d/ on Debian-family systems.
+  impact: >
+    Any attacker or process that gains access to the affected user account
+    can immediately escalate to root or another privileged user without
+    any additional credential. This eliminates the password barrier for
+    privilege escalation entirely for the affected account.
+  resolution: >
+    Remove NOPASSWD tags from sudoers rules unless operationally required.
+    Edit safely with: visudo. If NOPASSWD is required for automation,
+    scope it to the minimum required commands rather than ALL.
+  references:
+    - "CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0 §5.3.7"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/269.html"
+
+users.passwd_no_shadow:
+  title: "Password hashes stored in /etc/passwd instead of /etc/shadow"
+  severity: "HIGH"
+  cvss_score: 7.5
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-522"
+  description: >
+    One or more user accounts have password hashes stored directly in
+    /etc/passwd rather than /etc/shadow. The passwd file is world-readable
+    by design, meaning password hashes are exposed to all local users and
+    potentially to processes that can read the filesystem.
+  impact: >
+    World-readable password hashes can be extracted by any local user and
+    subjected to offline cracking without any privilege escalation. Weak
+    or reused passwords will be cracked quickly with modern tooling.
+  resolution: >
+    Run pwconv to migrate password hashes to /etc/shadow and set the
+    passwd field to x for all accounts. Verify with: pwck -r. Ensure
+    /etc/shadow has permissions 000 or 640 with root ownership.
+  references:
+    - "CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0 §6.2.2"
+    - "NIST SP 800-53 Rev 5 IA-5 (Authenticator Management)"
+    - "https://cwe.mitre.org/data/definitions/522.html"
+
+# -------------------------
+# Permissions checker findings
+# -------------------------
+
+permissions.shadow_world_readable:
+  title: "/etc/shadow is readable by non-root users"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:N"
+  cwe: "CWE-732"
+  description: >
+    /etc/shadow has permissions that allow non-root users to read its
+    contents. The shadow file contains hashed passwords for all local
+    accounts. On Debian-family systems the expected permission is 640
+    with ownership root:shadow, or 000 on some configurations.
+  impact: >
+    Any local user or process that can read /etc/shadow gains access to
+    all local password hashes. These can be subjected to offline cracking
+    without further exploitation. Cracked credentials enable lateral
+    movement and privilege escalation.
+  resolution: >
+    Restore correct permissions immediately: chmod 640 /etc/shadow &&
+    chown root:shadow /etc/shadow. Verify with: ls -la /etc/shadow.
+    Rotate passwords for all local accounts as a precaution if the
+    file was readable for an unknown period.
+  references:
+    - "CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0 §6.1.3"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.sudoers_world_readable:
+  title: "/etc/sudoers has overly permissive permissions"
+  severity: "HIGH"
+  cvss_score: 7.1
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-732"
+  description: >
+    /etc/sudoers has permissions that exceed the expected 0440 mode.
+    The sudoers file defines privilege escalation rules for the system.
+    Overly permissive modes allow unauthorized users to read escalation
+    rules or, if writable, modify them.
+  impact: >
+    A readable sudoers file exposes the full privilege escalation policy
+    to any local user, revealing which accounts can escalate and to what
+    commands. A writable sudoers file allows direct injection of NOPASSWD
+    rules for any account.
+  resolution: >
+    Restore correct permissions: chmod 440 /etc/sudoers && chown
+    root:root /etc/sudoers. Apply the same to files under /etc/sudoers.d/.
+    Always edit sudoers via visudo to prevent syntax errors that could
+    break sudo access.
+  references:
+    - "CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0 §5.3.2"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.ssh_dir_permissions:
+  title: "SSH directory or authorized_keys has incorrect permissions"
+  severity: "HIGH"
+  cvss_score: 7.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-732"
+  description: >
+    A user's ~/.ssh directory or ~/.ssh/authorized_keys file has
+    permissions that exceed the expected mode. OpenSSH enforces strict
+    permission requirements and may refuse to use keys from directories
+    or files with overly permissive modes, but misconfigured permissions
+    also allow unauthorized key injection.
+  impact: >
+    World or group writable ~/.ssh directories allow other users to inject
+    authorized keys, granting themselves SSH access as the target user.
+    If the target user has sudo access, this enables full privilege
+    escalation via key injection without touching any password.
+  resolution: >
+    Set correct permissions: chmod 700 ~/.ssh && chmod 600
+    ~/.ssh/authorized_keys. Verify ownership is correct: chown -R
+    <user>:<user> ~/.ssh. Audit authorized_keys contents for unexpected
+    entries.
+  references:
+    - "CIS Ubuntu Linux 22.04 LTS Benchmark v1.0.0 §5.2.19"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"

--- a/internal/security/registry/data/linux_fedora.yaml
+++ b/internal/security/registry/data/linux_fedora.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/linux_rhel.yaml
+++ b/internal/security/registry/data/linux_rhel.yaml
@@ -1,1 +1,283 @@
-# stub: findings for this platform/family are pending implementation
+# RHEL family finding definitions for the orkowatch registry.
+# Covers RHEL, CentOS, Rocky Linux, AlmaLinux, Oracle Linux, Amazon Linux,
+# and derivatives identified via ID_LIKE=rhel in /etc/os-release.
+# Severity tiers follow CVSS v3.1 base score ranges:
+#   CRITICAL 9.0-10.0 | HIGH 7.0-8.9 | MEDIUM 4.0-6.9 | LOW 0.1-3.9
+# All entries sourced from CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0,
+# NIST SP 800-53 Rev 5, and CVSS v3.1 scoring methodology.
+
+# -------------------------
+# Firewall checker findings
+# -------------------------
+
+firewall.firewalld_not_running:
+  title: "firewalld is installed but not running"
+  severity: "HIGH"
+  cvss_score: 8.2
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H"
+  cwe: "CWE-284"
+  description: >
+    firewalld is the default firewall management tool on RHEL-family systems.
+    The service is installed but not in a running state, meaning no
+    host-based packet filtering is enforced on any network interface
+    despite the tool being present.
+  impact: >
+    All listening services are reachable on all interfaces without
+    restriction. firewalld being inactive despite installation suggests
+    the service was stopped or disabled after installation, leaving
+    the host without a host-based network control layer.
+  resolution: >
+    Enable and start firewalld: systemctl enable --now firewalld.
+    Verify status with: firewall-cmd --state. Configure zones and
+    services appropriate to the host role. Add required service rules
+    before enabling to avoid lockout: firewall-cmd --permanent
+    --add-service=ssh && firewall-cmd --reload.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §3.5.1"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+firewall.firewalld_not_installed:
+  title: "No recognized firewall manager is installed"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-284"
+  description: >
+    Neither firewalld nor any other recognized firewall manager (iptables,
+    nftables) was detected on this RHEL-family system. The host has no
+    host-based packet filtering installed or active.
+  impact: >
+    All services bound to network interfaces are directly reachable without
+    any network-level access control. This eliminates host-based boundary
+    protection entirely and maximizes exposure of all listening services
+    to the network.
+  resolution: >
+    Install and enable firewalld: dnf install firewalld && systemctl
+    enable --now firewalld. Configure default zone policy to drop or
+    reject and add explicit rules for required services.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §3.5.1"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+firewall.firewalld_default_zone_public:
+  title: "firewalld default zone is set to public"
+  severity: "MEDIUM"
+  cvss_score: 5.3
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+  cwe: "CWE-284"
+  description: >
+    The firewalld default zone is set to public, which is the least
+    restrictive predefined zone and permits ssh and dhcpv6-client
+    services by default. On RHEL-family servers, the default zone
+    should reflect the actual network trust level of the primary
+    interface.
+  impact: >
+    Interfaces assigned to the public zone permit inbound SSH and
+    DHCPv6 client traffic by default without explicit administrator
+    action. Additional services added without zone consideration may
+    be inadvertently exposed on the public zone.
+  resolution: >
+    Review and set the default zone appropriate to the deployment
+    environment: firewall-cmd --set-default-zone=<zone>. For servers,
+    the drop or block zone with explicit service allowances is more
+    appropriate than public.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §3.5.1.4"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+# -------------------------
+# User checker findings
+# -------------------------
+
+users.sudo_nopasswd:
+  title: "Sudoers entry permits privilege escalation without password"
+  severity: "HIGH"
+  cvss_score: 8.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+  cwe: "CWE-269"
+  description: >
+    A sudoers rule contains the NOPASSWD tag, allowing one or more users
+    to execute commands with elevated privileges without providing a
+    password. On RHEL-family systems this is commonly found in
+    /etc/sudoers or files under /etc/sudoers.d/.
+  impact: >
+    Any attacker or process that gains access to the affected user account
+    can immediately escalate to root or another privileged user without
+    any additional credential. This eliminates the password barrier for
+    privilege escalation entirely for the affected account.
+  resolution: >
+    Remove NOPASSWD tags from sudoers rules unless operationally required.
+    Edit safely with: visudo. If NOPASSWD is required for automation,
+    scope it to the minimum required commands rather than ALL.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §5.3.7"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/269.html"
+
+users.wheel_group_empty:
+  title: "The wheel group has no members"
+  severity: "LOW"
+  cvss_score: 2.1
+  cvss_vector: "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:L/A:N"
+  cwe: "CWE-269"
+  description: >
+    The wheel group, which controls sudo access on RHEL-family systems,
+    has no members. On systems where the sudoers configuration grants
+    sudo access to the wheel group, an empty wheel group means no
+    standard user has a defined path to administrative access.
+  impact: >
+    Administrators may be using direct root login or undefined privilege
+    escalation paths that bypass audit logging. Lack of wheel group
+    membership may indicate sudo is not properly configured as the
+    primary escalation mechanism.
+  resolution: >
+    Add appropriate administrator accounts to the wheel group:
+    usermod -aG wheel <username>. Verify sudoers grants wheel group
+    access: grep wheel /etc/sudoers. Ensure direct root login is
+    disabled and sudo is the sole escalation path.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §5.3"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/269.html"
+
+users.passwd_no_shadow:
+  title: "Password hashes stored in /etc/passwd instead of /etc/shadow"
+  severity: "HIGH"
+  cvss_score: 7.5
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-522"
+  description: >
+    One or more user accounts have password hashes stored directly in
+    /etc/passwd rather than /etc/shadow. The passwd file is world-readable
+    by design, meaning password hashes are exposed to all local users and
+    any process that can read the filesystem.
+  impact: >
+    World-readable password hashes can be extracted by any local user and
+    subjected to offline cracking without any privilege escalation required.
+    Weak or reused passwords will be cracked quickly with modern tooling.
+  resolution: >
+    Run pwconv to migrate password hashes to /etc/shadow and replace
+    passwd field entries with x. Verify with: pwck -r. Ensure /etc/shadow
+    has permissions 000 with root ownership on RHEL-family systems.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §6.2.2"
+    - "NIST SP 800-53 Rev 5 IA-5 (Authenticator Management)"
+    - "https://cwe.mitre.org/data/definitions/522.html"
+
+# -------------------------
+# Permissions checker findings
+# -------------------------
+
+permissions.shadow_world_readable:
+  title: "/etc/shadow is readable by non-root users"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:N"
+  cwe: "CWE-732"
+  description: >
+    /etc/shadow has permissions that allow non-root users to read its
+    contents. On RHEL-family systems the expected permission is 000
+    with ownership root:root. Any deviation allows password hash
+    extraction by unprivileged users.
+  impact: >
+    Any local user or process that can read /etc/shadow gains access to
+    all local password hashes. These can be subjected to offline cracking
+    without further exploitation. Cracked credentials enable lateral
+    movement and privilege escalation across any system sharing those
+    credentials.
+  resolution: >
+    Restore correct permissions immediately: chmod 000 /etc/shadow &&
+    chown root:root /etc/shadow. Verify with: ls -la /etc/shadow.
+    Rotate passwords for all local accounts as a precaution if the
+    file was readable for an unknown period.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §6.1.3"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.sudoers_world_readable:
+  title: "/etc/sudoers has overly permissive permissions"
+  severity: "HIGH"
+  cvss_score: 7.1
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-732"
+  description: >
+    /etc/sudoers has permissions that exceed the expected 0440 mode.
+    The sudoers file defines privilege escalation rules for the system.
+    Overly permissive modes allow unauthorized users to read escalation
+    rules or, if writable, modify them directly.
+  impact: >
+    A readable sudoers file exposes the full privilege escalation policy
+    to any local user, revealing which accounts can escalate and to what
+    commands. A writable sudoers file allows direct injection of NOPASSWD
+    rules, granting immediate root access to any account.
+  resolution: >
+    Restore correct permissions: chmod 440 /etc/sudoers && chown
+    root:root /etc/sudoers. Apply the same to all files under
+    /etc/sudoers.d/. Always edit via visudo to prevent syntax errors
+    that could break sudo access entirely.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §5.3.2"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.ssh_dir_permissions:
+  title: "SSH directory or authorized_keys has incorrect permissions"
+  severity: "HIGH"
+  cvss_score: 7.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-732"
+  description: >
+    A user's ~/.ssh directory or ~/.ssh/authorized_keys file has
+    permissions that exceed the expected mode. OpenSSH on RHEL-family
+    systems enforces strict permission requirements via StrictModes and
+    will refuse keys from directories or files with overly permissive
+    modes, but misconfigured permissions also enable unauthorized key
+    injection.
+  impact: >
+    World or group writable ~/.ssh directories allow other local users
+    to inject authorized keys, granting themselves SSH access as the
+    target user without knowing their password. If the target user has
+    wheel or sudo access, this enables full privilege escalation.
+  resolution: >
+    Set correct permissions: chmod 700 ~/.ssh && chmod 600
+    ~/.ssh/authorized_keys. Verify ownership: chown -R <user>:<user>
+    ~/.ssh. Audit authorized_keys contents for unexpected entries.
+    Enable SSH StrictModes in sshd_config if not already set.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §5.2.19"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.selinux_disabled:
+  title: "SELinux is disabled or set to permissive mode"
+  severity: "HIGH"
+  cvss_score: 7.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-284"
+  description: >
+    SELinux is either disabled or configured in permissive mode on this
+    RHEL-family system. SELinux provides mandatory access controls that
+    confine processes and users beyond standard POSIX permissions.
+    Permissive mode logs policy violations but does not enforce them.
+    Disabled mode provides no MAC enforcement whatsoever.
+  impact: >
+    Without SELinux enforcement, process confinement is absent. A
+    compromised service running as a confined SELinux type would normally
+    be restricted from accessing resources outside its policy domain.
+    Without enforcement, a compromised process has the full permissions
+    of its Unix user, significantly expanding the blast radius of any
+    exploitation.
+  resolution: >
+    Set SELinux to enforcing mode in /etc/selinux/config:
+    SELINUX=enforcing. Apply immediately without reboot: setenforce 1.
+    Resolve any AVC denials before switching to enforcing to avoid
+    service disruption: ausearch -m avc | audit2allow.
+  references:
+    - "CIS Red Hat Enterprise Linux 9 Benchmark v1.0.0 §1.6.1"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "NIST SP 800-53 Rev 5 SI-16 (Memory Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"

--- a/internal/security/registry/data/linux_rhel.yaml
+++ b/internal/security/registry/data/linux_rhel.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/linux_suse.yaml
+++ b/internal/security/registry/data/linux_suse.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/unix_freebsd.yaml
+++ b/internal/security/registry/data/unix_freebsd.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/unix_openbsd.yaml
+++ b/internal/security/registry/data/unix_openbsd.yaml
@@ -1,0 +1,1 @@
+# stub: findings for this platform/family are pending implementation

--- a/internal/security/registry/data/windows.yaml
+++ b/internal/security/registry/data/windows.yaml
@@ -1,0 +1,326 @@
+# Windows finding definitions for the orkowatch registry.
+# Severity tiers follow CVSS v3.1 base score ranges:
+#   CRITICAL 9.0-10.0 | HIGH 7.0-8.9 | MEDIUM 4.0-6.9 | LOW 0.1-3.9
+# All entries are sourced from CIS Windows 11 Benchmark v3.0.0,
+# NIST SP 800-53 Rev 5, and CVSS v3.1 scoring methodology.
+
+# -------------------------
+# SSH checker findings
+# -------------------------
+
+ssh.server_not_running:
+  title: "OpenSSH Server installed but not running"
+  severity: "MEDIUM"
+  cvss_score: 5.3
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
+  cwe: "CWE-16"
+  description: >
+    The OpenSSH Server (sshd) service is installed but currently stopped.
+    An installed but inactive SSH daemon represents an unmanaged attack
+    surface that any administrator-level process or user can start without
+    additional installation steps.
+  impact: >
+    If started, an unconfigured or default-configured SSH service may permit
+    password authentication or expose the system to brute-force attacks.
+    Presence alone indicates unreviewed remote access capability.
+  resolution: >
+    If SSH is not required, remove the OpenSSH Server optional feature via
+    Settings > Apps > Optional Features. If required, configure
+    C:\ProgramData\ssh\sshd_config before enabling the service and restrict
+    access via Windows Firewall rules.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §18.10.56"
+    - "NIST SP 800-53 Rev 5 CM-7 (Least Functionality)"
+    - "https://cwe.mitre.org/data/definitions/16.html"
+
+ssh.config_missing:
+  title: "OpenSSH configuration file not found"
+  severity: "MEDIUM"
+  cvss_score: 5.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L"
+  cwe: "CWE-16"
+  description: >
+    No sshd_config file was found at C:\ProgramData\ssh\sshd_config.
+    Without an explicit configuration file, sshd falls back to compiled-in
+    defaults which may permit password authentication and use deprecated
+    algorithms.
+  impact: >
+    Default SSH configurations frequently fail CIS and DISA STIG requirements.
+    An attacker who starts the SSH service inherits permissive defaults,
+    potentially enabling credential-based remote access without restriction.
+  resolution: >
+    Create C:\ProgramData\ssh\sshd_config with explicit directives for
+    PasswordAuthentication, PermitRootLogin, and AllowedUsers before
+    enabling the sshd service.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §18.10.56.2"
+    - "NIST SP 800-53 Rev 5 CM-6 (Configuration Settings)"
+    - "https://cwe.mitre.org/data/definitions/16.html"
+
+ssh.root_login_permitted:
+  title: "SSH PermitRootLogin is not explicitly disabled"
+  severity: "CRITICAL"
+  cvss_score: 9.8
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-250"
+  description: >
+    The SSH configuration does not explicitly set PermitRootLogin to no.
+    Direct privileged login over SSH gives an attacker full system control
+    upon credential compromise with no privilege escalation step required.
+  impact: >
+    A successful brute-force or credential stuffing attack against the root
+    or Administrator account yields immediate full control of the host.
+    No additional exploitation step is required post-authentication.
+  resolution: >
+    Set PermitRootLogin no in C:\ProgramData\ssh\sshd_config and restart
+    the sshd service. Administrative access should require key-based
+    authentication to a non-privileged account followed by explicit
+    privilege escalation.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §18.10.56.3"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "NIST SP 800-53 Rev 5 IA-2 (Identification and Authentication)"
+    - "https://cwe.mitre.org/data/definitions/250.html"
+
+ssh.password_auth_enabled:
+  title: "SSH password authentication is enabled"
+  severity: "HIGH"
+  cvss_score: 7.5
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-521"
+  description: >
+    PasswordAuthentication is set to yes in the SSH configuration.
+    Password-based SSH is susceptible to brute-force and credential
+    stuffing attacks, particularly when accounts have weak or reused
+    passwords.
+  impact: >
+    Any network-accessible SSH service with password authentication enabled
+    can be targeted by automated brute-force tools. Credential exposure
+    from unrelated breaches directly translates to SSH access risk.
+  resolution: >
+    Set PasswordAuthentication no in C:\ProgramData\ssh\sshd_config and
+    configure key-based authentication exclusively. Restart the sshd
+    service after making changes.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §18.10.56"
+    - "NIST SP 800-53 Rev 5 IA-5(1) (Authenticator Management)"
+    - "https://cwe.mitre.org/data/definitions/521.html"
+
+# -------------------------
+# Firewall checker findings
+# -------------------------
+
+firewall.profile_inactive:
+  title: "One or more Windows Firewall profiles are inactive"
+  severity: "CRITICAL"
+  cvss_score: 9.1
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-284"
+  description: >
+    One or more Windows Firewall profiles (Domain, Private, or Public) are
+    not active. A disabled firewall profile removes the host-based packet
+    filter for that network category, exposing all listening services to
+    unauthenticated network traffic matching that profile.
+  impact: >
+    All services bound to network interfaces governed by the inactive profile
+    become directly reachable without firewall enforcement. This eliminates
+    a critical defense-in-depth layer against lateral movement and remote
+    exploitation.
+  resolution: >
+    Enable all firewall profiles via: netsh advfirewall set allprofiles
+    state on. Verify profile state with: netsh advfirewall show allprofiles.
+    Ensure profiles remain enabled via Group Policy if the system is
+    domain-joined.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §9.1.1, §9.2.1, §9.3.1"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "NIST SP 800-53 Rev 5 SI-3 (Malicious Code Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+firewall.all_profiles_disabled:
+  title: "Windows Firewall is completely disabled on all profiles"
+  severity: "CRITICAL"
+  cvss_score: 9.8
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-284"
+  description: >
+    Windows Defender Firewall is disabled across all profiles — Domain,
+    Private, and Public. The host has no active host-based packet filtering
+    on any network interface. This is the highest-risk firewall
+    misconfiguration possible on a Windows host.
+  impact: >
+    Every listening service on every interface is reachable without
+    restriction. Combined with any other vulnerability, this eliminates
+    network-layer mitigation entirely. Lateral movement, exploitation of
+    unpatched services, and data exfiltration face no host-based network
+    controls.
+  resolution: >
+    Immediately enable all firewall profiles: netsh advfirewall set
+    allprofiles state on. Investigate how the firewall was disabled and
+    whether unauthorized access occurred during the period it was inactive.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §9.1.1, §9.2.1, §9.3.1"
+    - "NIST SP 800-53 Rev 5 SC-7 (Boundary Protection)"
+    - "https://cwe.mitre.org/data/definitions/284.html"
+
+# -------------------------
+# User checker findings
+# -------------------------
+
+users.no_password_required:
+  title: "Active user account has no password required"
+  severity: "HIGH"
+  cvss_score: 8.4
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-309"
+  description: >
+    One or more active user accounts have PasswordRequired set to false,
+    meaning Windows does not enforce a password for interactive or network
+    logon. This is distinct from a blank password — the system will not
+    prompt for or validate any credential for these accounts.
+  impact: >
+    Any local attacker, malicious process, or lateral movement attempt can
+    authenticate as this user without any credential. This eliminates the
+    authentication layer entirely for affected accounts and grants access
+    to all resources the account can reach.
+  resolution: >
+    Require passwords for all active accounts via: net user <username> *
+    or via Local Security Policy > Account Policies > Password Policy.
+    Set the account password and ensure PasswordRequired is enforced.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §1.1"
+    - "NIST SP 800-53 Rev 5 IA-5 (Authenticator Management)"
+    - "https://cwe.mitre.org/data/definitions/309.html"
+
+users.administrator_account_active:
+  title: "User account has local Administrator privileges"
+  severity: "MEDIUM"
+  cvss_score: 6.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-250"
+  description: >
+    One or more user accounts are members of the local Administrators group.
+    Administrator-level accounts have unrestricted access to the local
+    system and can bypass most security controls including UAC when
+    configured to auto-elevate.
+  impact: >
+    Compromise of an Administrator account yields full local system control.
+    Combined with credential reuse or weak passwords, Administrator group
+    membership significantly increases the blast radius of any account
+    compromise.
+  resolution: >
+    Limit the local Administrators group to accounts that explicitly require
+    administrative access. Standard users should operate under least-privilege
+    accounts. Review group membership regularly via: Get-LocalGroupMember
+    -Group Administrators.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §2.2"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/250.html"
+
+users.uac_disabled:
+  title: "User Account Control (UAC) is disabled"
+  severity: "CRITICAL"
+  cvss_score: 9.3
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+  cwe: "CWE-250"
+  description: >
+    User Account Control is disabled via the EnableLUA registry key being
+    set to 0. UAC is the primary privilege escalation barrier on Windows.
+    Without it, any process running in the context of a local Administrator
+    account inherits full administrative rights without a consent prompt.
+  impact: >
+    Malware, scripts, or any process running as the logged-in administrator
+    gains unrestricted system access without triggering UAC elevation prompts.
+    This eliminates the integrity level separation that UAC enforces and
+    allows privilege escalation without any user interaction.
+  resolution: >
+    Enable UAC by setting HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\
+    Policies\System\EnableLUA to 1, or via Local Security Policy >
+    Security Options > User Account Control: Run all administrators in
+    Admin Approval Mode. A system restart is required.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §2.3.17"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/250.html"
+
+# -------------------------
+# Permissions checker findings
+# -------------------------
+
+permissions.everyone_full_control:
+  title: "Everyone group has full control on a system path"
+  severity: "CRITICAL"
+  cvss_score: 9.8
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-732"
+  description: >
+    The Everyone group has been granted Full Control (F) on a critical
+    system directory. This grants unrestricted read, write, execute, and
+    delete permissions to all users including unauthenticated network
+    users on some configurations.
+  impact: >
+    Any local or network user can replace, modify, or delete files in the
+    affected directory. On system directories such as System32 or Program
+    Files, this enables DLL planting, binary replacement, and direct
+    privilege escalation without any exploit required.
+  resolution: >
+    Remove the Everyone group permission immediately using icacls:
+    icacls <path> /remove "Everyone". Restore expected ACLs using icacls
+    <path> /reset for system directories. Investigate how this permission
+    was granted.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §2.2"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.users_full_control:
+  title: "Users group has full control on a system path"
+  severity: "HIGH"
+  cvss_score: 7.8
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+  cwe: "CWE-732"
+  description: >
+    The BUILTIN\Users group has been granted Full Control (F) on a critical
+    system directory. Any authenticated local user can read, write, execute,
+    and delete files in this location.
+  impact: >
+    Any standard user account can replace binaries or plant DLLs in the
+    affected system directory, enabling privilege escalation without
+    exploiting any software vulnerability. This is a common DLL hijacking
+    precondition.
+  resolution: >
+    Remove the Full Control grant for BUILTIN\Users and restore read-execute
+    permissions only: icacls <path> /remove:g "BUILTIN\Users" then
+    icacls <path> /grant "BUILTIN\Users:(RX)". Verify against expected
+    Windows ACL baselines.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §2.2"
+    - "NIST SP 800-53 Rev 5 AC-3 (Access Enforcement)"
+    - "https://cwe.mitre.org/data/definitions/732.html"
+
+permissions.admin_share_present:
+  title: "Default administrative shares are present"
+  severity: "LOW"
+  cvss_score: 2.7
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N"
+  cwe: "CWE-284"
+  description: >
+    Default Windows administrative shares (C$, ADMIN$, IPC$) are present.
+    These shares are enabled by default and require Administrator credentials
+    to access remotely. They are informational in most environments but
+    represent a lateral movement path when Administrator credentials are
+    compromised.
+  impact: >
+    An attacker with valid Administrator credentials can use administrative
+    shares for remote file access and lateral movement (e.g. PsExec, WMI,
+    SMB-based tools) without installing any additional software on the target.
+  resolution: >
+    In high-security environments where remote administration is not required,
+    disable administrative shares via registry:
+    HKLM\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters\
+    AutoShareWks = 0. This persists across reboots. IPC$ cannot be disabled.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §18.3"
+    - "NIST SP 800-53 Rev 5 CM-7 (Least Functionality)"
+    - "https://cwe.mitre.org/data/definitions/284.html"

--- a/internal/security/registry/registry.go
+++ b/internal/security/registry/registry.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/papa0four/orkowatch/internal/security/types"
 )
 
 // Platform identifies the host OS family
@@ -47,6 +49,17 @@ const (
 	// Non-Linux Platforms
 	DistroNone    Distro = ""
 	DistroUnknown Distro = "uknown"
+)
+
+// Reference type classifications produced by ToReferences.
+const (
+	RefTypeCVE   = "CVE"
+	RefTypeCWE   = "CWE"
+	RefTypeCIS   = "CIS"
+	RefTypeNIST  = "NIST"
+	RefTypeMITRE = "MITRE"
+	RefTypeURL   = "URL"
+	RefTypeOther = "OTHER"
 )
 
 // OSContext obtains full platform and distro info to pass to auditor before registry lookups
@@ -301,4 +314,60 @@ func containsDistro(families []Distro, d Distro) bool {
 		}
 	}
 	return false
+}
+
+// ToReferences classifies flat YAML reference strings into
+// structured types.Reference entries by kind.
+func (d FindingDefinition) ToReferences() []types.Reference {
+	if len(d.References) == 0 {
+		return nil
+	}
+	out := make([]types.Reference, 0, len(d.References))
+	for _, raw := range d.References {
+		out = append(out, classifyReference(raw))
+	}
+	return out
+}
+
+func classifyReference(raw string) types.Reference {
+	trimmed := strings.TrimSpace(raw)
+
+	switch {
+	case isCWEReference(trimmed):
+		return types.Reference{Title: trimmed, URL: cweURL(trimmed), Type: RefTypeCWE}
+	case isCVEReference(trimmed):
+		return types.Reference{Title: trimmed, URL: cveURL(trimmed), Type: RefTypeCVE}
+	case strings.HasPrefix(trimmed, "CIS "):
+		return types.Reference{Title: trimmed, Type: RefTypeCIS}
+	case strings.HasPrefix(trimmed, "NIST "):
+		return types.Reference{Title: trimmed, Type: RefTypeNIST}
+	case strings.HasPrefix(trimmed, "MITRE "):
+		return types.Reference{Title: trimmed, Type: RefTypeMITRE}
+	case strings.HasPrefix(trimmed, "https://") || strings.HasPrefix(trimmed, "http://"):
+		return types.Reference{Title: trimmed, URL: trimmed, Type: RefTypeURL}
+	default:
+		return types.Reference{Title: trimmed, Type: RefTypeOther}
+	}
+}
+
+func isCWEReference(s string) bool {
+	return strings.HasPrefix(s, "CWE-") || strings.HasPrefix(s, "https://cwe.mitre.org/")
+}
+
+func isCVEReference(s string) bool {
+	return strings.HasPrefix(s, "CVE-") || strings.HasPrefix(s, "https://nvd.nist.gov/vuln/detail/CVE-")
+}
+
+func cweURL(s string) string {
+	if strings.HasPrefix(s, "https://") {
+		return s
+	}
+	return "https://cwe.mitre.org/data/definitions/" + strings.TrimPrefix(s, "CWE-") + ".html"
+}
+
+func cveURL(s string) string {
+	if strings.HasPrefix(s, "https://") {
+		return s
+	}
+	return "https://nvd.nist.gov/vuln/detail/" + s
 }

--- a/internal/security/registry/registry.go
+++ b/internal/security/registry/registry.go
@@ -1,0 +1,304 @@
+// internal/security/registry/registry.go
+package registry
+
+import (
+	"bufio"
+	_ "embed"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Platform identifies the host OS family
+type Platform string
+
+// Distro indentifies a *Nix distro family *if Windows, unused
+type Distro string
+
+// <checker>.<finding_id> to join checker detection logic and registry data
+type FindingKey string
+
+// Platform constants
+const (
+	PlatformWindows Platform = "windows"
+	PlatformLinux   Platform = "linux"
+	PlatformDarwin  Platform = "darwin"
+	PlatformUnix    Platform = "unix"
+	PlatformUnknown Platform = "unknown"
+)
+
+// Distro family constants where derivatives resolve to parent family
+const (
+	// Linux Families
+	DistroDebian  Distro = "debian"
+	DistroRHEL    Distro = "rhel"
+	DistroFedora  Distro = "fedora"
+	DistroArch    Distro = "arch"
+	DistroSUSE    Distro = "suse"
+	DistroAlpine  Distro = "alpine"
+	DistroGeneric Distro = "generic"
+
+	// Unix Families
+	DistroFreeBSD Distro = "freebsd"
+	DistroOpenBSD Distro = "openbsd"
+	DistroNetBSD  Distro = "netbsd"
+
+	// Non-Linux Platforms
+	DistroNone    Distro = ""
+	DistroUnknown Distro = "uknown"
+)
+
+// OSContext obtains full platform and distro info to pass to auditor before registry lookups
+type OSContext struct {
+	Platform Platform
+	Families []Distro
+}
+
+// FindingDefinition is a registry map for types.Finding
+type FindingDefinition struct {
+	Title       string   `yaml:"title"`
+	Severity    string   `yaml:"severity"`
+	CVSSScore   float64  `yaml:"cvss_score"`
+	CVSSVector  string   `yaml:"cvss_vector"`
+	CWE         string   `yaml:"cwe"`
+	Description string   `yaml:"description"`
+	Impact      string   `yaml:"impact"`
+	Resolution  string   `yaml:"resolution"`
+	References  []string `yaml:"references"`
+}
+
+// platformRegistry holds all indexed definitions
+type platformRegistry map[Platform]map[FindingKey]FindingDefinition
+
+// Linux family registry holds distro index findings
+type linuxFamilyRegistry map[Distro]map[FindingKey]FindingDefinition
+
+var (
+	registry      platformRegistry
+	linuxRegistry linuxFamilyRegistry
+)
+
+//go:embed data/windows.yaml
+var windowsData []byte
+
+//go:embed data/linux_common.yaml
+var linuxCommonData []byte
+
+//go:embed data/linux_debian.yaml
+var linuxDebianData []byte
+
+//go:embed data/linux_rhel.yaml
+var linuxRHELData []byte
+
+//go:embed data/linux_arch.yaml
+var linuxArchData []byte
+
+//go:embed data/linux_fedora.yaml
+var linuxFedoraData []byte
+
+//go:embed data/linux_suse.yaml
+var linuxSUSEData []byte
+
+//go:embed data/linux_alpine.yaml
+var linuxAlpineData []byte
+
+//go:embed data/darwin.yaml
+var darwinData []byte
+
+//go:embed data/unix_freebsd.yaml
+var unixFreeBSDData []byte
+
+//go:embed data/unix_openbsd.yaml
+var unixOpenBSDData []byte
+
+func init() {
+	registry = make(platformRegistry)
+	linuxRegistry = make(linuxFamilyRegistry)
+
+	registry[PlatformWindows] = mustLoad(windowsData)
+	registry[PlatformDarwin] = mustLoad(darwinData)
+
+	linuxRegistry[DistroGeneric] = mustLoad(linuxCommonData)
+	linuxRegistry[DistroDebian] = mustLoad(linuxDebianData)
+	linuxRegistry[DistroRHEL] = mustLoad(linuxRHELData)
+	linuxRegistry[DistroArch] = mustLoad(linuxArchData)
+	linuxRegistry[DistroFedora] = mustLoad(linuxFedoraData)
+	linuxRegistry[DistroSUSE] = mustLoad(linuxSUSEData)
+	linuxRegistry[DistroAlpine] = mustLoad(linuxAlpineData)
+
+	unixRegistry := make(map[Distro]map[FindingKey]FindingDefinition)
+	unixRegistry[DistroFreeBSD] = mustLoad(unixFreeBSDData)
+	unixRegistry[DistroOpenBSD] = mustLoad(unixOpenBSDData)
+	registry[PlatformUnix] = flattenUnix(unixRegistry)
+}
+
+// mustLoad parses a byte slice into a finding map
+func mustLoad(data []byte) map[FindingKey]FindingDefinition {
+	var raw map[string]FindingDefinition
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		panic("registry: failed to parse embedded YAML: " + err.Error())
+	}
+	out := make(map[FindingKey]FindingDefinition, len(raw))
+	for k, v := range raw {
+		out[FindingKey(k)] = v
+	}
+	return out
+}
+
+// flattenUnix merges unix family maps into a distro key map
+func flattenUnix(families map[Distro]map[FindingKey]FindingDefinition) map[FindingKey]FindingDefinition {
+	out := make(map[FindingKey]FindingDefinition)
+	for family, findings := range families {
+		for key, def := range findings {
+			prefixed := FindingKey(string(family) + "." + string(key))
+			out[prefixed] = def
+		}
+	}
+	return out
+}
+
+// Lookup retrieves a FindingDefinition for the given OSContext and key.
+func Lookup(ctx OSContext, key FindingKey) (FindingDefinition, bool) {
+	switch ctx.Platform {
+	case PlatformLinux:
+		for _, family := range ctx.Families {
+			if fm, ok := linuxRegistry[family]; ok {
+				if def, ok := fm[key]; ok {
+					return def, true
+				}
+			}
+		}
+		// fall through to common Linux findings
+		if def, ok := linuxRegistry[DistroGeneric][key]; ok {
+			return def, true
+		}
+		return FindingDefinition{}, false
+
+	default:
+		if pm, ok := registry[ctx.Platform]; ok {
+			if def, ok := pm[key]; ok {
+				return def, true
+			}
+		}
+		return FindingDefinition{}, false
+	}
+}
+
+// DetectOS identifies the current platform and, for Linux, resolves
+// the full distribution family chain from /etc/os-release.
+func DetectOS() OSContext {
+	switch platform := detectPlatform(); platform {
+	case PlatformLinux:
+		return OSContext{
+			Platform: PlatformLinux,
+			Families: detectLinuxFamilies(),
+		}
+	default:
+		return OSContext{Platform: platform}
+	}
+}
+
+// detectPlatform returns the Platform either via runtime.GOOS or /etc/os-release
+func detectPlatform() Platform {
+	// Check for Linux first via os-release presence
+	if _, err := os.Stat("/etc/os-release"); err == nil {
+		return PlatformLinux
+	}
+	// macOS
+	if _, err := os.Stat("/System/Library/CoreServices/SystemVersion.plist"); err == nil {
+		return PlatformDarwin
+	}
+	// FreeBSD / OpenBSD / NetBSD
+	if _, err := os.Stat("/etc/rc.conf"); err == nil {
+		return PlatformUnix
+	}
+	// Windows — none of the above exist
+	return PlatformWindows
+}
+
+// detectLinuxFamilies parses /etc/os-release and returns the
+// distro family chain ordered from most specific to least specific.
+func detectLinuxFamilies() []Distro {
+	file, err := os.Open("/etc/os-release")
+	if err != nil {
+		return []Distro{DistroGeneric}
+	}
+	defer file.Close() // nolint:errcheck // read-only file
+
+	var id, idLike string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "ID="):
+			id = strings.Trim(strings.TrimPrefix(line, "ID="), `"`)
+		case strings.HasPrefix(line, "ID_LIKE="):
+			idLike = strings.Trim(strings.TrimPrefix(line, "ID_LIKE="), `"`)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return []Distro{DistroGeneric}
+	}
+
+	var families []Distro
+
+	// Resolve the specific ID to a known family
+	if f := resolveDistro(id); f != DistroUnknown {
+		families = append(families, f)
+	}
+
+	// Walk ID_LIKE parent families in declared order
+	for _, parent := range strings.Fields(idLike) {
+		if f := resolveDistro(parent); f != DistroUnknown {
+			// avoid duplicates
+			if !containsDistro(families, f) {
+				families = append(families, f)
+			}
+		}
+	}
+
+	// Always terminate with generic as the final fallback
+	if !containsDistro(families, DistroGeneric) {
+		families = append(families, DistroGeneric)
+	}
+
+	return families
+}
+
+// resolveDistro maps a raw os-release ID or ID_LIKE token to a known Distro family constant.
+func resolveDistro(id string) Distro {
+	switch strings.ToLower(id) {
+	case "debian", "ubuntu", "linuxmint", "pop", "kali", "parrot",
+		"elementary", "raspbian", "zorin":
+		return DistroDebian
+	case "rhel", "centos", "rocky", "almalinux", "ol", "amzn":
+		return DistroRHEL
+	case "fedora":
+		return DistroFedora
+	case "arch", "manjaro", "endeavouros", "garuda", "artix":
+		return DistroArch
+	case "opensuse", "opensuse-leap", "opensuse-tumbleweed", "sles":
+		return DistroSUSE
+	case "alpine":
+		return DistroAlpine
+	case "freebsd":
+		return DistroFreeBSD
+	case "openbsd":
+		return DistroOpenBSD
+	case "netbsd":
+		return DistroNetBSD
+	default:
+		return DistroUnknown
+	}
+}
+
+// containsDistro reports whether d is present in families.
+func containsDistro(families []Distro, d Distro) bool {
+	for _, f := range families {
+		if f == d {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/security/registry/registry.go
+++ b/internal/security/registry/registry.go
@@ -16,7 +16,7 @@ type Platform string
 // Distro indentifies a *Nix distro family *if Windows, unused
 type Distro string
 
-// <checker>.<finding_id> to join checker detection logic and registry data
+// FindingKey formatted <checker>.<finding_id> to join checker detection logic and registry data
 type FindingKey string
 
 // Platform constants

--- a/internal/security/types/types.go
+++ b/internal/security/types/types.go
@@ -4,6 +4,8 @@ package types
 import (
 	"fmt"
 	"time"
+
+	"github.com/papa0four/orkowatch/internal/security/enrichment"
 )
 
 // Status symbols for check results
@@ -71,6 +73,20 @@ type ValidationError struct {
 	Message string
 }
 
+// ClassifiedReference is a non-CWE reference annotated by type.
+type ClassifiedReference struct {
+	Type  string
+	Value string
+}
+
+// ReferenceExtraction separates valid CWEs from malformed CWE attempts
+// and non-CWE references.
+type ReferenceExtraction struct {
+	CWEs   []string
+	Errors []error
+	Other  []ClassifiedReference
+}
+
 func (e *ValidationError) Error() string {
 	return fmt.Sprintf("validation error in %s: %s - %s", e.Checker, e.Field, e.Message)
 }
@@ -89,4 +105,60 @@ func SeverityFormat(severity string) (symbol, label string) {
 	default:
 		return SymbolInfo, severity
 	}
+}
+
+// CWEReferences returns the CWE IDs referenced by this
+// finding, deduplicated. Order matches first occurrence.
+func (f *Finding) CWEReferences() ReferenceExtraction {
+	var ext ReferenceExtraction
+	if len(f.References) == 0 {
+		return ext
+	}
+	seen := make(map[string]struct{}, len(f.References))
+	for _, ref := range f.References {
+		if ref.Type == "CWE" {
+			id, err := enrichment.NormalizeCWEID(ref.URL)
+			if err != nil {
+				id, err = enrichment.NormalizeCWEID(ref.Title)
+			}
+			if err != nil {
+				ext.Errors = append(ext.Errors, err)
+				continue
+			}
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			ext.CWEs = append(ext.CWEs, id)
+			continue
+		}
+		ext.Other = append(ext.Other, ClassifiedReference{
+			Type:  ref.Type,
+			Value: ref.Title,
+		})
+	}
+	return ext
+}
+
+// AllCWEReferences returns the canonical CWE IDs across all findings
+// in this result, deduplicated. Order matches first occurrence.
+func (r *AuditResult) AllCWEReferences() ReferenceExtraction {
+	var ext ReferenceExtraction
+	if len(r.Findings) == 0 {
+		return ext
+	}
+	seen := make(map[string]struct{})
+	for i := range r.Findings {
+		sub := r.Findings[i].CWEReferences()
+		for _, id := range sub.CWEs {
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			ext.CWEs = append(ext.CWEs, id)
+		}
+		ext.Errors = append(ext.Errors, sub.Errors...)
+		ext.Other = append(ext.Other, sub.Other...)
+	}
+	return ext
 }

--- a/internal/security/types/types.go
+++ b/internal/security/types/types.go
@@ -74,3 +74,19 @@ type ValidationError struct {
 func (e *ValidationError) Error() string {
 	return fmt.Sprintf("validation error in %s: %s - %s", e.Checker, e.Field, e.Message)
 }
+
+// SeverityFormat returns the display symbol and fixed-width padded severity label
+func SeverityFormat(severity string) (symbol, label string) {
+	switch severity {
+	case SeverityCritical:
+		return SymbolCritical, "CRITICAL"
+	case SeverityHigh:
+		return SymbolWarning, "HIGH    "
+	case SeverityMedium:
+		return SymbolWarning, "MEDIUM  "
+	case SeverityLow:
+		return SymbolInfo, "LOW     "
+	default:
+		return SymbolInfo, severity
+	}
+}


### PR DESCRIPTION
## Summary

Closes the original non-verbose output gap and resolves a chain of related correctness issues discovered during cross-platform output validation on Windows and Ubuntu. All changes have been validated locally on both platforms. CI pipeline passes.

## Changes

### Output and formatter fixes

- Removed the no-checks guard from `security_unix.go` and `security_windows.go` -- running `security_audit` with no flags now runs all checks instead of printing help
- Fixed extra blank lines between check blocks in `all` non-verbose output by tightening `{{end}}` placement in `defaultTemplate`
- Fixed `convertToAuditResult` in `all.go` to carry `EnrichmentRequested`, `EnrichmentError`, `Enrichment`, and `References` forward so `--enrich` works correctly through the `all` command path

### Registry wiring fixes

- `ssh.go` -- `ctx` is now stored on `UnixSSHChecker`; registry lookups for all Unix SSH finding keys were silently failing against a zero-value `OSContext`
- `firewall.go` -- added `ctx` field to `UnixFirewallChecker`, updated `NewUnixFirewallChecker` to accept and store `ctx`, added `registry.Lookup` call for `firewall.no_active_manager` when no active firewall is detected, updated call site in `audit.go`

### Sub-branches merged

- `bug/29` -- Windows audit correctness
- `chore/38` -- registry foundation
- `enhancement/40` -- Windows structured findings
- `enhancement/42` -- Unix structured findings and `authConfigResult` pattern
- `bug/44` -- findings-based summary scoring
- `bug/46` -- formatter overhaul and `SeverityFormat` centralization
- `enhancement/48` -- enrichment subsystem scaffold and `--enrich` flag
- `docs/49` -- enrichment subsystem contributor documentation

## Validation

Tested on Windows 11 and Ubuntu 24.04. Commands validated:

- `owatch security_audit`
- `owatch security_audit -v`
- `owatch security_audit --enrich`
- `owatch security_audit -v --enrich`
- `owatch all`
- `owatch all -v`
- `owatch all --enrich`
- `owatch all -v --enrich`
- `owatch all --skip-modules os,software`
- `owatch all --skip-modules os,software -v`

## Known deferred items

- Unix user checker weak shell and admin privilege conditions are Details-only pending source-verified YAML entries (tracked separately)
- Platform/version detail in `security_audit` system header deferred
- Cross-platform containerized test coverage deferred to Stage 3

## Closes

Closes #31 