### PR TITLE
[Bug] Validate report file writes before writing to disk

### DIFF
--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -2,8 +2,9 @@
 package cmd
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
-	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -12,18 +13,20 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/papa0four/orkowatch/internal/osfingerprint"
+	"github.com/papa0four/orkowatch/internal/report"
 	"github.com/papa0four/orkowatch/internal/security/audit"
 	"github.com/papa0four/orkowatch/internal/security/formatter"
 	"github.com/papa0four/orkowatch/internal/softwarelist"
 )
 
 var (
-	allVerbose      bool
-	allOutputFormat string
-	allReportFile   string
-	skipModules     []string
-	allTimeout      time.Duration
-	allEnrich       bool
+	allVerbose            bool
+	allEnrich             bool
+	allAllowElevatedWrite bool
+	allOutputFormat       string
+	allReportFile         string
+	skipModules           []string
+	allTimeout            time.Duration
 )
 
 // allCmd represents the all command that combines all scanning modules
@@ -64,6 +67,8 @@ func init() {
 		"Maximum time to run all scans")
 	allCmd.Flags().BoolVarP(&allEnrich, "enrich", "e", false,
 		"Query external sources to annotate findings with CVEs mapped to referenced CWEs")
+	allCmd.Flags().BoolVar(&allAllowElevatedWrite, "allow-elevated-write", false,
+		"Permit an elevated write outside the allowlisted directories")
 
 	RootCmd.AddCommand(allCmd)
 }
@@ -262,31 +267,34 @@ func outputResults(result *ScanResult) error {
 	opts := formatter.FormatOptions{
 		Format:        formatter.OutputFormat(allOutputFormat),
 		Verbose:       allVerbose,
-		ColorOutput:   isTerminal(),
+		ColorOutput:   isTerminal() && allReportFile == "",
 		IncludeSystem: true,
 		Compact:       false,
 	}
 
-	var output io.Writer = os.Stdout
-	if allReportFile != "" {
-		if err := isSafeReportPath(allReportFile); err != nil {
-			return fmt.Errorf("invalid report file path: %w", err)
-		}
-		file, err := os.Create(allReportFile) // #nosec G304 -- path validated by isSafeReportPath before use
-		if err != nil {
-			return fmt.Errorf("failed to create report file: %w", err)
-		}
-		defer file.Close() //nolint:errcheck // report file written successfully before close; close error does not affect output
-		output = file
-	}
-
 	auditResult := convertToAuditResult(result)
 
-	f := formatter.NewFormatter(output, opts)
+	var buf bytes.Buffer
+	f := formatter.NewFormatter(&buf, opts)
 	if err := f.Format(auditResult); err != nil {
 		return fmt.Errorf("failed to format results: %w", err)
 	}
 
+	if allReportFile == "" {
+		fmt.Print(buf.String())
+		return nil
+	}
+
+	wOpts := report.Options{AllowElevatedWrite: allAllowElevatedWrite}
+	if err := report.Write(allReportFile, buf.Bytes(), wOpts); err != nil {
+		if errors.Is(err, report.ErrElevatedWriteDenied) {
+			return fmt.Errorf("%w; pass --allow-elevated-write to permit it", err)
+		}
+		return fmt.Errorf("failed to write report file: %w", err)
+	}
+	if allVerbose {
+		fmt.Printf("[+] Report saved to: %s\n", allReportFile)
+	}
 	return nil
 }
 
@@ -310,16 +318,4 @@ func isTerminal() bool {
 		return false
 	}
 	return (fileInfo.Mode() & os.ModeCharDevice) != 0
