### PR TITLE
[Bug] Fix raw diagnostic warnings not reflected in check summary counts

### DIFF
--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -108,12 +108,19 @@ type (
 		References  []types.Reference `json:"references,omitempty" yaml:"references,omitempty"`
 	}
 
+	// formattedSummary carries per-severity finding counts and check-level
+	// pass/skip totals for structured output formats. WarningChecks and
+	// FailedChecks are removed -- findings are the canonical signal; check
+	// status is reflected in PassedChecks and SkippedChecks only.
 	formattedSummary struct {
-		TotalChecks   int `json:"total_checks" yaml:"total_checks"`
-		PassedChecks  int `json:"passed_checks" yaml:"passed_checks"`
-		WarningChecks int `json:"warning_checks" yaml:"warning_checks"`
-		FailedChecks  int `json:"failed_checks" yaml:"failed_checks"`
-		SkippedChecks int `json:"skipped_checks" yaml:"skipped_checks"`
+		TotalChecks      int `json:"total_checks" yaml:"total_checks"`
+		PassedChecks     int `json:"passed_checks" yaml:"passed_checks"`
+		SkippedChecks    int `json:"skipped_checks" yaml:"skipped_checks"`
+		TotalFindings    int `json:"total_findings" yaml:"total_findings"`
+		CriticalFindings int `json:"critical_findings" yaml:"critical_findings"`
+		HighFindings     int `json:"high_findings" yaml:"high_findings"`
+		MediumFindings   int `json:"medium_findings" yaml:"medium_findings"`
+		LowFindings      int `json:"low_findings" yaml:"low_findings"`
 	}
 )
 
@@ -340,11 +347,14 @@ func convertToFormattedResult(result *audit.Result) formattedResult {
 			SoftwareCount: result.SystemInfo.SoftwareCount,
 		},
 		Summary: formattedSummary{
-			TotalChecks:   result.Summary.TotalChecks,
-			PassedChecks:  result.Summary.PassedChecks,
-			WarningChecks: result.Summary.WarningChecks,
-			FailedChecks:  result.Summary.FailedChecks,
-			SkippedChecks: result.Summary.SkippedChecks,
+			TotalChecks:      result.Summary.TotalChecks,
+			PassedChecks:     result.Summary.PassedChecks,
+			SkippedChecks:    result.Summary.SkippedChecks,
+			TotalFindings:    result.Summary.TotalFindings,
+			CriticalFindings: result.Summary.CriticalFindings,
+			HighFindings:     result.Summary.HighFindings,
+			MediumFindings:   result.Summary.MediumFindings,
+			LowFindings:      result.Summary.LowFindings,
 		},
 	}
 
