### PR TITLE
bug/33: command and flag audit across all subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ owatch software
 owatch security_audit -v
 
 # Run specific security checks
-owatch security_audit --check-ssh
-owatch security_audit --check-firewall
-owatch security_audit --check-users
+owatch security_audit --ssh
+owatch security_audit --fwall
+owatch security_audit --users
+owatch security_audit --fperms /path/to/check
 
 # Run all scans and save report as JSON
 owatch all -o json --report-file report.json
@@ -51,10 +52,10 @@ owatch all --skip-modules software,security
 
 | Flag | Description | Default |
 |---|---|---|
-| `--check-ssh` | Run SSH configuration check | false |
-| `--check-firewall` | Run firewall configuration check | false |
-| `--check-users` | Run user accounts check | false |
-| `--file-permissions` | Check permissions of specified path | — |
+| `--ssh` | Run SSH configuration check | false |
+| `--fwall` | Run firewall configuration check | false |
+| `--users` | Run user accounts check | false |
+| `--fperms` | Check permissions of specified path | — |
 | `-o, --output` | Output format: text, json, yaml | text |
 | `--report-file` | Save report to file | — |
 | `--min-severity` | Minimum severity to report: LOW, MEDIUM, HIGH, CRITICAL | LOW |

--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -41,7 +41,7 @@ Results can be output in various formats and saved to a file.`,
   owatch all
 
   # Run all scans with verbose output
-  owatch all -v || owatch all --verbose
+  owatch all -v
 
   # Skip specific modules
   owatch all --skip-modules security,software

--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -78,8 +79,27 @@ type ScanResult struct {
 	Errors        []string              `json:"errors,omitempty"`
 }
 
+// validateSkipModules rejects any --skip-modules value that is not recognized
+func validateSkipModules() error {
+	valid := map[string]bool{
+		"os":       true,
+		"software": true,
+		"security": true,
+	}
+	for _, module := range skipModules {
+		if !valid[strings.ToLower(module)] {
+			return fmt.Errorf("invalid module to skip: %s (valid: os, software, security)", module)
+		}
+	}
+	return nil
+}
+
 func runAllScans(cmd *cobra.Command, args []string) error {
 	startTime := time.Now()
+
+	if err := validateSkipModules(); err != nil {
+		return err
+	}
 
 	if isModuleSkipped("os") && isModuleSkipped("software") && isModuleSkipped("security") {
 		return fmt.Errorf("all modules have been skipped, at least one module must be run")
@@ -193,11 +213,19 @@ func runSecurityAuditModule() (*audit.Result, error) {
 }
 
 func convertToAuditResult(scan *ScanResult) *audit.Result {
-	if scan.SecurityAudit == nil {
-		return nil
+	var sysInfo audit.SystemInfo
+	if scan.SecurityAudit != nil {
+		sysInfo = scan.SecurityAudit.SystemInfo
+	} else {
+		sysInfo = audit.SystemInfo{
+			OS:           runtime.GOOS,
+			Architecture: runtime.GOARCH,
+		}
+		if hostname, err := os.Hostname(); err == nil {
+			sysInfo.Hostname = hostname
+		}
 	}
 
-	sysInfo := scan.SecurityAudit.SystemInfo
 	if scan.OSInfo != nil {
 		if scan.OSInfo.Platform != "" {
 			sysInfo.OS = scan.OSInfo.Platform
@@ -211,18 +239,23 @@ func convertToAuditResult(scan *ScanResult) *audit.Result {
 		sysInfo.SoftwareCount = scan.SoftwareCount
 	}
 
-	return &audit.Result{
-		StartTime:           scan.Timestamp,
-		EndTime:             scan.Timestamp.Add(scan.Duration),
-		Duration:            scan.Duration,
-		Results:             scan.SecurityAudit.Results,
-		SystemInfo:          sysInfo,
-		Summary:             scan.SecurityAudit.Summary,
-		EnrichmentRequested: scan.SecurityAudit.EnrichmentRequested,
-		EnrichmentError:     scan.SecurityAudit.EnrichmentError,
-		Enrichment:          scan.SecurityAudit.Enrichment,
-		References:          scan.SecurityAudit.References,
+	result := &audit.Result{
+		StartTime:  scan.Timestamp,
+		EndTime:    scan.Timestamp.Add(scan.Duration),
+		Duration:   scan.Duration,
+		SystemInfo: sysInfo,
 	}
+
+	if scan.SecurityAudit != nil {
+		result.Results = scan.SecurityAudit.Results
+		result.Summary = scan.SecurityAudit.Summary
+		result.EnrichmentRequested = scan.SecurityAudit.EnrichmentRequested
+		result.EnrichmentError = scan.SecurityAudit.EnrichmentError
+		result.Enrichment = scan.SecurityAudit.Enrichment
+		result.References = scan.SecurityAudit.References
+	}
+
+	return result
 }
 
 func outputResults(result *ScanResult) error {
@@ -248,9 +281,6 @@ func outputResults(result *ScanResult) error {
 	}
 
 	auditResult := convertToAuditResult(result)
-	if auditResult == nil {
-		return fmt.Errorf("no security audit results available")
-	}
 
 	f := formatter.NewFormatter(output, opts)
 	if err := f.Format(auditResult); err != nil {

--- a/cmd/commands/osinfo.go
+++ b/cmd/commands/osinfo.go
@@ -2,14 +2,10 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/papa0four/orkowatch/internal/osfingerprint"
 )
-
-var osinfoVerbose bool
 
 // osinfoCmd represents the command for gathering OS information
 var osinfoCmd = &cobra.Command{
@@ -17,14 +13,10 @@ var osinfoCmd = &cobra.Command{
 	Short: "Gather OS Fingerprint information",
 	Long:  `osinfo will scan the host machine and retrieve basic OS fingerprint information such as platform, version, and kernel details.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if osinfoVerbose {
-			fmt.Println("[*] Verbose mode enabled. Gathering additional information...")
-		}
 		osfingerprint.PrintOSInfo()
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(osinfoCmd)
-	osinfoCmd.Flags().BoolVarP(&osinfoVerbose, "verbose", "v", false, "Enable verbose output")
 }

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -26,6 +26,7 @@ var RootCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(security.SecurityCmd)
+	RootCmd.Flags().BoolP("version", "V", false, "version for owatch")
 }
 
 // Execute runs the root command and exits with a non-zero status on error

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -17,7 +17,7 @@ var RootCmd = &cobra.Command{
 	Short:   "orkowatch is a lightweight scanner for host OS vulnerabilities",
 	Long:    `orkowatch helps engineers and architects scan for vulnerabilities in OS, software, and security protocols`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("owatch requires a subcommand (e.g., osinfo, security_audit, software).")
+		fmt.Println("owatch requires a subcommand (e.g., all, osinfo, security_audit, software).")
 		if err := cmd.Help(); err != nil {
 			fmt.Fprintf(os.Stderr, "error displaying help: %v\n", err)
 		}

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -50,13 +50,13 @@ You can run all checks or specify individual checks to run.`,
   owatch security_audit -v
 
   # Run specific checks
-  owatch security_audit --check-ssh
-  owatch security_audit --check-firewall
-  owatch security_audit --check-users
-  owatch security_audit --file-permissions /path/to/file
+  owatch security_audit --ssh
+  owatch security_audit --fwall
+  owatch security_audit --users
+  owatch security_audit --fperms /path/to/file
 
   # Run checks with verbose output
-  owatch security_audit --check-ssh -v
+  owatch security_audit --ssh -v
 
   # Set minimum severity level
   owatch security_audit --min-severity HIGH
@@ -124,13 +124,13 @@ func init() {
 		"Minimum severity level to report (LOW, MEDIUM, HIGH, CRITICAL)")
 	SecurityCmd.Flags().DurationVar(&timeout, "timeout", 10*time.Minute,
 		"Maximum time to run the audit")
-	SecurityCmd.Flags().BoolVar(&checkSSH, "check-ssh", false,
+	SecurityCmd.Flags().BoolVar(&checkSSH, "ssh", false,
 		"Run SSH configuration check")
-	SecurityCmd.Flags().BoolVar(&checkFirewall, "check-firewall", false,
+	SecurityCmd.Flags().BoolVar(&checkFirewall, "fwall", false,
 		"Run firewall configuration check")
-	SecurityCmd.Flags().BoolVar(&checkUsers, "check-users", false,
+	SecurityCmd.Flags().BoolVar(&checkUsers, "users", false,
 		"Run user accounts check")
-	SecurityCmd.Flags().StringVar(&checkFilePerms, "file-permissions", "",
+	SecurityCmd.Flags().StringVar(&checkFilePerms, "fperms", "",
 		"Check permissions of specified file path")
 	SecurityCmd.Flags().BoolVarP(&enrich, "enrich", "e", false,
 		"Query external sources to annotate findings with CVEs mapped to referenced CWEs")
@@ -194,14 +194,14 @@ func validateFlags(cmd *cobra.Command) error {
 
 // validateFilePermsPath enforces existing path and file rejecting explicit empty value
 func validateFilePermsPath(cmd *cobra.Command) error {
-	if !cmd.Flags().Changed("file-permissions") {
+	if !cmd.Flags().Changed("fperms") {
 		return nil
 	}
 	if checkFilePerms == "" {
-		return fmt.Errorf("--file-permissions requires a path")
+		return fmt.Errorf("--fperms: requires a path")
 	}
 	if _, err := os.Stat(checkFilePerms); err != nil {
-		return fmt.Errorf("--file-permissions path is not accessible: %w", err)
+		return fmt.Errorf("--fperms: path is not accessible: %w", err)
 	}
 	return nil
 }

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -213,7 +213,7 @@ func logVerboseConfig(checks []string) {
 	if len(checks) > 0 {
 		fmt.Printf("[*] Running checks: %s\n", strings.Join(checks, ", "))
 	} else {
-		fmt.Println("[*] Runnning comprehensive security audit")
+		fmt.Println("[*] Running comprehensive security audit")
 	}
 	fmt.Printf("[*] Output format: %s\n", outputFormat)
 	if len(skipChecks) > 0 {

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -20,7 +20,6 @@ var (
 	verbose      bool
 	outputFormat string
 	reportFile   string
-	customPaths  []string
 	skipChecks   []string
 	minSeverity  string
 	timeout      time.Duration
@@ -119,8 +118,6 @@ func init() {
 		"Output format (text, json, yaml)")
 	SecurityCmd.Flags().StringVar(&reportFile, "report-file", "",
 		"Save audit report to file")
-	SecurityCmd.Flags().StringSliceVar(&customPaths, "paths", []string{},
-		"Custom paths to check (comma-separated)")
 	SecurityCmd.Flags().StringSliceVar(&skipChecks, "skip-checks", []string{},
 		"Checks to skip (comma-separated)")
 	SecurityCmd.Flags().StringVar(&minSeverity, "min-severity", "LOW",
@@ -156,7 +153,7 @@ func buildChecks() []string {
 	return checks
 }
 
-func validateFlags() error {
+func validateFlags(cmd *cobra.Command) error {
 	validFormats := map[string]bool{
 		"text": true,
 		"json": true,
@@ -176,10 +173,8 @@ func validateFlags() error {
 		return fmt.Errorf("invalid severity level: %s", minSeverity)
 	}
 
-	for _, path := range customPaths {
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			return fmt.Errorf("path does not exist: %s", path)
-		}
+	if err := validateFilePermsPath(cmd); err != nil {
+		return err
 	}
 
 	validChecks := map[string]bool{
@@ -197,6 +192,20 @@ func validateFlags() error {
 	return nil
 }
 
+// validateFilePermsPath enforces existing path and file rejecting explicit empty value
+func validateFilePermsPath(cmd *cobra.Command) error {
+	if !cmd.Flags().Changed("file-permissions") {
+		return nil
+	}
+	if checkFilePerms == "" {
+		return fmt.Errorf("--file-permissions requires a path")
+	}
+	if _, err := os.Stat(checkFilePerms); err != nil {
+		return fmt.Errorf("--file-permissions path is not accessible: %w", err)
+	}
+	return nil
+}
+
 func logVerboseConfig(checks []string) {
 	if !verbose {
 		return
@@ -207,9 +216,6 @@ func logVerboseConfig(checks []string) {
 		fmt.Println("[*] Runnning comprehensive security audit")
 	}
 	fmt.Printf("[*] Output format: %s\n", outputFormat)
-	if len(customPaths) > 0 {
-		fmt.Printf("[*] Custom paths: %s\n", strings.Join(customPaths, ", "))
-	}
 	if len(skipChecks) > 0 {
 		fmt.Printf("[*] Skipped checks: %s\n", strings.Join(skipChecks, ", "))
 	}
@@ -221,8 +227,8 @@ func logVerboseConfig(checks []string) {
 func runAuditWithTimeout(checks []string) error {
 	opts := audit.Options{
 		Verbose:        verbose,
-		CustomPaths:    customPaths,
 		SkipChecks:     skipChecks,
+		FilePermsPath:  checkFilePerms,
 		MinSeverity:    minSeverity,
 		Timeout:        timeout,
 		SpecificChecks: checks,

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -151,7 +151,7 @@ func buildChecks() []string {
 		checks = append(checks, "users")
 	}
 	if checkFilePerms != "" {
-		checks = append(checks, "file-permissions")
+		checks = append(checks, "permissions")
 	}
 	return checks
 }

--- a/cmd/commands/security/security_unix.go
+++ b/cmd/commands/security/security_unix.go
@@ -18,7 +18,7 @@ func init() {
 func runUnixAudit(cmd *cobra.Command, args []string) error {
 	checks := buildChecks()
 
-	if err := validateFlags(); err != nil {
+	if err := validateFlags(cmd); err != nil {
 		return err
 	}
 

--- a/cmd/commands/security/security_windows.go
+++ b/cmd/commands/security/security_windows.go
@@ -18,7 +18,7 @@ func init() {
 func runWindowsAudit(cmd *cobra.Command, args []string) error {
 	checks := buildChecks()
 
-	if err := validateFlags(); err != nil {
+	if err := validateFlags(cmd); err != nil {
 		return err
 	}
 

--- a/cmd/commands/version.go
+++ b/cmd/commands/version.go
@@ -1,9 +1,28 @@
 // cmd/commands/version.go
 package cmd
 
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
 /*
 Version is the current application version.
 It defaults to the active development stage and is overridden
 at build time via -ldflags "-X github.com/papa0four/orkowatch/cmd/commands.Version=..."
 */
 var Version = "dev"
+
+// versionCmd prints the application version, matching the --version output
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the orkowatch version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("owatch version %s\n", Version)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}

--- a/internal/osfingerprint/osfingerprint.go
+++ b/internal/osfingerprint/osfingerprint.go
@@ -14,6 +14,7 @@ type OSInfo struct {
 	Platform        string
 	PlatformVersion string
 	KernelVersion   string
+	Hostname        string
 	AdditionalInfo  map[string]string // store any additional OS-Specific details
 }
 
@@ -29,6 +30,7 @@ func GetOSFingerprint() (*OSInfo, error) {
 		Platform:        info.Platform,
 		PlatformVersion: info.PlatformVersion,
 		KernelVersion:   info.KernelVersion,
+		Hostname:        info.Hostname,
 		AdditionalInfo:  make(map[string]string),
 	}
 
@@ -42,7 +44,6 @@ func GetOSFingerprint() (*OSInfo, error) {
 		osInfo.AdditionalInfo["HardwareModel"] = runtime.GOARCH // Specific to MacOS
 	case "linux":
 		osInfo.AdditionalInfo["DistroFamily"] = info.PlatformFamily // Linux/Unix distribution
-		osInfo.AdditionalInfo["Hostname"] = info.Hostname
 	case "freebsd":
 		osInfo.AdditionalInfo["ProductName"] = "FreeBSD"
 	default:
@@ -60,8 +61,8 @@ func PrintOSInfo() {
 		return
 	}
 
-	fmt.Printf("OS: %s\nPlatform: %s\nVersion: %s\nKernel Version: %s\n",
-		osInfo.OS, osInfo.Platform, osInfo.PlatformVersion, osInfo.KernelVersion)
+	fmt.Printf("OS: %s\nHostname: %s\nPlatform: %s\nVersion: %s\nKernel Version: %s\n",
+		osInfo.OS, osInfo.Hostname, osInfo.Platform, osInfo.PlatformVersion, osInfo.KernelVersion)
 
 	// Print additional OS-specific information
 	for key, value := range osInfo.AdditionalInfo {

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -32,8 +32,8 @@ type SecurityAuditor struct {
 type Options struct {
 	Verbose        bool
 	SpecificChecks []string
-	CustomPaths    []string
 	SkipChecks     []string
+	FilePermsPath  string
 	MinSeverity    string
 	Timeout        time.Duration
 	Enrich         bool
@@ -93,12 +93,12 @@ func NewSecurityAuditor(opts Options) *SecurityAuditor {
 		auditor.sshChecker = checker.NewWindowsSSHChecker(ctx)
 		auditor.firewallChecker = checker.NewWindowsFirewallChecker(ctx)
 		auditor.userChecker = checker.NewWindowsUserChecker(ctx)
-		auditor.permissionChecker = checker.NewWindowsPermissionChecker(ctx)
+		auditor.permissionChecker = checker.NewWindowsPermissionChecker(ctx, opts.FilePermsPath)
 	default:
 		auditor.sshChecker = checker.NewUnixSSHChecker(ctx)
 		auditor.firewallChecker = checker.NewUnixFirewallChecker(ctx)
 		auditor.userChecker = checker.NewUnixUserChecker(ctx)
-		auditor.permissionChecker = checker.NewUnixPermissionChecker()
+		auditor.permissionChecker = checker.NewUnixPermissionChecker(opts.FilePermsPath)
 	}
 
 	return auditor

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -72,6 +72,12 @@ type Summary struct {
 	SkippedChecks int
 }
 
+// checkRunner pairs a check's canonical name with its execution function
+type checkRunner struct {
+	name string
+	run  func() types.AuditResult
+}
+
 // NewSecurityAuditor creates a new security auditor based on the OS
 func NewSecurityAuditor(opts Options) *SecurityAuditor {
 	ctx := registry.DetectOS()
@@ -124,7 +130,7 @@ func (sa *SecurityAuditor) RunAudit() (*Result, error) {
 			case "users":
 				checkResult = timeCheck(sa.userChecker.Check)
 				result.Results = append(result.Results, checkResult)
-			case "file-permissions":
+			case "permissions":
 				checkResult = timeCheck(sa.permissionChecker.Check)
 				result.Results = append(result.Results, checkResult)
 			}
@@ -141,45 +147,24 @@ func (sa *SecurityAuditor) runAllChecks(result *Result) (*Result, error) {
 		fmt.Println("[*] Starting comprehensive security audit...")
 	}
 
+	checks := sa.activeChecks()
+	if len(checks) == 0 {
+		return nil, fmt.Errorf("all available checks were skipped; at least one must run")
+	}
+
 	var wg sync.WaitGroup
-	const numSecurityChecks = 4
-	resultsChan := make(chan types.AuditResult, numSecurityChecks)
+	resultsChan := make(chan types.AuditResult, len(checks))
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if sa.verbose {
-			fmt.Println("[*] Running SSH configuration check...")
-		}
-		resultsChan <- timeCheck(sa.sshChecker.Check)
-	}()
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if sa.verbose {
-			fmt.Println("[*] Running firewall configuration check...")
-		}
-		resultsChan <- timeCheck(sa.firewallChecker.Check)
-	}()
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if sa.verbose {
-			fmt.Println("[*] Running user account security check...")
-		}
-		resultsChan <- timeCheck(sa.userChecker.Check)
-	}()
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if sa.verbose {
-			fmt.Println("[*] Running file permissions check...")
-		}
-		resultsChan <- timeCheck(sa.permissionChecker.Check)
-	}()
+	for _, check := range checks {
+		wg.Add(1)
+		go func(c checkRunner) {
+			defer wg.Done()
+			if sa.verbose {
+				fmt.Printf("[*] Running %s check...\n", c.name)
+			}
+			resultsChan <- timeCheck(c.run)
+		}(check)
+	}
 
 	go func() {
 		wg.Wait()
@@ -192,6 +177,33 @@ func (sa *SecurityAuditor) runAllChecks(result *Result) (*Result, error) {
 
 	sa.finalize(result)
 	return result, nil
+}
+
+func (sa *SecurityAuditor) activeChecks() []checkRunner {
+	all := []checkRunner{
+		{name: "ssh", run: sa.sshChecker.Check},
+		{name: "firewall", run: sa.firewallChecker.Check},
+		{name: "users", run: sa.userChecker.Check},
+		{name: "permissions", run: sa.permissionChecker.Check},
+	}
+
+	if len(sa.options.SkipChecks) == 0 {
+		return all
+	}
+
+	skipped := make(map[string]struct{}, len(sa.options.SkipChecks))
+	for _, s := range sa.options.SkipChecks {
+		skipped[s] = struct{}{}
+	}
+
+	active := make([]checkRunner, 0, len(all))
+	for _, c := range all {
+		if _, skip := skipped[c.name]; skip {
+			continue
+		}
+		active = append(active, c)
+	}
+	return active
 }
 
 func (sa *SecurityAuditor) finalize(result *Result) {

--- a/internal/security/checker/permissions.go
+++ b/internal/security/checker/permissions.go
@@ -2,12 +2,14 @@
 package checker
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/papa0four/orkowatch/internal/security/registry"
 	"github.com/papa0four/orkowatch/internal/security/types"
@@ -35,6 +37,19 @@ const (
 	findPermSGID          = "-2000"
 	findPermWorldWritable = "-0002"
 )
+
+// findScanTimeout bounds each FS-wide find operation to prevent audit hang
+const findScanTimeout = 60 * time.Second
+
+// runBoundedFind executes find rooted at "/" and is bounded by findScanTimeout
+func runBoundedFind(args []string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), findScanTimeout)
+	defer cancel()
+
+	full := append([]string{"/", "-xdev"}, args...)
+	cmd := exec.CommandContext(ctx, "find", full...) // #nosec G204 -- find predicate args sourced from hardcoded permission constants, not user input
+	return cmd.CombinedOutput()
+}
 
 // PermissionChecker defines interface for permission checking
 type PermissionChecker interface {
@@ -190,13 +205,11 @@ func (p *UnixPermissionChecker) checkPathPermissions(cp criticalPath, result *ty
 }
 
 func (p *UnixPermissionChecker) checkSUIDFiles(result *types.AuditResult) {
-	cmd := exec.Command("find", "/",
+	output, err := runBoundedFind([]string{
 		"-type", "f",
-		"-perm", findPermSUID, // SUID
-		"-o", "-perm", findPermSGID, // SGID
-	)
-
-	output, err := cmd.CombinedOutput()
+		"-perm", findPermSUID,
+		"-o", "-perm", findPermSGID,
+	})
 	if err != nil {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s Error checking SUID/SGID files: %v", types.SymbolError, err))
@@ -216,13 +229,12 @@ func (p *UnixPermissionChecker) checkSUIDFiles(result *types.AuditResult) {
 }
 
 func (p *UnixPermissionChecker) checkWorldWritableFiles(result *types.AuditResult) {
-	cmd := exec.Command("find", "/",
+	output, err := runBoundedFind([]string{
 		"-type", "f",
 		"-perm", findPermWorldWritable,
 		"-not", "-type", "l",
-		"-ls")
-
-	output, err := cmd.CombinedOutput()
+		"-ls",
+	})
 	if err != nil {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s Error checking world-writable files: %v", types.SymbolError, err))
@@ -242,11 +254,10 @@ func (p *UnixPermissionChecker) checkWorldWritableFiles(result *types.AuditResul
 }
 
 func (p *UnixPermissionChecker) checkUnownedFiles(result *types.AuditResult) {
-	cmd := exec.Command("find", "/",
+	output, err := runBoundedFind([]string{
 		"-nouser", "-o", "-nogroup",
-		"-ls")
-
-	output, err := cmd.CombinedOutput()
+		"-ls",
+	})
 	if err != nil {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s Error checking unowned files: %v", types.SymbolError, err))

--- a/internal/security/checker/permissions.go
+++ b/internal/security/checker/permissions.go
@@ -2,7 +2,9 @@
 package checker
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -41,14 +43,67 @@ const (
 // findScanTimeout bounds each FS-wide find operation to prevent audit hang
 const findScanTimeout = 60 * time.Second
 
+// countUnreadablePaths counts the paths find could not read, i.e. permission denied
+func countUnreadablePaths(stderr []byte) int {
+	if len(stderr) == 0 {
+		return 0
+	}
+	count := 0
+	for _, line := range strings.Split(string(stderr), "\n") {
+		if strings.Contains(line, "Permission denied") {
+			count++
+		}
+	}
+	return count
+}
+
 // runBoundedFind executes find rooted at "/" and is bounded by findScanTimeout
-func runBoundedFind(args []string) ([]byte, error) {
+func runBoundedFind(args []string) (output []byte, skipped int, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), findScanTimeout)
 	defer cancel()
 
 	full := append([]string{"/", "-xdev"}, args...)
 	cmd := exec.CommandContext(ctx, "find", full...) // #nosec G204 -- find predicate args sourced from hardcoded permission constants, not user input
-	return cmd.CombinedOutput()
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	if ctx.Err() == context.DeadlineExceeded {
+		return nil, 0, fmt.Errorf("find timed out after %s", findScanTimeout)
+	}
+
+	// ExitError means find ran and exited non-zero; this is okay
+	var exitErr *exec.ExitError
+	if runErr != nil && !errors.As(runErr, &exitErr) {
+		return nil, 0, runErr
+	}
+
+	return stdout.Bytes(), countUnreadablePaths(stderr.Bytes()), nil
+}
+
+// nonEmptyLines splits find output into clean line-by-line output
+func nonEmptyLines(output []byte) []string {
+	raw := strings.Split(string(output), "\n")
+	lines := make([]string, 0, len(raw))
+	for _, line := range raw {
+		if line = strings.TrimSpace(line); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+// appendSkippedNote annotates the number of paths find could not read
+func appendSkippedNote(result *types.AuditResult, skipped int) {
+	if skipped <= 0 {
+		return
+	}
+	result.Details = append(result.Details,
+		fmt.Sprintf("%s Scanned with %d unreadable paths skipped (run with elevated privileges for complete coverage)",
+			types.SymbolInfo, skipped))
 }
 
 // PermissionChecker defines interface for permission checking
@@ -205,10 +260,9 @@ func (p *UnixPermissionChecker) checkPathPermissions(cp criticalPath, result *ty
 }
 
 func (p *UnixPermissionChecker) checkSUIDFiles(result *types.AuditResult) {
-	output, err := runBoundedFind([]string{
+	output, skipped, err := runBoundedFind([]string{
 		"-type", "f",
-		"-perm", findPermSUID,
-		"-o", "-perm", findPermSGID,
+		"(", "-perm", findPermSUID, "-o", "-perm", findPermSGID, ")",
 	})
 	if err != nil {
 		result.Details = append(result.Details,
@@ -216,20 +270,19 @@ func (p *UnixPermissionChecker) checkSUIDFiles(result *types.AuditResult) {
 		return
 	}
 
-	suidFiles := strings.Split(string(output), "\n")
-	if len(suidFiles) > 0 {
+	files := nonEmptyLines(output)
+	if len(files) > 0 {
 		result.Details = append(result.Details, "\nSUID/SGID Files Found:")
-		for _, file := range suidFiles {
-			if file = strings.TrimSpace(file); file != "" {
-				result.Details = append(result.Details,
-					fmt.Sprintf("%s %s", types.SymbolWarning, file))
-			}
+		for _, file := range files {
+			result.Details = append(result.Details,
+				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
 	}
+	appendSkippedNote(result, skipped)
 }
 
 func (p *UnixPermissionChecker) checkWorldWritableFiles(result *types.AuditResult) {
-	output, err := runBoundedFind([]string{
+	output, skipped, err := runBoundedFind([]string{
 		"-type", "f",
 		"-perm", findPermWorldWritable,
 		"-not", "-type", "l",
@@ -241,20 +294,19 @@ func (p *UnixPermissionChecker) checkWorldWritableFiles(result *types.AuditResul
 		return
 	}
 
-	wwFiles := strings.Split(string(output), "\n")
-	if len(wwFiles) > 0 {
+	files := nonEmptyLines(output)
+	if len(files) > 0 {
 		result.Details = append(result.Details, "\nWorld-Writable Files Found:")
-		for _, file := range wwFiles {
-			if file = strings.TrimSpace(file); file != "" {
-				result.Details = append(result.Details,
-					fmt.Sprintf("%s %s", types.SymbolWarning, file))
-			}
+		for _, file := range files {
+			result.Details = append(result.Details,
+				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
 	}
+	appendSkippedNote(result, skipped)
 }
 
 func (p *UnixPermissionChecker) checkUnownedFiles(result *types.AuditResult) {
-	output, err := runBoundedFind([]string{
+	output, skipped, err := runBoundedFind([]string{
 		"-nouser", "-o", "-nogroup",
 		"-ls",
 	})
@@ -264,16 +316,15 @@ func (p *UnixPermissionChecker) checkUnownedFiles(result *types.AuditResult) {
 		return
 	}
 
-	unownedFiles := strings.Split(string(output), "\n")
-	if len(unownedFiles) > 0 {
+	files := nonEmptyLines(output)
+	if len(files) > 0 {
 		result.Details = append(result.Details, "\nUnowned Files Found:")
-		for _, file := range unownedFiles {
-			if file = strings.TrimSpace(file); file != "" {
-				result.Details = append(result.Details,
-					fmt.Sprintf("%s %s", types.SymbolWarning, file))
-			}
+		for _, file := range files {
+			result.Details = append(result.Details,
+				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
 	}
+	appendSkippedNote(result, skipped)
 }
 
 // Check implements PermissionChecker interface for Windows systems

--- a/internal/security/checker/permissions.go
+++ b/internal/security/checker/permissions.go
@@ -58,12 +58,12 @@ func countUnreadablePaths(stderr []byte) int {
 }
 
 // runBoundedFind executes find rooted at "/" and is bounded by findScanTimeout
-func runBoundedFind(args []string) (output []byte, skipped int, err error) {
+func runBoundedFind(root string, args []string) (output []byte, skipped int, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), findScanTimeout)
 	defer cancel()
 
-	full := append([]string{"/", "-xdev"}, args...)
-	cmd := exec.CommandContext(ctx, "find", full...) // #nosec G204 -- find predicate args sourced from hardcoded permission constants, not user input
+	full := append([]string{root, "-xdev"}, args...)
+	cmd := exec.CommandContext(ctx, "find", full...) // #nosec G204 -- root validated by caller; predicate args sourced from hardcoded permission constants
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -97,13 +97,13 @@ func nonEmptyLines(output []byte) []string {
 }
 
 // appendSkippedNote annotates the number of paths find could not read
-func appendSkippedNote(result *types.AuditResult, skipped int) {
+func appendSkippedNote(result *types.AuditResult, scan string, skipped int) {
 	if skipped <= 0 {
 		return
 	}
 	result.Details = append(result.Details,
-		fmt.Sprintf("%s Scanned with %d unreadable paths skipped (run with elevated privileges for complete coverage)",
-			types.SymbolInfo, skipped))
+		fmt.Sprintf("%s %s: %d unreadable paths skipped (run with elevated privileges for complete coverage)",
+			types.SymbolInfo, scan, skipped))
 }
 
 // PermissionChecker defines interface for permission checking
@@ -113,14 +113,16 @@ type PermissionChecker interface {
 
 // UnixPermissionChecker implements PermissionChecker for Unix-like systems
 type UnixPermissionChecker struct {
-	paths  []criticalPath
-	osType string
+	paths    []criticalPath
+	osType   string
+	scanRoot string
 }
 
 // WindowsPermissionChecker implements PermissionChecker for Windows systems
 type WindowsPermissionChecker struct {
-	Paths []string
-	ctx   registry.OSContext
+	Paths    []string
+	ctx      registry.OSContext
+	scanRoot string
 }
 
 // criticalPath represents a path that needs permission checking
@@ -132,9 +134,10 @@ type criticalPath struct {
 }
 
 // NewUnixPermissionChecker creates a new Unix permission checker
-func NewUnixPermissionChecker() *UnixPermissionChecker {
+func NewUnixPermissionChecker(scanRoot string) *UnixPermissionChecker {
 	checker := &UnixPermissionChecker{
-		osType: runtime.GOOS,
+		osType:   runtime.GOOS,
+		scanRoot: scanRoot,
 	}
 
 	// Set default critical paths based on OS
@@ -143,7 +146,7 @@ func NewUnixPermissionChecker() *UnixPermissionChecker {
 }
 
 // NewWindowsPermissionChecker creates a new Windows permission checker
-func NewWindowsPermissionChecker(ctx registry.OSContext) *WindowsPermissionChecker {
+func NewWindowsPermissionChecker(ctx registry.OSContext, scanRoot string) *WindowsPermissionChecker {
 	return &WindowsPermissionChecker{
 		Paths: []string{
 			"C:\\Windows\\System32",
@@ -152,7 +155,8 @@ func NewWindowsPermissionChecker(ctx registry.OSContext) *WindowsPermissionCheck
 			"C:\\ProgramData",
 			"C:\\Users",
 		},
-		ctx: ctx,
+		ctx:      ctx,
+		scanRoot: scanRoot,
 	}
 }
 
@@ -165,11 +169,13 @@ func (p *UnixPermissionChecker) Check() types.AuditResult {
 		Details:     make([]string, 0),
 	}
 
-	for _, cpath := range p.paths {
-		if err := p.checkPathPermissions(cpath, &result); err != nil {
-			result.Details = append(result.Details,
-				fmt.Sprintf("%s Error checking %s: %v",
-					types.SymbolError, cpath.path, err))
+	if p.scanRoot == "" {
+		for _, cpath := range p.paths {
+			if err := p.checkPathPermissions(cpath, &result); err != nil {
+				result.Details = append(result.Details,
+					fmt.Sprintf("%s Error checking %s: %v",
+						types.SymbolError, cpath.path, err))
+			}
 		}
 	}
 
@@ -179,6 +185,14 @@ func (p *UnixPermissionChecker) Check() types.AuditResult {
 
 	result.Status = "COMPLETED"
 	return result
+}
+
+// effectiveRoot resolves the find scan root; operator supplied
+func (p *UnixPermissionChecker) effectiveRoot() string {
+	if p.scanRoot == "" {
+		return "/"
+	}
+	return p.scanRoot
 }
 
 func (p *UnixPermissionChecker) getCriticalPathConfigs() []criticalPath {
@@ -260,7 +274,8 @@ func (p *UnixPermissionChecker) checkPathPermissions(cp criticalPath, result *ty
 }
 
 func (p *UnixPermissionChecker) checkSUIDFiles(result *types.AuditResult) {
-	output, skipped, err := runBoundedFind([]string{
+	const scan string = "SUID/SGID scan"
+	output, skipped, err := runBoundedFind(p.effectiveRoot(), []string{
 		"-type", "f",
 		"(", "-perm", findPermSUID, "-o", "-perm", findPermSGID, ")",
 	})
@@ -278,11 +293,12 @@ func (p *UnixPermissionChecker) checkSUIDFiles(result *types.AuditResult) {
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
 	}
-	appendSkippedNote(result, skipped)
+	appendSkippedNote(result, scan, skipped)
 }
 
 func (p *UnixPermissionChecker) checkWorldWritableFiles(result *types.AuditResult) {
-	output, skipped, err := runBoundedFind([]string{
+	const scan string = "World-writable scan"
+	output, skipped, err := runBoundedFind(p.effectiveRoot(), []string{
 		"-type", "f",
 		"-perm", findPermWorldWritable,
 		"-not", "-type", "l",
@@ -302,11 +318,12 @@ func (p *UnixPermissionChecker) checkWorldWritableFiles(result *types.AuditResul
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
 	}
-	appendSkippedNote(result, skipped)
+	appendSkippedNote(result, scan, skipped)
 }
 
 func (p *UnixPermissionChecker) checkUnownedFiles(result *types.AuditResult) {
-	output, skipped, err := runBoundedFind([]string{
+	const scan string = "Unowned-files scan"
+	output, skipped, err := runBoundedFind(p.effectiveRoot(), []string{
 		"-nouser", "-o", "-nogroup",
 		"-ls",
 	})
@@ -324,7 +341,7 @@ func (p *UnixPermissionChecker) checkUnownedFiles(result *types.AuditResult) {
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
 	}
-	appendSkippedNote(result, skipped)
+	appendSkippedNote(result, scan, skipped)
 }
 
 // Check implements PermissionChecker interface for Windows systems
@@ -337,8 +354,18 @@ func (p *WindowsPermissionChecker) Check() types.AuditResult {
 		Findings:    make([]types.Finding, 0),
 	}
 
+	if p.scanRoot != "" {
+		if err := p.checkWindowsPermissions(p.scanRoot, true, &result); err != nil {
+			result.Details = append(result.Details,
+				fmt.Sprintf("%s Error checking %s, %v",
+					types.SymbolError, p.scanRoot, err))
+		}
+		result.Status = "COMPLETED"
+		return result
+	}
+
 	for _, path := range p.Paths {
-		if err := p.checkWindowsPermissions(path, &result); err != nil {
+		if err := p.checkWindowsPermissions(path, false, &result); err != nil {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s Error checking %s: %v",
 					types.SymbolError, path, err))
@@ -352,11 +379,11 @@ func (p *WindowsPermissionChecker) Check() types.AuditResult {
 	return result
 }
 
-func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, result *types.AuditResult) error {
-	cmd := exec.Command("icacls", path) // #nosec G204 -- path sourced from hardcoded Windows system directory list, not user input
-	output, err := cmd.CombinedOutput()
+func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, recursive bool, result *types.AuditResult) error {
+	const scan string = "ACL traversal"
+	output, skipped, err := runICACLS(path, recursive)
 	if err != nil {
-		return fmt.Errorf("failed to check permissions: %v", err)
+		return fmt.Errorf("failed to check permissions: %w", err)
 	}
 
 	everyoneFindingAdded := false
@@ -412,7 +439,44 @@ func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, result *
 		}
 	}
 
+	appendSkippedNote(result, scan, skipped)
 	return nil
+}
+
+// runICACLS executes against the given path with optional recursion for tree traversal
+func runICACLS(path string, recursive bool) (output []byte, skipped int, err error) {
+	args := []string{path}
+	if recursive {
+		args = append(args, "/T")
+	}
+	cmd := exec.Command("icacls", args...) // #nosec G204 -- path validated by caller; flags are fixed literals
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	var exitErr *exec.ExitError
+	if runErr != nil && !errors.As(runErr, &exitErr) {
+		return nil, 0, runErr
+	}
+
+	return stdout.Bytes(), countDeniedPaths(stderr.Bytes()), nil
+}
+
+// countDeniedPaths counts the paths icacls could not access
+func countDeniedPaths(stderr []byte) int {
+	if len(stderr) == 0 {
+		return 0
+	}
+	count := 0
+	for _, line := range strings.Split(string(stderr), "\n") {
+		if strings.Contains(line, "Access is denied") {
+			count++
+		}
+	}
+	return count
 }
 
 func (p *WindowsPermissionChecker) checkNetworkShares(result *types.AuditResult) {


### PR DESCRIPTION
## Summary

Parent branch consolidating the full command and flag surface audit. Each
sub-branch merged into `bug/33` under its own PR; this merges the audited
surface to `dev`. Canonical check vocabulary, flag renames, scoped
permissions scanning, the `version` subcommand, and the `all --skip-modules`
fix all land here.

## Changes

- `audit.go` -- `--skip-checks` wired via `checkRunner` and `activeChecks()`;
  all-skipped guard returns a meaningful error (bug/58)
- `permissions.go` -- bounded Unix `find /` with `-xdev` and 60s
  `context.WithTimeout` via `runBoundedFind` (bug/60); `find` exit-status-1
  no longer fatal; SUID/SGID predicate precedence fixed; `countUnreadablePaths`,
  `nonEmptyLines`, `appendSkippedNote` added (bug/62); per-scan labeled
  skipped-paths notes (bug/65)
- `security.go` -- `--file-permissions` wired end-to-end with scoped scan
  root, `validateFilePermsPath`, `effectiveRoot()`; dead `--paths` removed;
  Windows `runICACLS` with `/T` recursion and graceful denied-path handling
  (bug/64); check flags renamed to `--ssh`, `--fwall`, `--users`, `--fperms`
  (chore/68); `Runnning` typo fixed
- `version.go`, `root.go` -- `version` subcommand added; `-v`/`--version`
  conflict resolved by registering `--version` as `-V`, freeing `-v` for
  `--verbose` (chore/72); `all` added to the no-subcommand hint
- `osinfo.go`, `osfingerprint` -- dead `osinfo -v` flag removed; `Hostname`
  promoted to a first-class `OSInfo` field populated on all platforms
- `all.go` -- `--skip-modules` no longer errors when `security` is skipped;
  partial scans render via reworked `convertToAuditResult`;
  `validateSkipModules` rejects invalid module names (bug/74); misleading
  `|| owatch all --verbose` removed from example
- `README.md` -- flag references updated to canonical names (docs/69)

## Verified

`all`, `help`, `--report-file`, `--output` (json/yaml), `--timeout` confirmed
working. Cobra `completion` confirmed generating post-rename for all shells.

## Deferred

`--min-severity` defect and completion sourcing docs to #34. Report-path
write-safety asymmetry between `all` and `security_audit` tracked as Branch D.

Closes #33 