-}
-
-// isSafeReportPath validates the report file path to prevent
-// path traversal attacks (CWE-22) when creating output files.
-func isSafeReportPath(path string) error {
-	if strings.Contains(path, "..") {
-		return fmt.Errorf("report file path must not contain traversal sequences: %s", path)
-	}
-	if path == "" {
-		return fmt.Errorf("report file path must not be empty")
-	}
-	return nil
 }

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -12,10 +12,12 @@ import (
 
 // RootCmd defines the base command for the CLI
 var RootCmd = &cobra.Command{
-	Use:     "owatch",
-	Version: Version,
-	Short:   "orkowatch is a lightweight scanner for host OS vulnerabilities",
-	Long:    `orkowatch helps engineers and architects scan for vulnerabilities in OS, software, and security protocols`,
+	Use:           "owatch",
+	Version:       Version,
+	Short:         "orkowatch is a lightweight scanner for host OS vulnerabilities",
+	Long:          `orkowatch helps engineers and architects scan for vulnerabilities in OS, software, and security protocols`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("owatch requires a subcommand (e.g., all, osinfo, security_audit, software).")
 		if err := cmd.Help(); err != nil {

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -3,6 +3,7 @@ package security
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/papa0four/orkowatch/internal/report"
 	"github.com/papa0four/orkowatch/internal/security/audit"
 	"github.com/papa0four/orkowatch/internal/security/types"
 )
@@ -32,6 +34,9 @@ var (
 
 	// enrichment flag
 	enrich bool
+
+	// allow escalated dir write
+	allowElevatedWrite bool
 )
 
 // SecurityCmd represents the security audit command
@@ -134,6 +139,8 @@ func init() {
 		"Check permissions of specified file path")
 	SecurityCmd.Flags().BoolVarP(&enrich, "enrich", "e", false,
 		"Query external sources to annotate findings with CVEs mapped to referenced CWEs")
+	SecurityCmd.Flags().BoolVar(&allowElevatedWrite, "allow-elevated-write", false,
+		"Permit an elevated write outside the allowlisted directories")
 }
 
 func buildChecks() []string {
@@ -282,7 +289,11 @@ func outputResults(result *audit.Result) error {
 	}
 
 	if reportFile != "" {
-		if err := os.WriteFile(reportFile, []byte(output), 0600); err != nil {
+		opts := report.Options{AllowElevatedWrite: allowElevatedWrite}
+		if err := report.Write(reportFile, []byte(output), opts); err != nil {
+			if errors.Is(err, report.ErrElevatedWriteDenied) {
+				return fmt.Errorf("%w; pass --allow-elevated-write to permit it", err)
+			}
 			return fmt.Errorf("failed to write report file: %w", err)
 		}
 		if verbose {

--- a/internal/report/report_unix.go
+++ b/internal/report/report_unix.go
@@ -123,7 +123,9 @@ func openAndWrite(target string, data []byte) error {
 	}
 
 	if _, err := f.Write(data); err != nil {
-		_ = f.Close()
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("close file: %w", err)
+		}
 		return fmt.Errorf("write report: %w", err)
 	}
 	return f.Close()

--- a/internal/report/report_unix.go
+++ b/internal/report/report_unix.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 )
 
+const reportFileMode = 0600
+
 // systemRoots are refused because they sensitive to an attacker
 var systemRoots = []string{
 	"/etc", "/usr", "/bin", "/sbin", "/lib", "/lib64",
@@ -104,31 +106,32 @@ func invokingUserHome() string {
 }
 
 // openAndWrite writes data to target with no-follow semantics
-func openAndWrite(target string, data []byte) error {
-	if info, err := os.Lstat(target); err == nil {
+func openAndWrite(target string, data []byte) (err error) {
+	if info, lerr := os.Lstat(target); lerr == nil {
 		if info.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("%w: symlink", ErrNotRegularFile)
 		}
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("%w: %s", ErrNotRegularFile, target)
 		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("stat destination: %w", err)
+	} else if !errors.Is(lerr, os.ErrNotExist) {
+		return fmt.Errorf("stat destination: %w", lerr)
 	}
 
-	// target is validated through the guard pipeline above and opened no-follow.
-	f, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, reportFileMode) // #nosec G304 -- validated, no-follow write
+	f, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, reportFileMode) // #nosec G304 -- target validated through the guard pipeline and opened no-follow
 	if err != nil {
 		return fmt.Errorf("open destination: %w", err)
 	}
-
-	if _, err := f.Write(data); err != nil {
-		if err := f.Close(); err != nil {
-			return fmt.Errorf("close file: %w", err)
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
 		}
-		return fmt.Errorf("write report: %w", err)
+	}()
+
+	if _, werr := f.Write(data); werr != nil {
+		return fmt.Errorf("write report: %w", werr)
 	}
-	return f.Close()
+	return nil
 }
 
 // parentWritableByOthers reports whether dir grants write to group or other

--- a/internal/report/report_unix.go
+++ b/internal/report/report_unix.go
@@ -1,0 +1,140 @@
+// internal/report/report_unix.go
+//go:build linux || darwin || freebsd || openbsd
+// +build linux darwin freebsd openbsd
+
+package report
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"syscall"
+)
+
+// systemRoots are refused because they sensitive to an attacker
+var systemRoots = []string{
+	"/etc", "/usr", "/bin", "/sbin", "/lib", "/lib64",
+	"/boot", "/sys", "/proc", "/dev", "/root",
+	"/run", "/var/run", "/var/spool/cron",
+	"/System", "/Library/LaunchDaemons", "/Library/LaunchAgents",
+}
+
+// userPersistence are home-relative locations that are refused due to their sensitivity
+var userPersistence = []string{
+	".ssh", ".config/autostart", ".config/systemd/user",
+	".bashrc", ".bash_profile", ".profile", ".zshrc",
+	"Library/LaunchAgents",
+}
+
+// canonicalParent resolves the parent chain so the location checks compare
+// against the real directory
+func canonicalParent(parent string) (string, error) {
+	real, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", ErrParentMissing, parent)
+	}
+	return real, nil
+}
+
+func refusedReason(target string) string {
+	for _, root := range systemRoots {
+		if pathWithin(target, root) {
+			return root
+		}
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	for _, rel := range userPersistence {
+		base := filepath.Join(home, rel)
+		if pathWithin(target, base) {
+			return base
+		}
+	}
+	return ""
+}
+
+// isElevated reports root, where a write can land anywhere and the tool becomes
+// a privileged write primitive.
+func isElevated() (bool, error) {
+	return os.Geteuid() == 0, nil
+}
+
+// withinAllowlist permits an elevated write only under roots the operator clearly owns
+func withinAllowlist(target string) (bool, error) {
+	for _, root := range allowlistRoots() {
+		real, err := filepath.EvalSymlinks(root)
+		if err != nil {
+			continue
+		}
+		if pathWithin(target, real) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func allowlistRoots() []string {
+	roots := make([]string, 0, 2)
+	if cwd, err := os.Getwd(); err == nil {
+		roots = append(roots, cwd)
+	}
+	if home := invokingUserHome(); home != "" {
+		roots = append(roots, home)
+	}
+	return roots
+}
+
+// invokingUserHome returns the home of the user behind sudo, so an elevated run
+// can still target that user's space rather than only root's.
+func invokingUserHome() string {
+	name := os.Getenv("SUDO_USER")
+	if name == "" {
+		return ""
+	}
+	u, err := user.Lookup(name)
+	if err != nil {
+		return ""
+	}
+	return u.HomeDir
+}
+
+// openAndWrite writes data to target with no-follow semantics
+func openAndWrite(target string, data []byte) error {
+	if info, err := os.Lstat(target); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: symlink", ErrNotRegularFile)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("%w: %s", ErrNotRegularFile, target)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat destination: %w", err)
+	}
+
+	// target is validated through the guard pipeline above and opened no-follow.
+	f, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, reportFileMode) // #nosec G304 -- validated, no-follow write
+	if err != nil {
+		return fmt.Errorf("open destination: %w", err)
+	}
+
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write report: %w", err)
+	}
+	return f.Close()
+}
+
+// parentWritableByOthers reports whether dir grants write to group or other
+func parentWritableByOthers(dir string) (bool, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return false, err
+	}
+	const groupOrOtherWrite = 0022
+	return info.Mode().Perm()&groupOrOtherWrite != 0, nil
+}

