### PR TITLE
[Chore] Add version subcommand and settle version/verbose flag semantics

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -26,6 +26,7 @@ var RootCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(security.SecurityCmd)
+	RootCmd.Flags().BoolP("version", "V", false, "version for owatch")
 }
 
 // Execute runs the root command and exits with a non-zero status on error

--- a/cmd/commands/version.go
+++ b/cmd/commands/version.go
@@ -1,9 +1,28 @@
 // cmd/commands/version.go
 package cmd
 
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
 /*
 Version is the current application version.
 It defaults to the active development stage and is overridden
 at build time via -ldflags "-X github.com/papa0four/orkowatch/cmd/commands.Version=..."
 */
 var Version = "dev"
+
+// versionCmd prints the application version, matching the --version output
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the orkowatch version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("owatch version %s\n", Version)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
## Summary

Adds the `version` subcommand and resolves the `-v` flag conflict. Previously `owatch version` did not exist and `-v` was the short form of `--version` at the root, colliding with `-v`/`--verbose` on subcommands. Version now uses `-V`, reserving `-v` exclusively for verbose.

## Changes

### `cmd/commands/version.go`
- Added a `version` subcommand printing the same terse output as `--version`, registered via `init()`

### `cmd/commands/root.go`
- Registered `--version` with `-V` as its short form, overriding Cobra's default `-v` and freeing `-v` for verbose

## Behavior

- `owatch -V`, `owatch --version`, and `owatch version` all print the version
- `owatch -v` is no longer bound to version
- `-v`/`--verbose` works unambiguously on subcommands

## Out of Scope

- Root-level `--verbose` behavior is not wired; `-v` is reserved, not implemented at root
- Richer build metadata for the `version` subcommand is deferred to Stage 3 GoReleaser work

## Testing

- All three version forms confirmed
- `-v` at root rejected as unknown; `security_audit --ssh -v` runs verbose correctly
- README checked; no version/`-v` reference required updating
- Pipeline passes: `gofmt`, `go build`, `go vet`, `gosec`, `govulncheck`, `golangci-lint`, `GOOS=windows go build`

Closes #72 