### PR TITLE
[Bug] Windows user checker incorrectly flags linked and federated accounts as having no password required

### DIFF
--- a/internal/security/checker/users.go
+++ b/internal/security/checker/users.go
@@ -16,7 +16,7 @@ import (
 )
 
 // windowsUserCSVFields is the number of columns produced by Get-LocalUser
-const windowsUserCSVFields = 7
+const windowsUserCSVFields = 8
 
 // UserChecker defines interface for user account checking
 type UserChecker interface {
@@ -633,7 +633,7 @@ func (w *WindowsUserChecker) getWindowsUsers() ([]windowsUserInfo, error) {
 	var users []windowsUserInfo
 
 	psCmd := `Get-LocalUser | ` +
-		`Select-Object Name,Enabled,PasswordRequired,PasswordLastSet,LastLogon,AccountExpires,Description | ` +
+		`Select-Object Name,Enabled,PasswordRequired,PasswordLastSet,LastLogon,AccountExpires,Description,PrincipalSource | ` +
 		`ConvertTo-Csv -NoTypeInformation`
 	cmd := exec.Command("powershell", "-Command", psCmd)
 	output, err := cmd.CombinedOutput()
@@ -678,6 +678,7 @@ func (w *WindowsUserChecker) getWindowsUsers() ([]windowsUserInfo, error) {
 			LastLogon:        fields[4],
 			AccountExpires:   fields[5],
 			Description:      fields[6],
+			PrincipalSource:  fields[7],
 			IsAdmin:          adminUsers[fields[0]],
 		}
 
@@ -689,6 +690,10 @@ func (w *WindowsUserChecker) getWindowsUsers() ([]windowsUserInfo, error) {
 
 func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result *types.AuditResult) {
 	noPasswordFindingAdded := false
+	msAccountFindingAdded := false
+	azureADFindingAdded := false
+	domainFindingAdded := false
+	unknownPrincipalFindingAdded := false
 
 	for _, user := range users {
 		details := user.Name
@@ -712,22 +717,93 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolInfo, details))
 		} else if !user.PasswordRequired {
-			details += " (No Password Required)"
-			result.Details = append(result.Details,
-				fmt.Sprintf("%s %s", types.SymbolWarning, details))
-			// One finding for the class of violation, not one per user account
-			if !noPasswordFindingAdded {
-				if def, ok := registry.Lookup(w.ctx, "users.no_password_required"); ok {
-					result.Findings = append(result.Findings, types.Finding{
-						Title:       def.Title,
-						Severity:    def.Severity,
-						Description: def.Description,
-						Impact:      def.Impact,
-						Resolution:  def.Resolution,
-						References:  def.ToReferences(),
-					})
+			switch user.PrincipalSource {
+			case "MicrosoftAccount":
+				details += " (Microsoft Account -- no local password hash)"
+				result.Details = append(result.Details,
+					fmt.Sprintf("%s %s", types.SymbolInfo, details))
+				if !msAccountFindingAdded {
+					if def, ok := registry.Lookup(w.ctx, "user.microsoft_account_no_local_password"); ok {
+						result.Findings = append(result.Findings, types.Finding{
+							Title:       def.Title,
+							Severity:    def.Severity,
+							Description: def.Description,
+							Impact:      def.Impact,
+							Resolution:  def.Resolution,
+							References:  def.ToReferences(),
+						})
+					}
+					msAccountFindingAdded = true
 				}
-				noPasswordFindingAdded = true
+			case "AzureAD":
+				details += " (Azure AD -- no local password hash)"
+				result.Details = append(result.Details,
+					fmt.Sprintf("%s %s", types.SymbolInfo, details))
+				if !azureADFindingAdded {
+					if def, ok := registry.Lookup(w.ctx, "users.azure_ad_account_no_local_password"); ok {
+						result.Findings = append(result.Findings, types.Finding{
+							Title:       def.Title,
+							Severity:    def.Severity,
+							Description: def.Description,
+							Impact:      def.Impact,
+							Resolution:  def.Resolution,
+							References:  def.ToReferences(),
+						})
+					}
+					azureADFindingAdded = true
+				}
+			case "ActiveDirectory":
+				details += " (Active Directory -- no local password hash)"
+				result.Details = append(result.Details,
+					fmt.Sprintf("%s %s", types.SymbolInfo, details))
+				if !domainFindingAdded {
+					if def, ok := registry.Lookup(w.ctx, "users.domain_account_no_local_password"); ok {
+						result.Findings = append(result.Findings, types.Finding{
+							Title:       def.Title,
+							Severity:    def.Severity,
+							Description: def.Description,
+							Impact:      def.Impact,
+							Resolution:  def.Resolution,
+							References:  def.ToReferences(),
+						})
+					}
+					domainFindingAdded = true
+				}
+			case "Unknown":
+				details += " (Unknown principal source -- no local password hash)"
+				result.Details = append(result.Details,
+					fmt.Sprintf("%s %s", types.SymbolWarning, details))
+				if !unknownPrincipalFindingAdded {
+					if def, ok := registry.Lookup(w.ctx, "users.unknown_principal_no_local_password"); ok {
+						result.Findings = append(result.Findings, types.Finding{
+							Title:       def.Title,
+							Severity:    def.Severity,
+							Description: def.Description,
+							Impact:      def.Impact,
+							Resolution:  def.Resolution,
+							References:  def.ToReferences(),
+						})
+					}
+					unknownPrincipalFindingAdded = true
+				}
+			default:
+				// Local account or unrecognized source with no password required
+				details += " (No Password Required)"
+				result.Details = append(result.Details,
+					fmt.Sprintf("%s %s", types.SymbolWarning, details))
+				if !noPasswordFindingAdded {
+					if def, ok := registry.Lookup(w.ctx, "users.no_password_required"); ok {
+						result.Findings = append(result.Findings, types.Finding{
+							Title:       def.Title,
+							Severity:    def.Severity,
+							Description: def.Description,
+							Impact:      def.Impact,
+							Resolution:  def.Resolution,
+							References:  def.ToReferences(),
+						})
+					}
+					noPasswordFindingAdded = true
+				}
 			}
 		} else {
 			result.Details = append(result.Details,
@@ -783,6 +859,7 @@ type windowsUserInfo struct {
 	LastLogon        string
 	AccountExpires   string
 	Description      string
+	PrincipalSource  string
 	IsAdmin          bool
 }
 

--- a/internal/security/registry/data/windows.yaml
+++ b/internal/security/registry/data/windows.yaml
@@ -244,6 +244,121 @@ users.uac_disabled:
     - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
     - "https://cwe.mitre.org/data/definitions/250.html"
 
+users.microsoft_account_no_local_password:
+  title: "Microsoft-linked account has no local password hash"
+  severity: "LOW"
+  cvss_score: 2.1
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:N"
+  description: >
+    One or more accounts are linked to a Microsoft identity (personal
+    Microsoft account) and carry no local password hash. Authentication
+    is delegated to the Microsoft identity platform. This is expected
+    behavior for Microsoft-linked accounts and does not indicate a
+    missing credential -- the account cannot be authenticated locally
+    without the associated Microsoft identity.
+  impact: >
+    Authentication posture for these accounts depends entirely on the
+    Microsoft account security configuration (MFA, password strength,
+    account recovery options). Local audit tooling cannot assess
+    the external identity provider's controls. Compromise of the linked
+    Microsoft account grants local access.
+  resolution: >
+    Ensure the linked Microsoft account has multi-factor authentication
+    enabled and a strong password via account.microsoft.com/security.
+    Review whether Microsoft-linked accounts are appropriate for this
+    system's threat model. Consider using local accounts for systems
+    that require fully auditable, offline-capable authentication.
+  references:
+    - "NIST SP 800-53 Rev 5 IA-2 (Identification and Authentication)"
+    - "NIST SP 800-53 Rev 5 IA-8 (Identification and Authentication -- Non-Organizational Users)"
+
+users.azure_ad_account_no_local_password:
+  title: "Azure AD account has no local password hash"
+  severity: "LOW"
+  cvss_score: 2.1
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:N"
+  description: >
+    One or more accounts are joined via Azure Active Directory (Entra ID)
+    and carry no local password hash. Authentication is managed by the
+    organization's Azure AD tenant. This is expected behavior for
+    Entra ID-joined accounts -- local credential enforcement does not
+    apply because the identity provider is the authoritative source.
+  impact: >
+    Authentication posture depends on the organization's Azure AD
+    tenant configuration including conditional access policies, MFA
+    enforcement, and account lockout settings. These controls are
+    outside the scope of local host auditing. Compromise of the Azure
+    AD account or tenant grants local access.
+  resolution: >
+    Verify that the Azure AD tenant enforces MFA via Conditional Access
+    and that account lockout policies meet organizational requirements.
+    Confirm that Azure AD-joined accounts are appropriate for this
+    system's classification and data handling requirements.
+  references:
+    - "NIST SP 800-53 Rev 5 IA-2 (Identification and Authentication)"
+    - "NIST SP 800-53 Rev 5 IA-3 (Device Identification and Authentication)"
+    - "CIS Windows 11 Benchmark v3.0.0 §1.1"
+
+users.domain_account_no_local_password:
+  title: "Active Directory domain account has no local password hash"
+  severity: "LOW"
+  cvss_score: 2.3
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:N"
+  description: >
+    One or more accounts are sourced from an Active Directory domain
+    and carry no local password hash. Authentication is handled by the
+    domain controller via Kerberos or NTLM. This is expected behavior
+    for domain accounts present in the local user list -- local password
+    enforcement does not apply.
+  impact: >
+    Authentication posture depends on the domain's password policy,
+    Kerberos configuration, and account lockout settings enforced by
+    the domain controller. These are outside local audit scope. Domain
+    credential compromise or pass-the-hash attacks against NTLM
+    authentication remain valid attack paths independent of local
+    password policy.
+  resolution: >
+    Ensure the domain enforces a strong password policy and account
+    lockout via Group Policy. Evaluate whether NTLM should be restricted
+    in favor of Kerberos-only authentication for sensitive systems.
+    Review domain accounts present on this host and remove any that
+    are not operationally required.
+  references:
+    - "CIS Windows 11 Benchmark v3.0.0 §1.1"
+    - "NIST SP 800-53 Rev 5 IA-2 (Identification and Authentication)"
+    - "NIST SP 800-53 Rev 5 SC-8 (Transmission Confidentiality and Integrity)"
+
+users.unknown_principal_no_password:
+  title: "Account with undetermined principal source has no local password hash"
+  severity: "MEDIUM"
+  cvss_score: 5.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+  cwe: "CWE-287"
+  description: >
+    One or more accounts report an Unknown PrincipalSource from
+    Get-LocalUser and carry no local password hash. The authentication
+    mechanism for these accounts cannot be determined from available
+    non-elevated information. This may indicate a SAM database anomaly,
+    a pre-Windows 10 1607 account remnant, or an account in an
+    indeterminate state.
+  impact: >
+    Without a confirmed authentication mechanism and no local credential
+    present, it is not possible to determine what controls govern access
+    to these accounts. An account in this state may be accessible
+    without any credential depending on how Windows resolves the
+    unknown source at logon time.
+  resolution: >
+    Investigate each affected account manually: Get-LocalUser -Name
+    <username> | Select-Object *. Determine whether the account is
+    still required. If the account cannot be attributed to a known
+    identity source, disable or remove it. If required, establish a
+    clear authentication mechanism and enforce a password or federated
+    identity linkage.
+  references:
+    - "NIST SP 800-53 Rev 5 IA-2 (Identification and Authentication)"
+    - "NIST SP 800-53 Rev 5 IA-4 (Identifier Management)"
+    - "https://cwe.mitre.org/data/definitions/287.html"
+
 # -------------------------
 # Permissions checker findings
 # -------------------------


### PR DESCRIPTION
## Summary

Extends the Windows user checker to distinguish between local accounts with no password required and accounts that authenticate via federated or domain-managed identity providers. Prior to this change, any account returning `PasswordRequired: False` from `Get-LocalUser` was flagged as `users.no_password_required` regardless of how authentication was actually enforced, producing inaccurate findings for Microsoft-linked, Azure AD, Active Directory, and unknown-source accounts.

## Changes

### `users.go`
- Added `PrincipalSource` to the `Get-LocalUser` PowerShell select
- Bumped `windowsUserCSVFields` from `7` to `8`
- Added `PrincipalSource string` field to `windowsUserInfo`
- Added `PrincipalSource: fields[7]` to the struct literal parse
- Replaced the single `!user.PasswordRequired` branch in `analyzeWindowsUsers` with a `switch` on `PrincipalSource` dispatching to five distinct finding keys with appropriate severity and detail messaging per principal source class

### `windows.yaml`
- Added `users.microsoft_account_no_local_password` -- LOW, no CWE, informational audit note for personal Microsoft account linked accounts
- Added `users.azure_ad_account_no_local_password` -- LOW, no CWE, informational audit note for Entra ID managed accounts
- Added `users.domain_account_no_local_password` -- LOW, no CWE, informational audit note for Active Directory domain accounts
- Added `users.unknown_principal_no_password` -- MEDIUM, CWE-287, ambiguous authentication mechanism with no local credential present

## Finding Matrix

| Principal source | Finding key | Severity |
|---|---|---|
| `Local` | `users.no_password_required` (existing) | HIGH |
| `MicrosoftAccount` | `users.microsoft_account_no_local_password` | LOW |
| `AzureAD` | `users.azure_ad_account_no_local_password` | LOW |
| `ActiveDirectory` | `users.domain_account_no_local_password` | LOW |
| `Unknown` | `users.unknown_principal_no_password` | MEDIUM |
| unrecognized/`Local` | `users.no_password_required` (default) | HIGH |

## Investigation Notes

Manual testing on the development machine confirmed that Windows 11 personal Microsoft account setups create a local SAM account underneath the Microsoft identity layer. `Get-LocalUser` reports `PrincipalSource: Local` for these accounts, not `MicrosoftAccount`. The `MicrosoftAccount`, `AzureAD`, and `ActiveDirectory` branches handle documented `PrincipalSource` enum values correctly and require a purpose-built test environment with explicitly linked federated accounts to exercise manually. Unit test coverage for all principal source branches is tracked as follow-on work.

## Testing

- Pipeline passes: `gofmt`, `go build`, `go vet`, `gosec`, `govulncheck`, `golangci-lint`
- `Local` + `PasswordRequired: False` confirmed firing `users.no_password_required` correctly against live Windows 11 output
- Linux user checker output unaffected -- no regressions
- Full summarized testing for all implemented Windows-linked account types will be performed in the stage 3 pipeline implementation
    - Requires Windows images to be configured with each to determine true acceptance

Closes #32 