### PR TITLE
[Chore] Add issue, PR, and branch templates plus CONTRIBUTING guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,26 @@
+---
+name: Bug
+about: A confirmed defect with observed behavior
+title: '[Bug] '
+labels: bug
+---
+
+## Summary
+
+<!-- What is broken, in one or two sentences. -->
+
+## Observed behavior
+
+<!-- Actual behavior with command and output. Confirmed, not assumed. -->
+
+## Expected behavior
+
+<!-- What should happen instead. -->
+
+## Scope
+
+<!-- Files or subsystems involved, if known. -->
+
+## Acceptance criteria
+
+- [ ]

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,18 @@
+---
+name: Chore
+about: Housekeeping, tooling, or maintenance with no user-facing behavior change
+title: '[Chore] '
+labels: chore
+---
+
+## Summary
+
+<!-- The maintenance work and why it is needed now. -->
+
+## Scope
+
+<!-- Files or areas touched. -->
+
+## Acceptance criteria
+
+- [ ]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,18 @@
+---
+name: Docs
+about: Documentation additions or corrections
+title: '[Docs] '
+labels: docs
+---
+
+## Summary
+
+<!-- What documentation is added or corrected. -->
+
+## Scope
+
+<!-- Files or sections involved. -->
+
+## Acceptance criteria
+
+- [ ]

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,26 @@
+---
+name: Enhancement
+about: New capability or improvement to existing behavior
+title: '[Enhancement] '
+labels: enhancement
+---
+
+## Summary
+
+<!-- What the enhancement adds. -->
+
+## Motivation
+
+<!-- The problem it solves or value it adds. -->
+
+## Scope
+
+<!-- Files, subsystems, or new components involved. -->
+
+## Acceptance criteria
+
+- [ ] 
+
+## Out of scope
+
+<!-- What this issue explicitly does not cover. -->

--- a/.github/ISSUE_TEMPLATE/infrastructure.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure.md
@@ -1,0 +1,26 @@
+---
+name: Infrastructure
+about: CI, pipelines, build, release, or environment work
+title: '[Infrastructure] '
+labels: infrastructure
+---
+
+## Summary
+
+<!-- The infrastructure work and the capability it enables. -->
+
+## Motivation
+
+<!-- Why it is needed now. -->
+
+## Scope
+
+<!-- Pipelines, configs, or environments involved. -->
+
+## Acceptance criteria
+
+- [ ] 
+
+## Out of scope
+
+<!-- What this issue explicitly does not cover. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What this PR does and why, in a few sentences. -->
+
+## Changes
+
+- `path` -- description
+
+## Verified
+
+- [ ] `gofmt -w .`
+- [ ] `go build ./...`
+- [ ] `go vet ./...`
+- [ ] `gosec ./...`
+- [ ] `govulncheck ./...`
+- [ ] `golangci-lint run --timeout=5m`
+- [ ] `GOOS=windows go build ./...` (cross-platform changes)
+
+Closes #

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to orkowatch
+
+orkowatch is a cross-platform host security auditing CLI. These conventions
+keep `dev` known-good and make intent explicit for anyone picking up the work.
+
+## Priorities
+
+Every decision is weighed in this order, and none is compromised for
+short-term ease:
+
+1. Scalable
+2. Optimal
+3. Thorough
+4. Safe
+5. Modular
+
+## Branch naming
+
+`<type>/<issue#>-<short-description>`
+
+- Types: `bug`, `enhancement`, `chore`, `docs`, `infrastructure`
+- Issue number is the GitHub issue this branch resolves
+- Description is lowercase, hyphen-separated, short enough to read at a glance
+
+Example: `chore/77-add-issue-pr-and-branch-templates`
+
+## Workflow
+
+- One problem at a time. Cut sub-branches one at a time to avoid rebase debt.
+- Sub-branches merge into their parent before the parent merges up.
+- `dev` is always known-good. `main` holds tagged releases only.
+- Open the matching GitHub issue before cutting the branch.
+
+## Pipeline gate
+
+The full local pipeline must pass before any merge:
+
+- `gofmt -w .`
+- `go build ./...`
+- `go vet ./...`
+- `gosec ./...`
+- `govulncheck ./...`
+- `golangci-lint run --timeout=5m`
+- `GOOS=windows go build ./...` for any cross-platform change
+
+## Pull requests
+
+- Follow the PR template. Fill the `Closes #` line with the issue number so
+  the linked issue auto-closes on merge.
+- Keep the `## Summary` / `## Changes` / `## Verified` structure.
+
+## Registry citations
+
+YAML registry entries require verified citable sources (CIS, NIST, or
+equivalent). Fabricated or stretched citations are not accepted. A check idea
+taken from a reference manual still needs a primary citation behind the entry.
+
+## Code conventions
+
+- Comments explain why, briefly. Naming carries meaning. Verbose explanation
+  lives in docs, not code.
+- Exported types and functions get doc comments in the `Name ...` form.
+- Named constants for domain values; structural indices may stay literal.
+- Use merge/merged/merging, not promote.


### PR DESCRIPTION
## Summary

Commits the contributor conventions that were previously held only by habit:
typed issue templates, a PR skeleton with a pre-baked `Closes` line, and a
CONTRIBUTING guide covering branch naming, workflow, the pipeline gate, and
the priority order. Removes the format drift that came from reconstructing
each issue and PR from memory.

## Changes

- `.github/ISSUE_TEMPLATE/config.yml` -- disable blank issues
- `.github/ISSUE_TEMPLATE/{bug,enhancement,chore,docs,infrastructure}.md` --
  one typed template per branch type
- `.github/PULL_REQUEST_TEMPLATE.md` -- Summary / Changes / Verified skeleton
  with pipeline checklist and a pre-baked `Closes #` line
- `CONTRIBUTING.md` -- priorities, branch naming, workflow, pipeline gate, PR
  and registry-citation conventions

## Verified

- [x] `gofmt -w .`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Five templates render in the Issues UI, no blank option
- [ ] PR body pre-fills from the template

Closes #77 