@@ -536,11 +546,15 @@ func formatText(result *audit.Result) (string, error) {
 
 	renderEnrichmentBlock(&builder, result)
 	builder.WriteString("Summary:\n")
-	fmt.Fprintf(&builder, "Checks Run: %d\n", len(result.Results))
-	fmt.Fprintf(&builder, "Passed:     %d\n", result.Summary.PassedChecks)
-	fmt.Fprintf(&builder, "Warnings:   %d\n", result.Summary.WarningChecks)
-	fmt.Fprintf(&builder, "Failed:     %d\n", result.Summary.FailedChecks)
-	fmt.Fprintf(&builder, "Duration:   %v\n", result.Duration)
+	fmt.Fprintf(&builder, "Checks Run:      %d\n", result.Summary.TotalChecks)
+	fmt.Fprintf(&builder, "Passed:          %d\n", result.Summary.PassedChecks)
+	fmt.Fprintf(&builder, "Skipped:         %d\n", result.Summary.SkippedChecks)
+	fmt.Fprintf(&builder, "Total Findings:  %d\n", result.Summary.TotalFindings)
+	fmt.Fprintf(&builder, "  Critical:      %d\n", result.Summary.CriticalFindings)
+	fmt.Fprintf(&builder, "  High:          %d\n", result.Summary.HighFindings)
+	fmt.Fprintf(&builder, "  Medium:        %d\n", result.Summary.MediumFindings)
+	fmt.Fprintf(&builder, "  Low:           %d\n", result.Summary.LowFindings)
+	fmt.Fprintf(&builder, "Duration:        %v\n", result.Duration)
 
 	if !verbose && hasFindings {
 		builder.WriteString("\nRun with -v for full finding details, impact analysis, and remediation guidance.\n")

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -63,13 +63,21 @@ type SystemInfo struct {
 	SoftwareCount int
 }
 
-// Summary provides a summary of the audit results
+// Summary reports the outcome of a completed audit at both check and finding
+// level. PassedChecks counts checks that completed with zero findings.
+// SkippedChecks counts checks excluded via --skip-checks. Finding counts are
+// broken down by severity so the analyst can assess exposure at a glance
+// without reading individual check output. TotalFindings is the sum of all
+// severity buckets.
 type Summary struct {
-	TotalChecks   int
-	PassedChecks  int
-	WarningChecks int
-	FailedChecks  int
-	SkippedChecks int
+	TotalChecks      int
+	PassedChecks     int
+	SkippedChecks    int
+	TotalFindings    int
+	CriticalFindings int
+	HighFindings     int
+	MediumFindings   int
+	LowFindings      int
 }
 
 // checkRunner pairs a check's canonical name with its execution function
@@ -98,7 +106,7 @@ func NewSecurityAuditor(opts Options) *SecurityAuditor {
 		auditor.sshChecker = checker.NewUnixSSHChecker(ctx)
 		auditor.firewallChecker = checker.NewUnixFirewallChecker(ctx)
 		auditor.userChecker = checker.NewUnixUserChecker(ctx)
-		auditor.permissionChecker = checker.NewUnixPermissionChecker(opts.FilePermsPath)
+		auditor.permissionChecker = checker.NewUnixPermissionChecker(ctx, opts.FilePermsPath)
 	}
 
 	return auditor
@@ -260,6 +268,13 @@ func aggregateReferences(results []types.AuditResult) types.ReferenceExtraction 
 	return ext
 }
 
+// calculateSummary iterates all check results and produces a Summary with
+// per-severity finding counts. A check is counted as passed only when it
+// completes with zero findings. ERROR status checks are not counted as
+// passed or skipped -- their findings still contribute to severity totals.
+// Severity classification uses the canonical SeverityX constants from the
+// types package so the bucketing is consistent with registry and enrichment
+// output.
 func (sa *SecurityAuditor) calculateSummary(results []types.AuditResult) Summary {
 	summary := Summary{
 		TotalChecks: len(results),
@@ -268,13 +283,27 @@ func (sa *SecurityAuditor) calculateSummary(results []types.AuditResult) Summary
 	for _, result := range results {
 		switch {
 		case result.Status == "ERROR":
-			summary.FailedChecks++
-		case len(result.Findings) > 0:
-			summary.WarningChecks++
-		case result.Status == "COMPLETED":
-			summary.PassedChecks++
-		default:
+			// ERROR checks are neither passed nor skipped --
+			// their findings still count toward severity totals
+		case result.Status == "SKIPPED":
 			summary.SkippedChecks++
+			continue
+		case len(result.Findings) == 0:
+			summary.PassedChecks++
+		}
+
+		for _, finding := range result.Findings {
+			summary.TotalFindings++
+			switch strings.ToUpper(finding.Severity) {
+			case types.SeverityCritical:
+				summary.CriticalFindings++
+			case types.SeverityHigh:
+				summary.HighFindings++
+			case types.SeverityMedium:
+				summary.MediumFindings++
+			case types.SeverityLow:
+				summary.LowFindings++
+			}
 		}
 	}
 	return summary

--- a/internal/security/checker/permissions.go
+++ b/internal/security/checker/permissions.go
@@ -116,6 +116,7 @@ type UnixPermissionChecker struct {
 	paths    []criticalPath
 	osType   string
 	scanRoot string
+	ctx      registry.OSContext
 }
 
 // WindowsPermissionChecker implements PermissionChecker for Windows systems
@@ -134,10 +135,11 @@ type criticalPath struct {
 }
 
 // NewUnixPermissionChecker creates a new Unix permission checker
-func NewUnixPermissionChecker(scanRoot string) *UnixPermissionChecker {
+func NewUnixPermissionChecker(ctx registry.OSContext, scanRoot string) *UnixPermissionChecker {
 	checker := &UnixPermissionChecker{
 		osType:   runtime.GOOS,
 		scanRoot: scanRoot,
+		ctx:      ctx,
 	}
 
 	// Set default critical paths based on OS
@@ -248,6 +250,16 @@ func (p *UnixPermissionChecker) checkPathPermissions(cp criticalPath, result *ty
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s WARNING: %s (%s) has permissions %v, expected %v",
 				types.SymbolWarning, cp.path, cp.description, mode.Perm(), cp.expected))
+		if def, ok := registry.Lookup(p.ctx, "permissions.path_exceeds_expected_mode"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
+			})
+		}
 	} else {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s %s has correct permissions: %v",
@@ -292,6 +304,16 @@ func (p *UnixPermissionChecker) checkSUIDFiles(result *types.AuditResult) {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
+		if def, ok := registry.Lookup(p.ctx, "permissions.suid_sgid_binary"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
+			})
+		}
 	}
 	appendSkippedNote(result, scan, skipped)
 }
