### PR TITLE
[Chore] Rename security_audit check flags to single canonical names

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ owatch software
 owatch security_audit -v
 
 # Run specific security checks
-owatch security_audit --check-ssh
-owatch security_audit --check-firewall
-owatch security_audit --check-users
+owatch security_audit --ssh
+owatch security_audit --fwall
+owatch security_audit --users
+owatch security_audit --fperms /path/to/check
 
 # Run all scans and save report as JSON
 owatch all -o json --report-file report.json
@@ -51,10 +52,10 @@ owatch all --skip-modules software,security
 
 | Flag | Description | Default |
 |---|---|---|
-| `--check-ssh` | Run SSH configuration check | false |
-| `--check-firewall` | Run firewall configuration check | false |
-| `--check-users` | Run user accounts check | false |
-| `--file-permissions` | Check permissions of specified path | — |
+| `--ssh` | Run SSH configuration check | false |
+| `--fwall` | Run firewall configuration check | false |
+| `--users` | Run user accounts check | false |
+| `--fperms` | Check permissions of specified path | — |
 | `-o, --output` | Output format: text, json, yaml | text |
 | `--report-file` | Save report to file | — |
 | `--min-severity` | Minimum severity to report: LOW, MEDIUM, HIGH, CRITICAL | LOW |

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -50,13 +50,13 @@ You can run all checks or specify individual checks to run.`,
   owatch security_audit -v
 
   # Run specific checks
-  owatch security_audit --check-ssh
-  owatch security_audit --check-firewall
-  owatch security_audit --check-users
-  owatch security_audit --file-permissions /path/to/file
+  owatch security_audit --ssh
+  owatch security_audit --fwall
+  owatch security_audit --users
+  owatch security_audit --fperms /path/to/file
 
   # Run checks with verbose output
-  owatch security_audit --check-ssh -v
+  owatch security_audit --ssh -v
 
   # Set minimum severity level
   owatch security_audit --min-severity HIGH
@@ -124,13 +124,13 @@ func init() {
 		"Minimum severity level to report (LOW, MEDIUM, HIGH, CRITICAL)")
 	SecurityCmd.Flags().DurationVar(&timeout, "timeout", 10*time.Minute,
 		"Maximum time to run the audit")
-	SecurityCmd.Flags().BoolVar(&checkSSH, "check-ssh", false,
+	SecurityCmd.Flags().BoolVar(&checkSSH, "ssh", false,
 		"Run SSH configuration check")
-	SecurityCmd.Flags().BoolVar(&checkFirewall, "check-firewall", false,
+	SecurityCmd.Flags().BoolVar(&checkFirewall, "fwall", false,
 		"Run firewall configuration check")
-	SecurityCmd.Flags().BoolVar(&checkUsers, "check-users", false,
+	SecurityCmd.Flags().BoolVar(&checkUsers, "users", false,
 		"Run user accounts check")
-	SecurityCmd.Flags().StringVar(&checkFilePerms, "file-permissions", "",
+	SecurityCmd.Flags().StringVar(&checkFilePerms, "fperms", "",
 		"Check permissions of specified file path")
 	SecurityCmd.Flags().BoolVarP(&enrich, "enrich", "e", false,
 		"Query external sources to annotate findings with CVEs mapped to referenced CWEs")
@@ -194,14 +194,14 @@ func validateFlags(cmd *cobra.Command) error {
 
 // validateFilePermsPath enforces existing path and file rejecting explicit empty value
 func validateFilePermsPath(cmd *cobra.Command) error {
-	if !cmd.Flags().Changed("file-permissions") {
+	if !cmd.Flags().Changed("fperms") {
 		return nil
 	}
 	if checkFilePerms == "" {
-		return fmt.Errorf("--file-permissions requires a path")
+		return fmt.Errorf("--fperms: requires a path")
 	}
 	if _, err := os.Stat(checkFilePerms); err != nil {
-		return fmt.Errorf("--file-permissions path is not accessible: %w", err)
+		return fmt.Errorf("--fperms: path is not accessible: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Renames the `security_audit` check flags to single canonical names, removing the verbose `--check-` prefix and the inconsistent `--file-permissions` name. README references updated to match.

## Changes

### `cmd/commands/security/security.go`
- `--check-ssh` to `--ssh`
- `--check-firewall` to `--fwall`
- `--check-users` to `--users`
- `--file-permissions` to `--fperms` (still takes a path argument)
- Updated the `Changed()` lookup and validation error messages to the new name
- Updated the command `Example` text to the new names

### `README.md`
- Usage examples and the Security Audit Flags table updated to the renamed flags
- Added a `--fperms` usage example

Unrelated stale references (`--output`, `--skip-modules`) left untouched; tracked in the broader command audit.

## Testing

- Each renamed flag runs its check; old names are rejected as unknown flags
- Pipeline passes: `gofmt`, `go build`, `go vet`, `gosec`, `govulncheck`, `golangci-lint`, `GOOS=windows go build`

Closes #68 