### PR TITLE
[Bug] Bound Unix permissions find operations to prevent default-audit hang

### DIFF
--- a/internal/security/checker/permissions.go
+++ b/internal/security/checker/permissions.go
@@ -2,12 +2,14 @@
 package checker
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/papa0four/orkowatch/internal/security/registry"
 	"github.com/papa0four/orkowatch/internal/security/types"
@@ -35,6 +37,19 @@ const (
 	findPermSGID          = "-2000"
 	findPermWorldWritable = "-0002"
 )
+
+// findScanTimeout bounds each FS-wide find operation to prevent audit hang
+const findScanTimeout = 60 * time.Second
+
+// runBoundedFind executes find rooted at "/" and is bounded by findScanTimeout
+func runBoundedFind(args []string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), findScanTimeout)
+	defer cancel()
+
+	full := append([]string{"/", "-xdev"}, args...)
+	cmd := exec.CommandContext(ctx, "find", full...) // #nosec G204 -- find predicate args sourced from hardcoded permission constants, not user input
+	return cmd.CombinedOutput()
+}
 
 // PermissionChecker defines interface for permission checking
 type PermissionChecker interface {
@@ -190,13 +205,11 @@ func (p *UnixPermissionChecker) checkPathPermissions(cp criticalPath, result *ty
 }
 
 func (p *UnixPermissionChecker) checkSUIDFiles(result *types.AuditResult) {
-	cmd := exec.Command("find", "/",
+	output, err := runBoundedFind([]string{
 		"-type", "f",
-		"-perm", findPermSUID, // SUID
-		"-o", "-perm", findPermSGID, // SGID
-	)
-
-	output, err := cmd.CombinedOutput()
+		"-perm", findPermSUID,
+		"-o", "-perm", findPermSGID,
+	})
 	if err != nil {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s Error checking SUID/SGID files: %v", types.SymbolError, err))
@@ -216,13 +229,12 @@ func (p *UnixPermissionChecker) checkSUIDFiles(result *types.AuditResult) {
 }
 
 func (p *UnixPermissionChecker) checkWorldWritableFiles(result *types.AuditResult) {
-	cmd := exec.Command("find", "/",
+	output, err := runBoundedFind([]string{
 		"-type", "f",
 		"-perm", findPermWorldWritable,
 		"-not", "-type", "l",
-		"-ls")
-
-	output, err := cmd.CombinedOutput()
+		"-ls",
+	})
 	if err != nil {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s Error checking world-writable files: %v", types.SymbolError, err))
@@ -242,11 +254,10 @@ func (p *UnixPermissionChecker) checkWorldWritableFiles(result *types.AuditResul
 }
 
 func (p *UnixPermissionChecker) checkUnownedFiles(result *types.AuditResult) {
-	cmd := exec.Command("find", "/",
+	output, err := runBoundedFind([]string{
 		"-nouser", "-o", "-nogroup",
-		"-ls")
-
-	output, err := cmd.CombinedOutput()
+		"-ls",
+	})
 	if err != nil {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s Error checking unowned files: %v", types.SymbolError, err))


### PR DESCRIPTION
## Summary

The Unix permissions checker ran three `find /` operations with no timeout and no filesystem bounding, causing the default security audit to hang on hosts with large, slow, or network-mounted filesystems. This bounds each operation to the root filesystem and adds a per-operation timeout, resolving the hang for default audits.

## Changes

### `internal/security/checker/permissions.go`
- Added `findScanTimeout` constant (60s) bounding each filesystem-wide find operation
- Added `runBoundedFind` helper running find rooted at `/` with `-xdev` and a context timeout, consolidating the previously triplicated command-execution pattern
- `checkSUIDFiles`, `checkWorldWritableFiles`, and `checkUnownedFiles` now call `runBoundedFind` with only their predicate arguments

## Behavior

The `-xdev` flag keeps each scan on the root filesystem, skipping mounted and pseudo-filesystems (`/proc`, `/sys`, `/dev`, `/run`, network mounts) which were the dominant cause of unbounded traversal. The timeout is a safety net for an unusually large root filesystem. This is the default-bounded behavior; operator-directed scans across mounts or arbitrary roots are a separate planned enhancement.

## Testing

- Default `security_audit -v` completes without hanging (previously hung indefinitely)
- Permissions check completes within the timeout bound on the development host
- Pipeline passes: `gofmt`, `go build`, `go vet`, `gosec`, `govulncheck`, `golangci-lint`

## Follow-on Work

Two defects surfaced during this branch, each tracked separately under #33:
- `find` exit status 1 (unreadable paths during traversal) is treated as fatal and discards valid output
- World-writable scan output volume needs signal-to-noise handling

Closes #60 