### PR TITLE
[Bug] Fix all --skip-modules breaking on security skip and silently ignoring invalid names

### DIFF
--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -78,8 +79,27 @@ type ScanResult struct {
 	Errors        []string              `json:"errors,omitempty"`
 }
 
+// validateSkipModules rejects any --skip-modules value that is not recognized
+func validateSkipModules() error {
+	valid := map[string]bool{
+		"os":       true,
+		"software": true,
+		"security": true,
+	}
+	for _, module := range skipModules {
+		if !valid[strings.ToLower(module)] {
+			return fmt.Errorf("invalid module to skip: %s (valid: os, software, security)", module)
+		}
+	}
+	return nil
+}
+
 func runAllScans(cmd *cobra.Command, args []string) error {
 	startTime := time.Now()
+
+	if err := validateSkipModules(); err != nil {
+		return err
+	}
 
 	if isModuleSkipped("os") && isModuleSkipped("software") && isModuleSkipped("security") {
 		return fmt.Errorf("all modules have been skipped, at least one module must be run")
@@ -193,11 +213,19 @@ func runSecurityAuditModule() (*audit.Result, error) {
 }
 
 func convertToAuditResult(scan *ScanResult) *audit.Result {
-	if scan.SecurityAudit == nil {
-		return nil
+	var sysInfo audit.SystemInfo
+	if scan.SecurityAudit != nil {
+		sysInfo = scan.SecurityAudit.SystemInfo
+	} else {
+		sysInfo = audit.SystemInfo{
+			OS:           runtime.GOOS,
+			Architecture: runtime.GOARCH,
+		}
+		if hostname, err := os.Hostname(); err == nil {
+			sysInfo.Hostname = hostname
+		}
 	}
 
-	sysInfo := scan.SecurityAudit.SystemInfo
 	if scan.OSInfo != nil {
 		if scan.OSInfo.Platform != "" {
 			sysInfo.OS = scan.OSInfo.Platform
@@ -211,18 +239,23 @@ func convertToAuditResult(scan *ScanResult) *audit.Result {
 		sysInfo.SoftwareCount = scan.SoftwareCount
 	}
 
-	return &audit.Result{
-		StartTime:           scan.Timestamp,
-		EndTime:             scan.Timestamp.Add(scan.Duration),
-		Duration:            scan.Duration,
-		Results:             scan.SecurityAudit.Results,
-		SystemInfo:          sysInfo,
-		Summary:             scan.SecurityAudit.Summary,
-		EnrichmentRequested: scan.SecurityAudit.EnrichmentRequested,
-		EnrichmentError:     scan.SecurityAudit.EnrichmentError,
-		Enrichment:          scan.SecurityAudit.Enrichment,
-		References:          scan.SecurityAudit.References,
+	result := &audit.Result{
+		StartTime:  scan.Timestamp,
+		EndTime:    scan.Timestamp.Add(scan.Duration),
+		Duration:   scan.Duration,
+		SystemInfo: sysInfo,
 	}
+
+	if scan.SecurityAudit != nil {
+		result.Results = scan.SecurityAudit.Results
+		result.Summary = scan.SecurityAudit.Summary
+		result.EnrichmentRequested = scan.SecurityAudit.EnrichmentRequested
+		result.EnrichmentError = scan.SecurityAudit.EnrichmentError
+		result.Enrichment = scan.SecurityAudit.Enrichment
+		result.References = scan.SecurityAudit.References
+	}
+
+	return result
 }
 
 func outputResults(result *ScanResult) error {
@@ -248,9 +281,6 @@ func outputResults(result *ScanResult) error {
 	}
 
 	auditResult := convertToAuditResult(result)
-	if auditResult == nil {
-		return fmt.Errorf("no security audit results available")
-	}
 
 	f := formatter.NewFormatter(output, opts)
 	if err := f.Format(auditResult); err != nil {


### PR DESCRIPTION
## Summary

The `all` command's `--skip-modules` failed when skipping the `security` module and silently ignored unrecognized module names. Both are fixed: a partial scan now renders the modules that ran, and invalid module names are rejected.

## Changes

### `cmd/commands/all.go`
- `convertToAuditResult` no longer returns nil when the security module is skipped; it synthesizes system info from runtime and the OS/software modules and returns a valid result with an empty check set
- Removed the nil guard in `outputResults` that treated a skipped security module as a fatal error
- Added `validateSkipModules`, rejecting any `--skip-modules` value outside the canonical set (`os`, `software`, `security`)
- Added `runtime` import for the synthesized system info

## Behavior

- Skipping `security` renders OS and software output with an empty check-results section
- Skipping `software` renders OS and security output
- Invalid module names are rejected with a meaningful error
- The all-modules-skipped guard still returns its error

## Testing

- Skip `security`, skip `software,security` verified (verbose and non-verbose)
- Invalid name `osinfo` rejected
- `--report-file` JSON written and valid; `--output` json/yaml valid and parseable; `--timeout 1s` fires the timeout path
- Pipeline passes: `gofmt`, `go build`, `go vet`, `gosec`, `govulncheck`, `golangci-lint`, `GOOS=windows go build`

Closes #74 