--- a/internal/report/report_windows.go
+++ b/internal/report/report_windows.go
@@ -14,6 +14,9 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// fileDeleteChild is the directory right to delete child objects
+const fileDeleteChild = 0x40
+
 func refusedReason(target string) string {
 	// Windows paths are case-insensitive, so fold both sides before comparing.
 	target = strings.ToLower(filepath.Clean(target))
@@ -48,8 +51,7 @@ func refusedBases() []string {
 
 // canonicalParent returns the OS-resolved long-form path of parent so the
 // location checks cannot be evaded by 8.3 short names, links, or trailing dots
-// and spaces. Extended-length and device prefixes are refused, since a report
-// path has no legitimate use for them.
+// and spaces.
 func canonicalParent(parent string) (string, error) {
 	if strings.HasPrefix(parent, `\\?\`) || strings.HasPrefix(parent, `\\.\`) {
 		return "", fmt.Errorf("%w: extended-length or device path", ErrRefusedLocation)
@@ -73,11 +75,15 @@ func canonicalParent(parent string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("%w: %s", ErrParentMissing, parent)
 	}
-	defer windows.CloseHandle(h)
+	defer func() {
+		if cerr := windows.CloseHandle(h); cerr != nil && err == nil {
+			err = fmt.Errorf("close directory handle: %w", cerr)
+		}
+	}()
 
 	const finalPathFlags = 0
 	buf := make([]uint16, windows.MAX_PATH)
-	n, err := windows.GetFinalPathNameByHandle(h, &buf[0], uint32(len(buf)), finalPathFlags)
+	n, err := windows.GetFinalPathNameByHandle(h, &buf[0], windows.MAX_PATH, finalPathFlags)
 	if err != nil {
 		return "", fmt.Errorf("canonicalize path: %w", err)
 	}
@@ -128,97 +134,101 @@ func allowlistRoots() []string {
 	return roots
 }
 
-var (
-	advapi32                      = windows.NewLazySystemDLL("advapi32.dll")
-	procGetEffectiveRightsFromACL = advapi32.NewProc("GetEffectiveRightsFromAclW")
-)
-
-// trusteeW mirrors TRUSTEE_W. For a SID-form trustee, Name holds the SID pointer.
-type trusteeW struct {
-	MultipleTrustee          *trusteeW
-	MultipleTrusteeOperation uint32
-	TrusteeForm              uint32
-	TrusteeType              uint32
-	Name                     *uint16
-}
-
-const (
-	trusteeIsSid     = 0 // TRUSTEE_IS_SID
-	trusteeIsUnknown = 0 // TRUSTEE_IS_UNKNOWN
-)
-
 // parentWritableByOthers reports whether a broad group has effective write
 // access to dir.
 func parentWritableByOthers(dir string) (bool, error) {
-	sd, err := windows.GetNamedSecurityInfo(dir, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	sd, err := windows.GetNamedSecurityInfo(
+		dir,
+		windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION,
+	)
 	if err != nil {
 		return false, fmt.Errorf("read security info: %w", err)
 	}
-	dacl, present, err := sd.DACL()
+
+	dacl, _, err := sd.DACL()
+	if errors.Is(err, windows.ERROR_OBJECT_NOT_FOUND) {
+		// No DACL exists; a NULL DACL grants everyone full access.
+		return true, nil
+	}
 	if err != nil {
 		return false, fmt.Errorf("read dacl: %w", err)
 	}
-	// A NULL DACL grants everyone full access, so treat its absence as exposed.
-	if !present || dacl == nil {
+	// A nil DACL here is an empty, fully permissive DACL.
+	if dacl == nil {
 		return true, nil
 	}
 
-	broad, err := broadSIDs()
+	trusted, err := trustedSIDs(sd)
 	if err != nil {
 		return false, err
 	}
 
-	const fileDeleteChild = 0x40
 	const writeMask = windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA |
 		fileDeleteChild | windows.DELETE |
 		windows.GENERIC_WRITE | windows.GENERIC_ALL |
 		windows.WRITE_DAC | windows.WRITE_OWNER
 
-	for _, sid := range broad {
-		mask, err := effectiveRights(dacl, sid)
-		if err != nil {
-			return false, err
+	// ACL field construction
+	type aclLayout struct {
+		revision byte
+		sbz1     byte
+		size     byte
+		count    uint16
+		sbz2     uint16
+	}
+	hdr := (*aclLayout)(unsafe.Pointer(dacl))                                  // #nosec G103 -- audited ACE walk over the fixed OS ACL layout
+	end := uintptr(unsafe.Pointer(dacl)) + uintptr(hdr.size)                   // #nosec G103 -- ACL end boundary, compared only and never converted back to a pointer
+	ace := unsafe.Pointer(uintptr(unsafe.Pointer(dacl)) + unsafe.Sizeof(*hdr)) // #nosec G103 -- first ACE follows the ACL header
+
+	for i := 0; i < int(hdr.count); i++ {
+		header := (*windows.ACE_HEADER)(ace) // #nosec G103 -- bounded ACE read within the ACL buffer
+		if header.AceSize == 0 || uintptr(ace)+uintptr(header.AceSize) > end {
+			break // malformed entry; do not read past the ACL buffer
 		}
-		if mask&writeMask != 0 {
-			return true, nil
+
+		if header.AceType == windows.ACCESS_ALLOWED_ACE_TYPE {
+			allowed := (*windows.ACCESS_ALLOWED_ACE)(ace)
+			if allowed.Mask&writeMask != 0 {
+				sid := (*windows.SID)(unsafe.Pointer(&allowed.SidStart)) // #nosec G103 -- SID embedded in the validated ACE
+				if !sidTrusted(sid, trusted) {
+					return true, nil
+				}
+			}
 		}
+
+		ace = unsafe.Pointer(uintptr(ace) + uintptr(header.AceSize)) // #nosec G103 -- advance within the bounds-checked ACL buffer
 	}
 	return false, nil
 }
 
-func effectiveRights(dacl *windows.ACL, sid *windows.SID) (uint32, error) {
-	trustee := trusteeW{
-		TrusteeForm: trusteeIsSid,
-		TrusteeType: trusteeIsUnknown,
-		Name:        (*uint16)(unsafe.Pointer(sid)),
+func trustedSIDs(sd *windows.SECURITY_DESCRIPTOR) ([]*windows.SID, error) {
+	wellKnown := []windows.WELL_KNOWN_SID_TYPE{
+		windows.WinLocalSystemSid,
+		windows.WinBuiltinAdministratorsSid,
+		windows.WinCreatorOwnerSid,
 	}
-	var mask uint32
-	ret, _, _ := procGetEffectiveRightsFromACL.Call(
-		uintptr(unsafe.Pointer(dacl)),
-		uintptr(unsafe.Pointer(&trustee)),
-		uintptr(unsafe.Pointer(&mask)),
-	)
-	if ret != 0 {
-		return 0, fmt.Errorf("effective rights: error %d", ret)
-	}
-	return mask, nil
-}
-
-func broadSIDs() ([]*windows.SID, error) {
-	types := []windows.WELL_KNOWN_SID_TYPE{
-		windows.WinWorldSid,             // Everyone
-		windows.WinAuthenticatedUserSid, // Authenticated Users
-		windows.WinBuiltinUsersSid,      // Users
-	}
-	sids := make([]*windows.SID, 0, len(types))
-	for _, t := range types {
+	trusted := make([]*windows.SID, 0, len(wellKnown)+1)
+	for _, t := range wellKnown {
 		sid, err := windows.CreateWellKnownSid(t)
 		if err != nil {
 			return nil, fmt.Errorf("well-known sid: %w", err)
 		}
-		sids = append(sids, sid)
+		trusted = append(trusted, sid)
 	}
-	return sids, nil
+	if owner, _, err := sd.Owner(); err == nil && owner != nil {
+		trusted = append(trusted, owner)
+	}
+	return trusted, nil
+}
+
+func sidTrusted(sid *windows.SID, trusted []*windows.SID) bool {
+	for _, t := range trusted {
+		if sid.Equals(t) {
+			return true
+		}
+	}
+	return false
 }
 
 // openAndWrite writes data to target without traversing a reparse point
@@ -254,26 +264,26 @@ func openAndWrite(target string, data []byte) error {
 		return fmt.Errorf("open destination: %w", err)
 	}
 	f := os.NewFile(uintptr(handle), target)
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	var fi windows.ByHandleFileInformation
-	if err := windows.GetFileInformationByHandle(handle, &fi); err != nil {
-		f.Close()
-		return fmt.Errorf("inspect destination: %w", err)
+	if ierr := windows.GetFileInformationByHandle(handle, &fi); err != nil {
+		return fmt.Errorf("inspect destination: %w", ierr)
 	}
 	if fi.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-		f.Close()
 		return fmt.Errorf("%w: reparse point", ErrNotRegularFile)
 	}
 
-	// Truncate only after the reparse check so a rejected link keeps its content.
-	if err := windows.SetEndOfFile(handle); err != nil {
-		f.Close()
-		return fmt.Errorf("truncate destination: %w", err)
+	if serr := windows.SetEndOfFile(handle); serr != nil {
+		return fmt.Errorf("truncate destination: %w", serr)
 	}
 
-	if _, err := f.Write(data); err != nil {
-		f.Close()
-		return fmt.Errorf("write report: %w", err)
+	if _, werr := f.Write(data); werr != nil {
+		return fmt.Errorf("write report: %w", werr)
 	}
-	return f.Close()
+	return nil
 }

--- a/internal/report/report_windows.go
+++ b/internal/report/report_windows.go
@@ -1,0 +1,279 @@
+// internal/report/report_windows.go
+//go:build windows
+
+package report
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func refusedReason(target string) string {
+	// Windows paths are case-insensitive, so fold both sides before comparing.
+	target = strings.ToLower(filepath.Clean(target))
+	for _, base := range refusedBases() {
+		if pathWithin(target, strings.ToLower(filepath.Clean(base))) {
+			return base
+		}
+	}
+	return ""
+}
+
+// refusedBases resolves system and per-user persistence locations from the
+// environment, refused because they hold OS files, installed programs, and the
+// Startup folders an attacker would use for persistence.
+func refusedBases() []string {
+	startupRel := filepath.Join("Microsoft", "Windows", "Start Menu", "Programs", "Startup")
+
+	bases := make([]string, 0, 5)
+	for _, env := range []string{"SystemRoot", "ProgramFiles", "ProgramFiles(x86)"} {
+		if v := os.Getenv(env); v != "" {
+			bases = append(bases, v)
+		}
+	}
+	if pd := os.Getenv("ProgramData"); pd != "" {
+		bases = append(bases, filepath.Join(pd, startupRel))
+	}
+	if ad := os.Getenv("APPDATA"); ad != "" {
+		bases = append(bases, filepath.Join(ad, startupRel))
+	}
+	return bases
+}
+
+// canonicalParent returns the OS-resolved long-form path of parent so the
+// location checks cannot be evaded by 8.3 short names, links, or trailing dots
+// and spaces. Extended-length and device prefixes are refused, since a report
+// path has no legitimate use for them.
+func canonicalParent(parent string) (string, error) {
+	if strings.HasPrefix(parent, `\\?\`) || strings.HasPrefix(parent, `\\.\`) {
+		return "", fmt.Errorf("%w: extended-length or device path", ErrRefusedLocation)
+	}
+
+	p, err := windows.UTF16PtrFromString(parent)
+	if err != nil {
+		return "", fmt.Errorf("encode path: %w", err)
+	}
+
+	// Backup semantics are required to obtain a directory handle.
+	h, err := windows.CreateFile(
+		p,
+		windows.FILE_READ_ATTRIBUTES,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", ErrParentMissing, parent)
+	}
+	defer windows.CloseHandle(h)
+
+	const finalPathFlags = 0
+	buf := make([]uint16, windows.MAX_PATH)
+	n, err := windows.GetFinalPathNameByHandle(h, &buf[0], uint32(len(buf)), finalPathFlags)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize path: %w", err)
+	}
+	if int(n) > len(buf) {
+		buf = make([]uint16, n)
+		if _, err := windows.GetFinalPathNameByHandle(h, &buf[0], n, finalPathFlags); err != nil {
+			return "", fmt.Errorf("canonicalize path: %w", err)
+		}
+	}
+
+	final := windows.UTF16ToString(buf)
+	if rest := strings.TrimPrefix(final, `\\?\UNC\`); rest != final {
+		return `\\` + rest, nil
+	}
+	return strings.TrimPrefix(final, `\\?\`), nil
+}
+
+// isElevated reports an elevated (Administrator) token, where a write can land
+// anywhere and the tool becomes a privileged write primitive.
+func isElevated() (bool, error) {
+	return windows.GetCurrentProcessToken().IsElevated(), nil
+}
+
+// withinAllowlist permits an elevated write only under roots the operator
+// clearly owns, so a privileged run cannot silently write elsewhere.
+func withinAllowlist(target string) (bool, error) {
+	target = strings.ToLower(filepath.Clean(target))
+	for _, root := range allowlistRoots() {
+		real, err := canonicalParent(root)
+		if err != nil {
+			continue
+		}
+		if pathWithin(target, strings.ToLower(filepath.Clean(real))) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func allowlistRoots() []string {
+	roots := make([]string, 0, 2)
+	if cwd, err := os.Getwd(); err == nil {
+		roots = append(roots, cwd)
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		roots = append(roots, home)
+	}
+	return roots
+}
+
+var (
+	advapi32                      = windows.NewLazySystemDLL("advapi32.dll")
+	procGetEffectiveRightsFromACL = advapi32.NewProc("GetEffectiveRightsFromAclW")
+)
+
+// trusteeW mirrors TRUSTEE_W. For a SID-form trustee, Name holds the SID pointer.
+type trusteeW struct {
+	MultipleTrustee          *trusteeW
+	MultipleTrusteeOperation uint32
+	TrusteeForm              uint32
+	TrusteeType              uint32
+	Name                     *uint16
+}
+
+const (
+	trusteeIsSid     = 0 // TRUSTEE_IS_SID
+	trusteeIsUnknown = 0 // TRUSTEE_IS_UNKNOWN
+)
+
+// parentWritableByOthers reports whether a broad group has effective write
+// access to dir.
+func parentWritableByOthers(dir string) (bool, error) {
+	sd, err := windows.GetNamedSecurityInfo(dir, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return false, fmt.Errorf("read security info: %w", err)
+	}
+	dacl, present, err := sd.DACL()
+	if err != nil {
+		return false, fmt.Errorf("read dacl: %w", err)
+	}
+	// A NULL DACL grants everyone full access, so treat its absence as exposed.
+	if !present || dacl == nil {
+		return true, nil
+	}
+
+	broad, err := broadSIDs()
+	if err != nil {
+		return false, err
+	}
+
+	const fileDeleteChild = 0x40
+	const writeMask = windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA |
+		fileDeleteChild | windows.DELETE |
+		windows.GENERIC_WRITE | windows.GENERIC_ALL |
+		windows.WRITE_DAC | windows.WRITE_OWNER
+
+	for _, sid := range broad {
+		mask, err := effectiveRights(dacl, sid)
+		if err != nil {
+			return false, err
+		}
+		if mask&writeMask != 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func effectiveRights(dacl *windows.ACL, sid *windows.SID) (uint32, error) {
+	trustee := trusteeW{
+		TrusteeForm: trusteeIsSid,
+		TrusteeType: trusteeIsUnknown,
+		Name:        (*uint16)(unsafe.Pointer(sid)),
+	}
+	var mask uint32
+	ret, _, _ := procGetEffectiveRightsFromACL.Call(
+		uintptr(unsafe.Pointer(dacl)),
+		uintptr(unsafe.Pointer(&trustee)),
+		uintptr(unsafe.Pointer(&mask)),
+	)
+	if ret != 0 {
+		return 0, fmt.Errorf("effective rights: error %d", ret)
+	}
+	return mask, nil
+}
+
+func broadSIDs() ([]*windows.SID, error) {
+	types := []windows.WELL_KNOWN_SID_TYPE{
+		windows.WinWorldSid,             // Everyone
+		windows.WinAuthenticatedUserSid, // Authenticated Users
+		windows.WinBuiltinUsersSid,      // Users
+	}
+	sids := make([]*windows.SID, 0, len(types))
+	for _, t := range types {
+		sid, err := windows.CreateWellKnownSid(t)
+		if err != nil {
+			return nil, fmt.Errorf("well-known sid: %w", err)
+		}
+		sids = append(sids, sid)
+	}
+	return sids, nil
+}
+
+// openAndWrite writes data to target without traversing a reparse point
+func openAndWrite(target string, data []byte) error {
+	if info, err := os.Lstat(target); err == nil {
+		if info.Mode()&(os.ModeSymlink|os.ModeIrregular) != 0 {
+			return fmt.Errorf("%w: reparse point", ErrNotRegularFile)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("%w: %s", ErrNotRegularFile, target)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat destination: %w", err)
+	}
+
+	path, err := windows.UTF16PtrFromString(target)
+	if err != nil {
+		return fmt.Errorf("encode path: %w", err)
+	}
+
+	// OPEN_REPARSE_POINT opens the final component literally instead of
+	// traversing it; OPEN_ALWAYS avoids truncating before the reparse check.
+	handle, err := windows.CreateFile(
+		path,
+		windows.GENERIC_WRITE,
+		0,
+		nil,
+		windows.OPEN_ALWAYS,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("open destination: %w", err)
+	}
+	f := os.NewFile(uintptr(handle), target)
+
+	var fi windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &fi); err != nil {
+		f.Close()
+		return fmt.Errorf("inspect destination: %w", err)
+	}
+	if fi.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		f.Close()
+		return fmt.Errorf("%w: reparse point", ErrNotRegularFile)
+	}
+
+	// Truncate only after the reparse check so a rejected link keeps its content.
+	if err := windows.SetEndOfFile(handle); err != nil {
+		f.Close()
+		return fmt.Errorf("truncate destination: %w", err)
+	}
+
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return fmt.Errorf("write report: %w", err)
+	}
+	return f.Close()
+}

--- a/internal/report/write.go
+++ b/internal/report/write.go
@@ -26,8 +26,6 @@ type Options struct {
 	AllowElevatedWrite bool
 }
 
-const reportFileMode = 0600
-
 // Write validates path through the full guard pipeline and writes data to it,
 func Write(path string, data []byte, opts Options) error {
 	abs, err := filepath.Abs(path)

--- a/internal/report/write.go
+++ b/internal/report/write.go
@@ -1,0 +1,116 @@
+// internal/report/write.go
+package report
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Sentinel errors returned by Write for unsafe destinations.
+var (
+	ErrParentMissing       = errors.New("destination directory does not exist")
+	ErrRefusedLocation     = errors.New("destination is a protected location")
+	ErrElevatedWriteDenied = errors.New("elevated write outside allowlisted roots requires explicit confirmation")
+	ErrNotRegularFile      = errors.New("destination exists and is not a regular file")
+	ErrElevatedExposedDir  = errors.New("elevated write refused: destination directory is writable by other users")
+)
+
+// Options carries caller decisions that affect write policy.
+type Options struct {
+	// AllowElevatedWrite is set when --allow-elevated-write is passed
+	// and, where a TTY exists, confirmed the prompt.
+	AllowElevatedWrite bool
+}
+
+const reportFileMode = 0600
+
+// Write validates path through the full guard pipeline and writes data to it,
+func Write(path string, data []byte, opts Options) error {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve path: %w", err)
+	}
+
+	// Resolve the parent against the real filesystem s
+	parent := filepath.Dir(abs)
+	realParent, err := canonicalParent(parent)
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Stat(realParent)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("%w: %s", ErrParentMissing, parent)
+	}
+
+	target := filepath.Join(realParent, filepath.Base(abs))
+
+	if reason := refusedReason(target); reason != "" {
+		return fmt.Errorf("%w: %s", ErrRefusedLocation, reason)
+	}
+
+	elevated, err := isElevated()
+	if err != nil {
+		return fmt.Errorf("determine privilege: %w", err)
+	}
+	if elevated {
+		// Refuse a root write into a directory other users can control
+		exposed, err := parentWritableByOthers(realParent)
+		if err != nil {
+			return fmt.Errorf("inspect destination directory: %w", err)
+		}
+		if exposed {
+			return fmt.Errorf("%w: %s", ErrElevatedExposedDir, realParent)
+		}
+
+		if !opts.AllowElevatedWrite {
+			allowed, err := withinAllowlist(target)
+			if err != nil {
+				return err
+			}
+			if !allowed {
+				return ErrElevatedWriteDenied
+			}
+		}
+	}
+
+	return openAndWrite(target, data)
+}
+
+// DefaultPath returns a generated report destination in CWD
+func DefaultPath(scan, format string) string {
+	stamp := time.Now().UTC().Format("20060102T150405Z")
+	return fmt.Sprintf("owatch-%s-%s.%s", scan, stamp, extension(format))
+}
+
+func extension(format string) string {
+	switch format {
+	case "json":
+		return "json"
+	case "yaml":
+		return "yaml"
+	case "csv":
+		return "csv"
+	case "text":
+		return "txt"
+	default:
+		// Unrecognized format falls back to usable default
+		return "json"
+	}
+}
+
+// pathWithin compares on path boundaries so a sibling is not mistaken for a child
+func pathWithin(target, base string) bool {
+	if target == base {
+		return true
+	}
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}


### PR DESCRIPTION
## Summary

`security_audit` wrote report files to any user-supplied path with no validation, and `all` carried only a partial guard, so the two commands did not agree on safety and neither blocked traversal, symlink redirection, or an elevated write into a system or persistence location. Both commands now route every report write through one shared, validated path in a new `internal/report` package, with identical logic on *nix and Windows.

## Changes

- `internal/report/write.go` -- shared pipeline: absolute-resolve, canonical parent, parent-must-exist, denylist check, elevation gate, and the public `Write`, plus `DefaultPath`, `extension`, `pathWithin`, `Options`, and the sentinel errors
- `internal/report/report_unix.go` -- unix seams: `EvalSymlinks`
  canonicalization, system and user-persistence denylist, `O_NOFOLLOW` write with regular-file check, euid elevation, owned-root allowlist, and the group/other-writable parent guard
- `internal/report/report_windows.go` -- Windows seams: `GetFinalPathNameByHandle` canonicalization with 8.3, junction, and extended-prefix handling, reparse-point reject on write, token elevation, allowlist, and a direct DACL walk refusing write to any principal outside SYSTEM, Administrators, CREATOR OWNER, and the owner
- `cmd/commands/security/security.go` -- `outputResults` writes via `report.Write`; `--allow-elevated-write` flag; `--allow-elevated-write` breadcrumb on the waivable elevated refusal
- `cmd/commands/all.go` -- `outputResults` buffers then writes via
  `report.Write`; removes `isSafeReportPath`; `--allow-elevated-write` flag; disables color when writing to a file
- `cmd/commands/root.go` -- `SilenceUsage` and `SilenceErrors` so runtime failures print one clean line, not a usage dump

## Verified

Ubuntu and Windows, both commands: allowed write succeeds and produces valid JSON; protected location, missing parent, and symlink or reparse target each refuse with a single clean line; elevated write to a system path refuses; on Windows an 8.3 short name, a junction, and an extended-length prefix all resolve and refuse, a directory with `Everyone:(W)` is correctly refused under
elevation, and an owner-only directory is correctly allowed. Full local pipeline passes on both platforms, including GOOS=windows go build ./...`.

## Deferred

Default-to-CWD filename generation and `scanLabel` move to the flag-semantics chore, so the no-path case keeps writing to stdout for now.

Closes #79 