@@ -317,6 +339,16 @@ func (p *UnixPermissionChecker) checkWorldWritableFiles(result *types.AuditResul
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
+		if def, ok := registry.Lookup(p.ctx, "permissions.world_writable_file"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
+			})
+		}
 	}
 	appendSkippedNote(result, scan, skipped)
 }
@@ -339,6 +371,16 @@ func (p *UnixPermissionChecker) checkUnownedFiles(result *types.AuditResult) {
 		for _, file := range files {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
+		}
+		if def, ok := registry.Lookup(p.ctx, "permissions.unowned_file"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
+			})
 		}
 	}
 	appendSkippedNote(result, scan, skipped)

--- a/internal/security/checker/users.go
+++ b/internal/security/checker/users.go
@@ -339,13 +339,20 @@ func (u *UnixUserChecker) getLinuxUsers() ([]userAccount, error) {
 		}
 	}
 
+	// Query each privileged group independently so a missing group (e.g. wheel
+	// or admin absent on Debian-family systems) does not cause the entire
+	// lookup to fail and silently zero out the sudoers map.
 	sudoers := make(map[string]bool)
-	sudoCmd := exec.Command("getent", "group", "sudo", "wheel", "admin")
-	if output, err := sudoCmd.CombinedOutput(); err == nil {
-		for _, line := range strings.Split(string(output), "\n") {
-			if fields := strings.Split(line, ":"); len(fields) >= groupFieldCount {
-				for _, user := range strings.Split(fields[groupFieldMembers], ",") {
-					sudoers[strings.TrimSpace(user)] = true
+	for _, group := range []string{"sudo", "wheel", "admin"} {
+		cmd := exec.Command("getent", "group", group) // #nosec G204 -- group names are hardcoded literals, not user input
+		if output, err := cmd.CombinedOutput(); err == nil {
+			for _, line := range strings.Split(string(output), "\n") {
+				if fields := strings.Split(line, ":"); len(fields) >= groupFieldCount {
+					for _, member := range strings.Split(fields[groupFieldMembers], ",") {
+						if name := strings.TrimSpace(member); name != "" {
+							sudoers[name] = true
+						}
+					}
 				}
 			}
 		}
@@ -404,6 +411,7 @@ func (u *UnixUserChecker) analyzeUsers(users []userAccount, result *types.AuditR
 		suspiciousUsers []string
 	)
 
+	seen := make(map[registry.FindingKey]struct{})
 	for _, user := range users {
 		details := fmt.Sprintf("%s (UID: %d, Shell: %s)", user.username, user.uid, user.shell)
 
@@ -419,12 +427,38 @@ func (u *UnixUserChecker) analyzeUsers(users []userAccount, result *types.AuditR
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: Regular user %s has administrative privileges",
 					types.SymbolWarning, user.username))
+			if _, dup := seen["users.regular_user_admin_privileges"]; !dup {
+				if def, ok := registry.Lookup(u.ctx, "users.regular_user_admin_privileges"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
+					})
+					seen["users.regular_user_admin_privileges"] = struct{}{}
+				}
+			}
 		}
 
-		if isWeakShell(user.shell) && !user.isSystem {
+		if isInteractiveShell(user.shell) && !user.isSystem {
 			result.Details = append(result.Details,
-				fmt.Sprintf("%s WARNING: User %s has a potentially insecure shell: %s",
+				fmt.Sprintf("%s User %s has an interactive login shell: %s",
 					types.SymbolWarning, user.username, user.shell))
+			if _, dup := seen["users.login_shell_present"]; !dup {
+				if def, ok := registry.Lookup(u.ctx, "users.login_shell_present"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
+					})
+					seen["users.login_shell_present"] = struct{}{}
+				}
+			}
 		}
 	}
 
@@ -871,22 +905,27 @@ func isSuspiciousUser(user userAccount) bool {
 		strings.Contains(user.username, "test")
 }
 
-func isWeakShell(shell string) bool {
-	weakShells := []string{
-		"/bin/sh",
-		"/usr/bin/sh",
-		"/bin/bash",
-		"/usr/bin/bash",
-		"cmd.exe",
-		"powershell.exe",
+// isInteractiveShell reports whether shell allows interactive login. Shells
+// that do not appear in the nologin/false/sync family are considered
+// interactive regardless of whether they are considered "secure" -- the
+// analyst decides whether the assignment is intentional.
+func isInteractiveShell(shell string) bool {
+	nonInteractive := []string{
+		"nologin",
+		"/bin/false",
+		"/usr/bin/false",
+		"/bin/sync",
+		"/usr/bin/sync",
+		"/sbin/halt",
+		"/sbin/shutdown",
 	}
-
-	for _, weakShell := range weakShells {
-		if strings.HasSuffix(shell, weakShell) {
-			return true
+	for _, s := range nonInteractive {
+		if strings.HasSuffix(shell, s) {
+			return false
 		}
 	}
-	return false
+	// empty shell field defaults to /bin/sh which is interactive
+	return true
 }
 
 func isSafeUsername(username string) bool {

--- a/internal/security/formatter/formatter.go
+++ b/internal/security/formatter/formatter.go
@@ -126,12 +126,15 @@ func (f *Formatter) prepareOutput(result *audit.Result) map[string]interface{} {
 
 	// Add summary
 	output["summary"] = map[string]interface{}{
-		"total_checks":   result.Summary.TotalChecks,
-		"passed_checks":  result.Summary.PassedChecks,
-		"warning_checks": result.Summary.WarningChecks,
-		"failed_checks":  result.Summary.FailedChecks,
-		"skipped_checks": result.Summary.SkippedChecks,
-		"duration":       result.Duration.String(),
+		"total_checks":      result.Summary.TotalChecks,
+		"passed_checks":     result.Summary.PassedChecks,
+		"skipped_checks":    result.Summary.SkippedChecks,
+		"total_findings":    result.Summary.TotalFindings,
+		"critical_findings": result.Summary.CriticalFindings,
+		"high_findings":     result.Summary.HighFindings,
+		"medium_findings":   result.Summary.MediumFindings,
+		"low_findings":      result.Summary.LowFindings,
+		"duration":          result.Duration.String(),
 	}
 
 	hasFindings := false
@@ -324,11 +327,15 @@ Enrichment:
 {{range .reference_errors}}    {{.}}
 {{end}}{{end}}{{end}}
 Summary:
-Checks Run: {{.summary.total_checks}}
-Passed:     {{.summary.passed_checks}}
-Warnings:   {{.summary.warning_checks}}
-Failed:     {{.summary.failed_checks}}
-Duration:   {{.summary.duration}}
+Checks Run:      {{.summary.total_checks}}
+Passed:          {{.summary.passed_checks}}
+Skipped:         {{.summary.skipped_checks}}
+Total Findings:  {{.summary.total_findings}}
+  Critical:      {{.summary.critical_findings}}
+  High:          {{.summary.high_findings}}
+  Medium:        {{.summary.medium_findings}}
+  Low:           {{.summary.low_findings}}
+Duration:        {{.summary.duration}}
 {{if and .non_verbose .has_findings}}
 Run with -v for full finding details, impact analysis, and remediation guidance.
 {{end}}`

--- a/internal/security/registry/data/linux_common.yaml
+++ b/internal/security/registry/data/linux_common.yaml
@@ -322,6 +322,60 @@ users.sssd_configured:
     - "NIST SP 800-53 Rev 5 IA-3 (Device Identification and Authentication)"
     - "https://cwe.mitre.org/data/definitions/287.html"
 
+users.regular_user_admin_privileges:
+  title: "Regular user account has administrative group membership"
+  severity: "MEDIUM"
+  cvss_score: 6.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-250"
+  description: >
+    A non-system user account is a member of a privileged group (sudo or
+    wheel). Administrative group membership grants the ability to execute
+    commands as root via sudo. This may reflect intentional operator
+    access or an unauthorized privilege assignment.
+  impact: >
+    Any process or attacker that gains access to this account can escalate
+    to root via sudo without requiring additional exploitation. The risk
+    is proportional to the strength of the account's authentication and
+    whether the administrative access is operationally justified.
+  resolution: >
+    Review sudo and wheel group membership: getent group sudo wheel.
+    Remove any account from administrative groups that does not require
+    elevated access. Scope sudo rules to specific commands where full
+    root access is not required.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.4.1"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/250.html"
+
+users.login_shell_present:
+  title: "User account has an interactive login shell"
+  severity: "LOW"
+  cvss_score: 2.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N"
+  cwe: "CWE-272"
+  description: >
+    A user account has an interactive login shell assigned. For regular
+    operator accounts this is expected. For accounts that should not
+    require interactive access (service accounts, daemon accounts, or
+    legacy accounts), an interactive shell represents an unnecessary
+    attack surface. This finding is informational -- context determines
+    whether it is a misconfiguration or intended policy.
+  impact: >
+    An account with an interactive shell that is compromised or
+    misused provides an attacker with a full interactive session.
+    Service accounts with login shells are a common persistence and
+    lateral movement vector when combined with weak or absent passwords.
+  resolution: >
+    For accounts that do not require interactive access, set the shell
+    to a nologin or false variant: usermod -s /usr/sbin/nologin
+    <username>. Review all accounts with interactive shells and confirm
+    each is operationally justified.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.4.2"
+    - "NIST SP 800-53 Rev 5 AC-2 (Account Management)"
+    - "https://cwe.mitre.org/data/definitions/272.html"
+
 # -------------------------
 # Permissions checker findings
 # -------------------------


### PR DESCRIPTION
## Summary

Checks that produced `[!] WARNING` lines in raw diagnostic output reported `Warnings: 0` in the summary because the summary counted checks, not findings, and raw diagnostic output was never promoted to structured findings. This branch fixes both problems.

Raw diagnostic warnings in the permissions and users checkers are now promoted to structured findings backed by verified registry entries. The summary is redesigned from check-level counting to per-severity finding-level counting, giving analysts an accurate picture of exposure at a glance.

## Changes

- `internal/security/registry/data/linux_common.yaml` -- added `users.regular_user_admin_privileges` and `users.login_shell_present` registry entries with verified CIS and NIST citations
- `internal/security/checker/users.go` -- fixed `getent` group query to query each privileged group individually so a missing group does not silently zero out the sudoers map; renamed `isWeakShell` to `isInteractiveShell` with corrected logic; added structured findings for admin group membership and interactive login shell with deduplication guard
- `internal/security/checker/permissions.go` -- added `ctx registry.OSContext` to `UnixPermissionChecker`; wired `ctx` through `NewUnixPermissionChecker`; added structured findings to `checkPathPermissions`, `checkSUIDFiles`, `checkWorldWritableFiles`, and `checkUnownedFiles`
- `internal/security/audit/audit.go` -- redesigned `Summary` struct from check-level to per-severity finding-level counts; rewrote `calculateSummary` to iterate findings and bucket by severity; a check is counted as passed only when it completes with zero findings
- `internal/security/formatter/formatter.go` -- updated `prepareOutput` summary map and `defaultTemplate` to reflect new summary field names
- `cmd/commands/security/security.go` -- updated `formattedSummary` struct, `convertToFormattedResult`, and `formatText` summary block to match new summary shape

## Verified

- [x] `gofmt -w .`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gosec ./...`
- [x] `govulncheck ./...`
- [x] `golangci-lint run --timeout=5m`
- [x] `GOOS=windows go build ./...`

Closes #105 