### PR TITLE
[Bug] Wire --file-permissions to scope the permissions scan instead of ignoring its path

### DIFF
--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -20,7 +20,6 @@ var (
 	verbose      bool
 	outputFormat string
 	reportFile   string
-	customPaths  []string
 	skipChecks   []string
 	minSeverity  string
 	timeout      time.Duration
@@ -119,8 +118,6 @@ func init() {
 		"Output format (text, json, yaml)")
 	SecurityCmd.Flags().StringVar(&reportFile, "report-file", "",
 		"Save audit report to file")
-	SecurityCmd.Flags().StringSliceVar(&customPaths, "paths", []string{},
-		"Custom paths to check (comma-separated)")
 	SecurityCmd.Flags().StringSliceVar(&skipChecks, "skip-checks", []string{},
 		"Checks to skip (comma-separated)")
 	SecurityCmd.Flags().StringVar(&minSeverity, "min-severity", "LOW",
@@ -156,7 +153,7 @@ func buildChecks() []string {
 	return checks
 }
 
-func validateFlags() error {
+func validateFlags(cmd *cobra.Command) error {
 	validFormats := map[string]bool{
 		"text": true,
 		"json": true,
@@ -176,10 +173,8 @@ func validateFlags() error {
 		return fmt.Errorf("invalid severity level: %s", minSeverity)
 	}
 
-	for _, path := range customPaths {
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			return fmt.Errorf("path does not exist: %s", path)
-		}
+	if err := validateFilePermsPath(cmd); err != nil {
+		return err
 	}
 
 	validChecks := map[string]bool{
@@ -197,6 +192,20 @@ func validateFlags() error {
 	return nil
 }
 
+// validateFilePermsPath enforces existing path and file rejecting explicit empty value
+func validateFilePermsPath(cmd *cobra.Command) error {
+	if !cmd.Flags().Changed("file-permissions") {
+		return nil
+	}
+	if checkFilePerms == "" {
+		return fmt.Errorf("--file-permissions requires a path")
+	}
+	if _, err := os.Stat(checkFilePerms); err != nil {
+		return fmt.Errorf("--file-permissions path is not accessible: %w", err)
+	}
+	return nil
+}
+
 func logVerboseConfig(checks []string) {
 	if !verbose {
 		return
@@ -207,9 +216,6 @@ func logVerboseConfig(checks []string) {
 		fmt.Println("[*] Runnning comprehensive security audit")
 	}
 	fmt.Printf("[*] Output format: %s\n", outputFormat)
-	if len(customPaths) > 0 {
-		fmt.Printf("[*] Custom paths: %s\n", strings.Join(customPaths, ", "))
-	}
 	if len(skipChecks) > 0 {
 		fmt.Printf("[*] Skipped checks: %s\n", strings.Join(skipChecks, ", "))
 	}
@@ -221,8 +227,8 @@ func logVerboseConfig(checks []string) {
 func runAuditWithTimeout(checks []string) error {
 	opts := audit.Options{
 		Verbose:        verbose,
-		CustomPaths:    customPaths,
 		SkipChecks:     skipChecks,
+		FilePermsPath:  checkFilePerms,
 		MinSeverity:    minSeverity,
 		Timeout:        timeout,
 		SpecificChecks: checks,

--- a/cmd/commands/security/security_unix.go
+++ b/cmd/commands/security/security_unix.go
@@ -18,7 +18,7 @@ func init() {
 func runUnixAudit(cmd *cobra.Command, args []string) error {
 	checks := buildChecks()
 
-	if err := validateFlags(); err != nil {
+	if err := validateFlags(cmd); err != nil {
 		return err
 	}
 

--- a/cmd/commands/security/security_windows.go
+++ b/cmd/commands/security/security_windows.go
@@ -18,7 +18,7 @@ func init() {
 func runWindowsAudit(cmd *cobra.Command, args []string) error {
 	checks := buildChecks()
 
-	if err := validateFlags(); err != nil {
+	if err := validateFlags(cmd); err != nil {
 		return err
 	}
 

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -32,8 +32,8 @@ type SecurityAuditor struct {
 type Options struct {
 	Verbose        bool
 	SpecificChecks []string
-	CustomPaths    []string
 	SkipChecks     []string
+	FilePermsPath  string
 	MinSeverity    string
 	Timeout        time.Duration
 	Enrich         bool
@@ -93,12 +93,12 @@ func NewSecurityAuditor(opts Options) *SecurityAuditor {
 		auditor.sshChecker = checker.NewWindowsSSHChecker(ctx)
 		auditor.firewallChecker = checker.NewWindowsFirewallChecker(ctx)
 		auditor.userChecker = checker.NewWindowsUserChecker(ctx)
-		auditor.permissionChecker = checker.NewWindowsPermissionChecker(ctx)
+		auditor.permissionChecker = checker.NewWindowsPermissionChecker(ctx, opts.FilePermsPath)
 	default:
 		auditor.sshChecker = checker.NewUnixSSHChecker(ctx)
 		auditor.firewallChecker = checker.NewUnixFirewallChecker(ctx)
 		auditor.userChecker = checker.NewUnixUserChecker(ctx)
-		auditor.permissionChecker = checker.NewUnixPermissionChecker()
+		auditor.permissionChecker = checker.NewUnixPermissionChecker(opts.FilePermsPath)
 	}
 
 	return auditor

--- a/internal/security/checker/permissions.go
+++ b/internal/security/checker/permissions.go
@@ -58,12 +58,12 @@ func countUnreadablePaths(stderr []byte) int {
 }
 
 // runBoundedFind executes find rooted at "/" and is bounded by findScanTimeout
-func runBoundedFind(args []string) (output []byte, skipped int, err error) {
+func runBoundedFind(root string, args []string) (output []byte, skipped int, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), findScanTimeout)
 	defer cancel()
 
-	full := append([]string{"/", "-xdev"}, args...)
-	cmd := exec.CommandContext(ctx, "find", full...) // #nosec G204 -- find predicate args sourced from hardcoded permission constants, not user input
+	full := append([]string{root, "-xdev"}, args...)
+	cmd := exec.CommandContext(ctx, "find", full...) // #nosec G204 -- root validated by caller; predicate args sourced from hardcoded permission constants
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -97,13 +97,13 @@ func nonEmptyLines(output []byte) []string {
 }
 
 // appendSkippedNote annotates the number of paths find could not read
-func appendSkippedNote(result *types.AuditResult, skipped int) {
+func appendSkippedNote(result *types.AuditResult, scan string, skipped int) {
 	if skipped <= 0 {
 		return
 	}
 	result.Details = append(result.Details,
-		fmt.Sprintf("%s Scanned with %d unreadable paths skipped (run with elevated privileges for complete coverage)",
-			types.SymbolInfo, skipped))
+		fmt.Sprintf("%s %s: %d unreadable paths skipped (run with elevated privileges for complete coverage)",
+			types.SymbolInfo, scan, skipped))
 }
 
 // PermissionChecker defines interface for permission checking
@@ -113,14 +113,16 @@ type PermissionChecker interface {
 
 // UnixPermissionChecker implements PermissionChecker for Unix-like systems
 type UnixPermissionChecker struct {
-	paths  []criticalPath
-	osType string
+	paths    []criticalPath
+	osType   string
+	scanRoot string
 }
 
 // WindowsPermissionChecker implements PermissionChecker for Windows systems
 type WindowsPermissionChecker struct {
-	Paths []string
-	ctx   registry.OSContext
+	Paths    []string
+	ctx      registry.OSContext
+	scanRoot string
 }
 
 // criticalPath represents a path that needs permission checking
@@ -132,9 +134,10 @@ type criticalPath struct {
 }
 
 // NewUnixPermissionChecker creates a new Unix permission checker
-func NewUnixPermissionChecker() *UnixPermissionChecker {
+func NewUnixPermissionChecker(scanRoot string) *UnixPermissionChecker {
 	checker := &UnixPermissionChecker{
-		osType: runtime.GOOS,
+		osType:   runtime.GOOS,
+		scanRoot: scanRoot,
 	}
 
 	// Set default critical paths based on OS
@@ -143,7 +146,7 @@ func NewUnixPermissionChecker() *UnixPermissionChecker {
 }
 
 // NewWindowsPermissionChecker creates a new Windows permission checker
-func NewWindowsPermissionChecker(ctx registry.OSContext) *WindowsPermissionChecker {
+func NewWindowsPermissionChecker(ctx registry.OSContext, scanRoot string) *WindowsPermissionChecker {
 	return &WindowsPermissionChecker{
 		Paths: []string{
 			"C:\\Windows\\System32",
@@ -152,7 +155,8 @@ func NewWindowsPermissionChecker(ctx registry.OSContext) *WindowsPermissionCheck
 			"C:\\ProgramData",
 			"C:\\Users",
 		},
-		ctx: ctx,
+		ctx:      ctx,
+		scanRoot: scanRoot,
 	}
 }
 
@@ -165,11 +169,13 @@ func (p *UnixPermissionChecker) Check() types.AuditResult {
 		Details:     make([]string, 0),
 	}
 
-	for _, cpath := range p.paths {
-		if err := p.checkPathPermissions(cpath, &result); err != nil {
-			result.Details = append(result.Details,
-				fmt.Sprintf("%s Error checking %s: %v",
-					types.SymbolError, cpath.path, err))
+	if p.scanRoot == "" {
+		for _, cpath := range p.paths {
+			if err := p.checkPathPermissions(cpath, &result); err != nil {
+				result.Details = append(result.Details,
+					fmt.Sprintf("%s Error checking %s: %v",
+						types.SymbolError, cpath.path, err))
+			}
 		}
 	}
 
@@ -179,6 +185,14 @@ func (p *UnixPermissionChecker) Check() types.AuditResult {
 
 	result.Status = "COMPLETED"
 	return result
+}
+
+// effectiveRoot resolves the find scan root; operator supplied
+func (p *UnixPermissionChecker) effectiveRoot() string {
+	if p.scanRoot == "" {
+		return "/"
+	}
+	return p.scanRoot
 }
 
 func (p *UnixPermissionChecker) getCriticalPathConfigs() []criticalPath {
@@ -260,7 +274,8 @@ func (p *UnixPermissionChecker) checkPathPermissions(cp criticalPath, result *ty
 }
 
 func (p *UnixPermissionChecker) checkSUIDFiles(result *types.AuditResult) {
-	output, skipped, err := runBoundedFind([]string{
+	const scan string = "SUID/SGID scan"
+	output, skipped, err := runBoundedFind(p.effectiveRoot(), []string{
 		"-type", "f",
 		"(", "-perm", findPermSUID, "-o", "-perm", findPermSGID, ")",
 	})
@@ -278,11 +293,12 @@ func (p *UnixPermissionChecker) checkSUIDFiles(result *types.AuditResult) {
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
 	}
-	appendSkippedNote(result, skipped)
+	appendSkippedNote(result, scan, skipped)
 }
 
 func (p *UnixPermissionChecker) checkWorldWritableFiles(result *types.AuditResult) {
-	output, skipped, err := runBoundedFind([]string{
+	const scan string = "World-writable scan"
+	output, skipped, err := runBoundedFind(p.effectiveRoot(), []string{
 		"-type", "f",
 		"-perm", findPermWorldWritable,
 		"-not", "-type", "l",
@@ -302,11 +318,12 @@ func (p *UnixPermissionChecker) checkWorldWritableFiles(result *types.AuditResul
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
 	}
-	appendSkippedNote(result, skipped)
+	appendSkippedNote(result, scan, skipped)
 }
 
 func (p *UnixPermissionChecker) checkUnownedFiles(result *types.AuditResult) {
-	output, skipped, err := runBoundedFind([]string{
+	const scan string = "Unowned-files scan"
+	output, skipped, err := runBoundedFind(p.effectiveRoot(), []string{
 		"-nouser", "-o", "-nogroup",
 		"-ls",
 	})
@@ -324,7 +341,7 @@ func (p *UnixPermissionChecker) checkUnownedFiles(result *types.AuditResult) {
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
 	}
-	appendSkippedNote(result, skipped)
+	appendSkippedNote(result, scan, skipped)
 }
 
 // Check implements PermissionChecker interface for Windows systems
@@ -337,8 +354,18 @@ func (p *WindowsPermissionChecker) Check() types.AuditResult {
 		Findings:    make([]types.Finding, 0),
 	}
 
+	if p.scanRoot != "" {
+		if err := p.checkWindowsPermissions(p.scanRoot, true, &result); err != nil {
+			result.Details = append(result.Details,
+				fmt.Sprintf("%s Error checking %s, %v",
+					types.SymbolError, p.scanRoot, err))
+		}
+		result.Status = "COMPLETED"
+		return result
+	}
+
 	for _, path := range p.Paths {
-		if err := p.checkWindowsPermissions(path, &result); err != nil {
+		if err := p.checkWindowsPermissions(path, false, &result); err != nil {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s Error checking %s: %v",
 					types.SymbolError, path, err))
@@ -352,11 +379,11 @@ func (p *WindowsPermissionChecker) Check() types.AuditResult {
 	return result
 }
 
-func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, result *types.AuditResult) error {
-	cmd := exec.Command("icacls", path) // #nosec G204 -- path sourced from hardcoded Windows system directory list, not user input
-	output, err := cmd.CombinedOutput()
+func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, recursive bool, result *types.AuditResult) error {
+	const scan string = "ACL traversal"
+	output, skipped, err := runICACLS(path, recursive)
 	if err != nil {
-		return fmt.Errorf("failed to check permissions: %v", err)
+		return fmt.Errorf("failed to check permissions: %w", err)
 	}
 
 	everyoneFindingAdded := false
@@ -412,7 +439,44 @@ func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, result *
 		}
 	}
 
+	appendSkippedNote(result, scan, skipped)
 	return nil
+}
+
+// runICACLS executes against the given path with optional recursion for tree traversal
+func runICACLS(path string, recursive bool) (output []byte, skipped int, err error) {
+	args := []string{path}
+	if recursive {
+		args = append(args, "/T")
+	}
+	cmd := exec.Command("icacls", args...) // #nosec G204 -- path validated by caller; flags are fixed literals
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	var exitErr *exec.ExitError
+	if runErr != nil && !errors.As(runErr, &exitErr) {
+		return nil, 0, runErr
+	}
+
+	return stdout.Bytes(), countDeniedPaths(stderr.Bytes()), nil
+}
+
+// countDeniedPaths counts the paths icacls could not access
+func countDeniedPaths(stderr []byte) int {
+	if len(stderr) == 0 {
+		return 0
+	}
+	count := 0
+	for _, line := range strings.Split(string(stderr), "\n") {
+		if strings.Contains(line, "Access is denied") {
+			count++
+		}
+	}
+	return count
 }
 
 func (p *WindowsPermissionChecker) checkNetworkShares(result *types.AuditResult) {


### PR DESCRIPTION
## Summary

`--file-permissions` accepted a path but discarded it, scanning the entire filesystem regardless of the value passed. The flag now scopes the permissions check to the given path on both Unix and Windows, with default behavior preserved when no path is given. The dead `--paths` flag is removed.

## Changes

### `internal/security/checker/permissions.go`
- `runBoundedFind` takes a scan root rather than hardcoding `/`
- `UnixPermissionChecker` holds a `scanRoot`; `effectiveRoot` resolves it (`/` default, or the operator path)
- Unix `Check` runs curated critical-path checks only in default mode; a scoped scan runs the find operations rooted at the path
- `WindowsPermissionChecker` holds a `scanRoot`; default mode runs the curated system-path ACL checks plus share enumeration, scoped mode runs a recursive ACL traversal of the path and skips shares
- Added `runICACLS` mirroring `runBoundedFind`: separate stdout/stderr capture, non-fatal handling of non-zero exit, denied-path count
- `checkWindowsPermissions` takes a recursive flag and surfaces skipped-path counts
- Skipped-paths notes are labeled per scan

### `internal/security/audit/audit.go`
- `Options` gains `FilePermsPath`, drops the unused `CustomPaths`
- Both checker constructors receive the scan root

### `cmd/commands/security/security.go`
- `--file-permissions` value plumbed into `Options`
- `validateFlags` takes the command and rejects an explicitly empty `--file-permissions`; a passed path must exist
- Removed the dead `--paths` flag and its plumbing

### `cmd/commands/security/security_unix.go`, `security_windows.go`
- Pass the command to `validateFlags`

## Behavior

- No path flag: default audit (curated checks plus full scans at `/` or the curated Windows system paths)
- `--file-permissions` with no argument or empty string: error
- `--file-permissions <path>`: scans only that path and its subdirectories, on Unix, Linux, and Windows; both files and directories handled

## Out of Scope

Multiple comma-separated paths and file-supplied path lists with per-path error handling, and a large-enumeration confirmation prompt, are tracked as follow-on enhancements.

## Testing

- Scoped directory and single-file scans verified on Linux
- Empty-string and nonexistent-path errors verified
- Default audit behavior unchanged
- Pipeline passes: `gofmt`, `go build`, `go vet`, `gosec`, `govulncheck`, `golangci-lint`, `GOOS=windows go build`, `GOOS=windows go vet`

Closes #64 