### PR TITLE
[Bug] Fix indistinguishable clean pass output in audit text formatter

### DIFF
--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -469,6 +469,11 @@ func renderReferenceErrors(builder *strings.Builder, refs types.ReferenceExtract
 	builder.WriteString("\n")
 }
 
+// formatText renders result as human-readable text, applying the active
+// minSeverity filter to findings before output. Each check block includes
+// a clean-pass confirmation when no findings meet the threshold, ensuring
+// an empty findings block is never visually ambiguous. Verbose mode appends
+// finding details, impact, resolution, and raw diagnostic output.
 func formatText(result *audit.Result) (string, error) {
 	var builder strings.Builder
 	isComprehensive := len(result.Results) > 1
@@ -512,6 +517,11 @@ func formatText(result *audit.Result) (string, error) {
 					}
 				}
 			}
+		} else {
+			// Explicit clean pass confirmation so an empty findings block is
+			// never mistaken for a silent checker failure.
+			fmt.Fprintf(&builder, "Findings:\n%s No findings at or above %s severity\n",
+				types.SymbolOK, strings.ToUpper(minSeverity))
 		}
 
 		if verbose && len(checkResult.Details) > 0 {


### PR DESCRIPTION
## Summary

A check that passed with no findings produced identical output to a check that silently failed to run. There was no visual confirmation that the checker ran and found nothing, making a clean result ambiguous to the operator.

This branch adds an explicit clean pass confirmation line to the findings block in `formatText` when no findings meet the active `--min-severity` threshold. The confirmation reflects the active threshold so the operator knows what filter was applied. JSON and YAML output are unaffected -- an empty findings array is already unambiguous in structured formats.

Also adds a godoc comment to `formatText` per the updated documentation conventions established in #34.

## Changes

- `cmd/commands/security/security.go` -- added `else` branch to findings block rendering a `[+] No findings at or above <SEVERITY> severity` line when `filteredFindings` is empty; added godoc comment to `formatText`

## Verified

- [x] `gofmt -w .`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gosec ./...`
- [x] `govulncheck ./...`
- [x] `golangci-lint run --timeout=5m`
- [x] `GOOS=windows go build ./...`

Closes #104 