### PR TITLE
[Enhancement] Security audit command deep audit and completion cleanu

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ enumeration and security auditing across Linux, Unix, macOS, and Windows.
 |---|---|
 | `owatch osinfo` | Gather OS fingerprint information |
 | `owatch software` | List installed software packages |
-| `owatch security_audit` | Run security audit checks |
+| `owatch audit` | Run security audit checks |
 | `owatch all` | Run all available scans |
 | `owatch version` | Display current version |
 
@@ -33,13 +33,13 @@ owatch osinfo
 owatch software
 
 # Run a full security audit with verbose output
-owatch security_audit -v
+owatch audit -v
 
 # Run specific security checks
-owatch security_audit --ssh
-owatch security_audit --fwall
-owatch security_audit --users
-owatch security_audit --fperms /path/to/check
+owatch audit --ssh
+owatch audit --fwall
+owatch audit --users
+owatch audit --fperms /path/to/check
 
 # Run all scans and save report as JSON
 owatch all -o json --report-file report.json
@@ -62,6 +62,34 @@ owatch all --skip-modules software,security
 | `--skip-checks` | Comma-separated checks to skip | — |
 | `--timeout` | Maximum audit duration | 10m |
 | `-v, --verbose` | Enable verbose output | false |
+
+## Shell Completion
+
+`owatch` can generate shell completion scripts via the `completion` subcommand.
+Completion scripts are sourced into the shell session, not executed directly.
+
+### bash
+```bash
+source <(owatch completion bash)
+```
+
+### zsh
+```zsh
+source <(owatch completion zsh)
+```
+
+### fish
+```fish
+owatch completion fish | source
+```
+
+### PowerShell
+```powershell
+owatch completion powershell | Out-String | Invoke-Expression
+```
+
+> **Note:** Shell completion requires `owatch` to be installed and available
+> in PATH. It does not work with `go run` during development.
 
 ## Demo
 

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -19,7 +19,7 @@ var RootCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("owatch requires a subcommand (e.g., all, osinfo, security_audit, software).")
+		fmt.Println("owatch requires a subcommand (e.g., all, osinfo, audit, software).")
 		if err := cmd.Help(); err != nil {
 			fmt.Fprintf(os.Stderr, "error displaying help: %v\n", err)
 		}

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -41,8 +41,9 @@ var (
 
 // SecurityCmd represents the security audit command
 var SecurityCmd = &cobra.Command{
-	Use:   "security_audit [flags] [check...]",
-	Short: "Perform a security audit of the system",
+	Use:     "audit [flags] [check...]",
+	Aliases: []string{"security_audit"},
+	Short:   "Perform a security audit of the system",
 	Long: `Perform a comprehensive security audit of the system.
 This command checks various security aspects including:
 - SSH configuration
@@ -52,22 +53,22 @@ This command checks various security aspects including:
 
 You can run all checks or specify individual checks to run.`,
 	Example: `  # Run all security checks with verbose output
-  owatch security_audit -v
+  owatch audit -v
 
   # Run specific checks
-  owatch security_audit --ssh
-  owatch security_audit --fwall
-  owatch security_audit --users
-  owatch security_audit --fperms /path/to/file
+  owatch audit --ssh
+  owatch audit --fwall
+  owatch audit --users
+  owatch audit --fperms /path/to/file
 
   # Run checks with verbose output
-  owatch security_audit --ssh -v
+  owatch audit --ssh -v
 
   # Set minimum severity level
-  owatch security_audit --min-severity HIGH
+  owatch audit --min-severity HIGH
 
   # Run checks and save report to file
-  owatch security_audit -v -o json --report-file audit.json`,
+  owatch audit -v -o json --report-file audit.json`,
 }
 
 // Formatter types
@@ -124,7 +125,7 @@ func init() {
 	SecurityCmd.Flags().StringVar(&reportFile, "report-file", "",
 		"Save audit report to file")
 	SecurityCmd.Flags().StringSliceVar(&skipChecks, "skip-checks", []string{},
-		"Checks to skip (comma-separated)")
+		"Checks to skip (comma-separated: ssh, firewall, users, permissions)")
 	SecurityCmd.Flags().StringVar(&minSeverity, "min-severity", "LOW",
 		"Minimum severity level to report (LOW, MEDIUM, HIGH, CRITICAL)")
 	SecurityCmd.Flags().DurationVar(&timeout, "timeout", 10*time.Minute,
@@ -357,6 +358,9 @@ func convertToFormattedResult(result *audit.Result) formattedResult {
 		}
 
 		for _, finding := range check.Findings {
+			if !meetsMinSeverity(finding.Severity, minSeverity) {
+				continue
+			}
 			fc.Findings = append(fc.Findings, formattedFinding{
 				Title:       finding.Title,
 				Severity:    finding.Severity,
@@ -372,6 +376,7 @@ func convertToFormattedResult(result *audit.Result) formattedResult {
 
 	return formatted
 }
+
 func renderEnrichmentBlock(builder *strings.Builder, result *audit.Result) {
 	if !result.EnrichmentRequested {
 		return
@@ -483,10 +488,16 @@ func formatText(result *audit.Result) (string, error) {
 		fmt.Fprintf(&builder, "Status: %s\n", checkResult.Status)
 		fmt.Fprintf(&builder, "Duration: %v\n", checkResult.Duration)
 
-		if len(checkResult.Findings) > 0 {
+		var filteredFindings []types.Finding
+		for _, finding := range checkResult.Findings {
+			if meetsMinSeverity(finding.Severity, minSeverity) {
+				filteredFindings = append(filteredFindings, finding)
+			}
+		}
+		if len(filteredFindings) > 0 {
 			hasFindings = true
 			builder.WriteString("Findings:\n")
-			for _, finding := range checkResult.Findings {
+			for _, finding := range filteredFindings {
 				symbol, label := types.SeverityFormat(finding.Severity)
 				fmt.Fprintf(&builder, "%s %s  %s\n", symbol, label, finding.Title)
 				if verbose {
@@ -526,4 +537,33 @@ func formatText(result *audit.Result) (string, error) {
 	}
 
 	return builder.String(), nil
+}
+
+// severityLevel returns the numeric rank of a severity string for threshold
+// comparisons. Unknown values return -1 so they are never silently dropped.
+func severityLevel(s string) int {
+	switch strings.ToUpper(s) {
+	case types.SeverityLow:
+		return 0
+	case types.SeverityMedium:
+		return 1
+	case types.SeverityHigh:
+		return 2
+	case types.SeverityCritical:
+		return 3
+	default:
+		return -1
+	}
+}
+
+// meetsMinSeverity reports whether findingSeverity is at or above the
+// minSeverity threshold. Unrecognized severity values pass through so
+// findings are never silently dropped.
+func meetsMinSeverity(findingSeverity, min string) bool {
+	fl := severityLevel(findingSeverity)
+	ml := severityLevel(min)
+	if fl < 0 || ml < 0 {
+		return true
+	}
+	return fl >= ml
 }

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -469,6 +469,11 @@ func renderReferenceErrors(builder *strings.Builder, refs types.ReferenceExtract
 	builder.WriteString("\n")
 }
 
+// formatText renders result as human-readable text, applying the active
+// minSeverity filter to findings before output. Each check block includes
+// a clean-pass confirmation when no findings meet the threshold, ensuring
+// an empty findings block is never visually ambiguous. Verbose mode appends
+// finding details, impact, resolution, and raw diagnostic output.
 func formatText(result *audit.Result) (string, error) {
 	var builder strings.Builder
 	isComprehensive := len(result.Results) > 1
@@ -512,6 +517,11 @@ func formatText(result *audit.Result) (string, error) {
 					}
 				}
 			}
+		} else {
+			// Explicit clean pass confirmation so an empty findings block is
+			// never mistaken for a silent checker failure.
+			fmt.Fprintf(&builder, "Findings:\n%s No findings at or above %s severity\n",
+				types.SymbolOK, strings.ToUpper(minSeverity))
 		}
 
 		if verbose && len(checkResult.Details) > 0 {

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -108,12 +108,19 @@ type (
 		References  []types.Reference `json:"references,omitempty" yaml:"references,omitempty"`
 	}
 
+	// formattedSummary carries per-severity finding counts and check-level
+	// pass/skip totals for structured output formats. WarningChecks and
+	// FailedChecks are removed -- findings are the canonical signal; check
+	// status is reflected in PassedChecks and SkippedChecks only.
 	formattedSummary struct {
-		TotalChecks   int `json:"total_checks" yaml:"total_checks"`
-		PassedChecks  int `json:"passed_checks" yaml:"passed_checks"`
-		WarningChecks int `json:"warning_checks" yaml:"warning_checks"`
-		FailedChecks  int `json:"failed_checks" yaml:"failed_checks"`
-		SkippedChecks int `json:"skipped_checks" yaml:"skipped_checks"`
+		TotalChecks      int `json:"total_checks" yaml:"total_checks"`
+		PassedChecks     int `json:"passed_checks" yaml:"passed_checks"`
+		SkippedChecks    int `json:"skipped_checks" yaml:"skipped_checks"`
+		TotalFindings    int `json:"total_findings" yaml:"total_findings"`
+		CriticalFindings int `json:"critical_findings" yaml:"critical_findings"`
+		HighFindings     int `json:"high_findings" yaml:"high_findings"`
+		MediumFindings   int `json:"medium_findings" yaml:"medium_findings"`
+		LowFindings      int `json:"low_findings" yaml:"low_findings"`
 	}
 )
 
@@ -340,11 +347,14 @@ func convertToFormattedResult(result *audit.Result) formattedResult {
 			SoftwareCount: result.SystemInfo.SoftwareCount,
 		},
 		Summary: formattedSummary{
-			TotalChecks:   result.Summary.TotalChecks,
-			PassedChecks:  result.Summary.PassedChecks,
-			WarningChecks: result.Summary.WarningChecks,
-			FailedChecks:  result.Summary.FailedChecks,
-			SkippedChecks: result.Summary.SkippedChecks,
+			TotalChecks:      result.Summary.TotalChecks,
+			PassedChecks:     result.Summary.PassedChecks,
+			SkippedChecks:    result.Summary.SkippedChecks,
+			TotalFindings:    result.Summary.TotalFindings,
+			CriticalFindings: result.Summary.CriticalFindings,
+			HighFindings:     result.Summary.HighFindings,
+			MediumFindings:   result.Summary.MediumFindings,
+			LowFindings:      result.Summary.LowFindings,
 		},
 	}
 
@@ -536,11 +546,15 @@ func formatText(result *audit.Result) (string, error) {
 
 	renderEnrichmentBlock(&builder, result)
 	builder.WriteString("Summary:\n")
-	fmt.Fprintf(&builder, "Checks Run: %d\n", len(result.Results))
-	fmt.Fprintf(&builder, "Passed:     %d\n", result.Summary.PassedChecks)
-	fmt.Fprintf(&builder, "Warnings:   %d\n", result.Summary.WarningChecks)
-	fmt.Fprintf(&builder, "Failed:     %d\n", result.Summary.FailedChecks)
-	fmt.Fprintf(&builder, "Duration:   %v\n", result.Duration)
+	fmt.Fprintf(&builder, "Checks Run:      %d\n", result.Summary.TotalChecks)
+	fmt.Fprintf(&builder, "Passed:          %d\n", result.Summary.PassedChecks)
+	fmt.Fprintf(&builder, "Skipped:         %d\n", result.Summary.SkippedChecks)
+	fmt.Fprintf(&builder, "Total Findings:  %d\n", result.Summary.TotalFindings)
+	fmt.Fprintf(&builder, "  Critical:      %d\n", result.Summary.CriticalFindings)
+	fmt.Fprintf(&builder, "  High:          %d\n", result.Summary.HighFindings)
+	fmt.Fprintf(&builder, "  Medium:        %d\n", result.Summary.MediumFindings)
+	fmt.Fprintf(&builder, "  Low:           %d\n", result.Summary.LowFindings)
+	fmt.Fprintf(&builder, "Duration:        %v\n", result.Duration)
 
 	if !verbose && hasFindings {
 		builder.WriteString("\nRun with -v for full finding details, impact analysis, and remediation guidance.\n")

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -63,13 +63,21 @@ type SystemInfo struct {
 	SoftwareCount int
 }
 
-// Summary provides a summary of the audit results
+// Summary reports the outcome of a completed audit at both check and finding
+// level. PassedChecks counts checks that completed with zero findings.
+// SkippedChecks counts checks excluded via --skip-checks. Finding counts are
+// broken down by severity so the analyst can assess exposure at a glance
+// without reading individual check output. TotalFindings is the sum of all
+// severity buckets.
 type Summary struct {
-	TotalChecks   int
-	PassedChecks  int
-	WarningChecks int
-	FailedChecks  int
-	SkippedChecks int
+	TotalChecks      int
+	PassedChecks     int
+	SkippedChecks    int
+	TotalFindings    int
+	CriticalFindings int
+	HighFindings     int
+	MediumFindings   int
+	LowFindings      int
 }
 
 // checkRunner pairs a check's canonical name with its execution function
@@ -98,7 +106,7 @@ func NewSecurityAuditor(opts Options) *SecurityAuditor {
 		auditor.sshChecker = checker.NewUnixSSHChecker(ctx)
 		auditor.firewallChecker = checker.NewUnixFirewallChecker(ctx)
 		auditor.userChecker = checker.NewUnixUserChecker(ctx)
-		auditor.permissionChecker = checker.NewUnixPermissionChecker(opts.FilePermsPath)
+		auditor.permissionChecker = checker.NewUnixPermissionChecker(ctx, opts.FilePermsPath)
 	}
 
 	return auditor
@@ -260,6 +268,13 @@ func aggregateReferences(results []types.AuditResult) types.ReferenceExtraction 
 	return ext
 }
 
+// calculateSummary iterates all check results and produces a Summary with
+// per-severity finding counts. A check is counted as passed only when it
+// completes with zero findings. ERROR status checks are not counted as
+// passed or skipped -- their findings still contribute to severity totals.
+// Severity classification uses the canonical SeverityX constants from the
+// types package so the bucketing is consistent with registry and enrichment
+// output.
 func (sa *SecurityAuditor) calculateSummary(results []types.AuditResult) Summary {
 	summary := Summary{
 		TotalChecks: len(results),
@@ -268,13 +283,27 @@ func (sa *SecurityAuditor) calculateSummary(results []types.AuditResult) Summary
 	for _, result := range results {
 		switch {
 		case result.Status == "ERROR":
-			summary.FailedChecks++
-		case len(result.Findings) > 0:
-			summary.WarningChecks++
-		case result.Status == "COMPLETED":
-			summary.PassedChecks++
-		default:
+			// ERROR checks are neither passed nor skipped --
+			// their findings still count toward severity totals
+		case result.Status == "SKIPPED":
 			summary.SkippedChecks++
+			continue
+		case len(result.Findings) == 0:
+			summary.PassedChecks++
+		}
+
+		for _, finding := range result.Findings {
+			summary.TotalFindings++
+			switch strings.ToUpper(finding.Severity) {
+			case types.SeverityCritical:
+				summary.CriticalFindings++
+			case types.SeverityHigh:
+				summary.HighFindings++
+			case types.SeverityMedium:
+				summary.MediumFindings++
+			case types.SeverityLow:
+				summary.LowFindings++
+			}
 		}
 	}
 	return summary

--- a/internal/security/checker/permissions.go
+++ b/internal/security/checker/permissions.go
@@ -116,6 +116,7 @@ type UnixPermissionChecker struct {
 	paths    []criticalPath
 	osType   string
 	scanRoot string
+	ctx      registry.OSContext
 }
 
 // WindowsPermissionChecker implements PermissionChecker for Windows systems
@@ -134,10 +135,11 @@ type criticalPath struct {
 }
 
 // NewUnixPermissionChecker creates a new Unix permission checker
-func NewUnixPermissionChecker(scanRoot string) *UnixPermissionChecker {
+func NewUnixPermissionChecker(ctx registry.OSContext, scanRoot string) *UnixPermissionChecker {
 	checker := &UnixPermissionChecker{
 		osType:   runtime.GOOS,
 		scanRoot: scanRoot,
+		ctx:      ctx,
 	}
 
 	// Set default critical paths based on OS
@@ -248,6 +250,16 @@ func (p *UnixPermissionChecker) checkPathPermissions(cp criticalPath, result *ty
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s WARNING: %s (%s) has permissions %v, expected %v",
 				types.SymbolWarning, cp.path, cp.description, mode.Perm(), cp.expected))
+		if def, ok := registry.Lookup(p.ctx, "permissions.path_exceeds_expected_mode"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
+			})
+		}
 	} else {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s %s has correct permissions: %v",
@@ -292,6 +304,16 @@ func (p *UnixPermissionChecker) checkSUIDFiles(result *types.AuditResult) {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
+		if def, ok := registry.Lookup(p.ctx, "permissions.suid_sgid_binary"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
+			})
+		}
 	}
 	appendSkippedNote(result, scan, skipped)
 }
@@ -317,6 +339,16 @@ func (p *UnixPermissionChecker) checkWorldWritableFiles(result *types.AuditResul
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
+		if def, ok := registry.Lookup(p.ctx, "permissions.world_writable_file"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
+			})
+		}
 	}
 	appendSkippedNote(result, scan, skipped)
 }
@@ -339,6 +371,16 @@ func (p *UnixPermissionChecker) checkUnownedFiles(result *types.AuditResult) {
 		for _, file := range files {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
+		}
+		if def, ok := registry.Lookup(p.ctx, "permissions.unowned_file"); ok {
+			result.Findings = append(result.Findings, types.Finding{
+				Title:       def.Title,
+				Severity:    def.Severity,
+				Description: def.Description,
+				Impact:      def.Impact,
+				Resolution:  def.Resolution,
+				References:  def.ToReferences(),
+			})
 		}
 	}
 	appendSkippedNote(result, scan, skipped)

--- a/internal/security/checker/users.go
+++ b/internal/security/checker/users.go
@@ -29,11 +29,15 @@ type platformConfig struct {
 	minUID      int
 }
 
-// UnixUserChecker implements UserChecker for Unix-like systems
+// UnixUserChecker implements UserChecker for Unix-like systems.
+// shadowReadable is set to true when /etc/shadow was successfully opened
+// during getLinuxUsers; it gates the no-password finding and surfaces a
+// diagnostic when the check runs without sufficient privileges.
 type UnixUserChecker struct {
-	config platformConfig
-	osType string
-	ctx    registry.OSContext
+	config         platformConfig
+	osType         string
+	ctx            registry.OSContext
+	shadowReadable bool
 }
 
 // WindowsUserChecker implements UserChecker for Windows systems
@@ -41,17 +45,23 @@ type WindowsUserChecker struct {
 	ctx registry.OSContext
 }
 
-// userAccount represents a parsed user account
+// userAccount represents a parsed user account from /etc/passwd and,
+// where available, /etc/shadow. isSystem is true when the UID falls
+// below the platform minimum for regular user accounts. isLocked is
+// true when the shadow password field begins with ! or *. hasPassword
+// is true when a non-empty, non-placeholder password hash is present
+// in /etc/shadow; false indicates no credential is set.
 type userAccount struct {
-	username   string
-	uid        int
-	gid        int
-	homeDir    string
-	shell      string
-	isSystem   bool
-	isLocked   bool
-	isAdmin    bool
-	isDisabled bool
+	username    string
+	uid         int
+	gid         int
+	homeDir     string
+	shell       string
+	isSystem    bool
+	isLocked    bool
+	isAdmin     bool
+	isDisabled  bool
+	hasPassword bool
 }
 
 // authConfigResult holds the outcome of auth configuration detection.
@@ -325,6 +335,7 @@ func (u *UnixUserChecker) getLinuxUsers() ([]userAccount, error) {
 
 	shadowEntries := make(map[string]string)
 	if shadow, err := os.Open("/etc/shadow"); err == nil {
+		u.shadowReadable = true
 		defer shadow.Close() // nolint:errcheck // read-only shadow file; close error does not affect scan results
 		scanner := bufio.NewScanner(shadow)
 		for scanner.Scan() {
@@ -392,6 +403,19 @@ func (u *UnixUserChecker) getLinuxUsers() ([]userAccount, error) {
 		if shadowEntry, exists := shadowEntries[account.username]; exists {
 			account.isLocked = strings.HasPrefix(shadowEntry, "!") ||
 				strings.HasPrefix(shadowEntry, "*")
+			// Only set hasPassword when shadow was readable and the entry is
+			// a real hash -- not a lock prefix, placeholder, or empty field.
+			// When shadow is unreadable the entry will not exist and hasPassword
+			// stays false; the no-password finding is suppressed in that case.
+			account.hasPassword = shadowEntry != "" &&
+				!strings.HasPrefix(shadowEntry, "!") &&
+				!strings.HasPrefix(shadowEntry, "*")
+		} else {
+			// Shadow entry absent -- either shadow is unreadable or the account
+			// has no shadow entry. Treat password status as unknown rather than
+			// assuming no password is set, to avoid false positives when running
+			// without elevated privileges.
+			account.hasPassword = true
 		}
 
 		users = append(users, account)
@@ -421,6 +445,48 @@ func (u *UnixUserChecker) analyzeUsers(users []userAccount, result *types.AuditR
 			suspiciousUsers = append(suspiciousUsers, details)
 		} else if !user.isSystem {
 			regularUsers = append(regularUsers, details)
+		}
+
+		// UID 0 on any account other than root is unconditional root equivalence
+		// regardless of account name, group membership, or sudo policy.
+		if user.uid == rootUID && user.username != "root" {
+			result.Details = append(result.Details,
+				fmt.Sprintf("%s CRITICAL: Account %s has UID 0 (root-equivalent)",
+					types.SymbolCritical, user.username))
+			if _, dup := seen["users.uid_zero_non_root"]; !dup {
+				if def, ok := registry.Lookup(u.ctx, "users.uid_zero_non_root"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
+					})
+					seen["users.uid_zero_non_root"] = struct{}{}
+				}
+			}
+		}
+
+		// An account with no password and an interactive shell can be accessed
+		// without any credential on systems where empty passwords are permitted.
+		if !user.hasPassword && isInteractiveShell(user.shell) && !user.isLocked {
+			result.Details = append(result.Details,
+				fmt.Sprintf("%s WARNING: Account %s has no password and an interactive login shell",
+					types.SymbolWarning, user.username))
+			if _, dup := seen["users.no_password_login_shell"]; !dup {
+				if def, ok := registry.Lookup(u.ctx, "users.no_password_login_shell"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
+					})
+					seen["users.no_password_login_shell"] = struct{}{}
+				}
+			}
 		}
 
 		if user.isAdmin && !user.isSystem {
@@ -460,6 +526,12 @@ func (u *UnixUserChecker) analyzeUsers(users []userAccount, result *types.AuditR
 				}
 			}
 		}
+	}
+
+	if !u.shadowReadable {
+		result.Details = append(result.Details,
+			fmt.Sprintf("%s No-password check skipped: /etc/shadow is not readable without elevated privileges",
+				types.SymbolInfo))
 	}
 
 	if len(adminUsers) > 0 {

--- a/internal/security/checker/users.go
+++ b/internal/security/checker/users.go
@@ -339,13 +339,20 @@ func (u *UnixUserChecker) getLinuxUsers() ([]userAccount, error) {
 		}
 	}
 
+	// Query each privileged group independently so a missing group (e.g. wheel
+	// or admin absent on Debian-family systems) does not cause the entire
+	// lookup to fail and silently zero out the sudoers map.
 	sudoers := make(map[string]bool)
-	sudoCmd := exec.Command("getent", "group", "sudo", "wheel", "admin")
-	if output, err := sudoCmd.CombinedOutput(); err == nil {
-		for _, line := range strings.Split(string(output), "\n") {
-			if fields := strings.Split(line, ":"); len(fields) >= groupFieldCount {
-				for _, user := range strings.Split(fields[groupFieldMembers], ",") {
-					sudoers[strings.TrimSpace(user)] = true
+	for _, group := range []string{"sudo", "wheel", "admin"} {
+		cmd := exec.Command("getent", "group", group) // #nosec G204 -- group names are hardcoded literals, not user input
+		if output, err := cmd.CombinedOutput(); err == nil {
+			for _, line := range strings.Split(string(output), "\n") {
+				if fields := strings.Split(line, ":"); len(fields) >= groupFieldCount {
+					for _, member := range strings.Split(fields[groupFieldMembers], ",") {
+						if name := strings.TrimSpace(member); name != "" {
+							sudoers[name] = true
+						}
+					}
 				}
 			}
 		}
@@ -404,6 +411,7 @@ func (u *UnixUserChecker) analyzeUsers(users []userAccount, result *types.AuditR
 		suspiciousUsers []string
 	)
 
+	seen := make(map[registry.FindingKey]struct{})
 	for _, user := range users {
 		details := fmt.Sprintf("%s (UID: %d, Shell: %s)", user.username, user.uid, user.shell)
 
@@ -419,12 +427,38 @@ func (u *UnixUserChecker) analyzeUsers(users []userAccount, result *types.AuditR
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: Regular user %s has administrative privileges",
 					types.SymbolWarning, user.username))
+			if _, dup := seen["users.regular_user_admin_privileges"]; !dup {
+				if def, ok := registry.Lookup(u.ctx, "users.regular_user_admin_privileges"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
+					})
+					seen["users.regular_user_admin_privileges"] = struct{}{}
+				}
+			}
 		}
 
-		if isWeakShell(user.shell) && !user.isSystem {
+		if isInteractiveShell(user.shell) && !user.isSystem {
 			result.Details = append(result.Details,
-				fmt.Sprintf("%s WARNING: User %s has a potentially insecure shell: %s",
+				fmt.Sprintf("%s User %s has an interactive login shell: %s",
 					types.SymbolWarning, user.username, user.shell))
+			if _, dup := seen["users.login_shell_present"]; !dup {
+				if def, ok := registry.Lookup(u.ctx, "users.login_shell_present"); ok {
+					result.Findings = append(result.Findings, types.Finding{
+						Title:       def.Title,
+						Severity:    def.Severity,
+						Description: def.Description,
+						Impact:      def.Impact,
+						Resolution:  def.Resolution,
+						References:  def.ToReferences(),
+					})
+					seen["users.login_shell_present"] = struct{}{}
+				}
+			}
 		}
 	}
 
@@ -871,22 +905,27 @@ func isSuspiciousUser(user userAccount) bool {
 		strings.Contains(user.username, "test")
 }
 
-func isWeakShell(shell string) bool {
-	weakShells := []string{
-		"/bin/sh",
-		"/usr/bin/sh",
-		"/bin/bash",
-		"/usr/bin/bash",
-		"cmd.exe",
-		"powershell.exe",
+// isInteractiveShell reports whether shell allows interactive login. Shells
+// that do not appear in the nologin/false/sync family are considered
+// interactive regardless of whether they are considered "secure" -- the
+// analyst decides whether the assignment is intentional.
+func isInteractiveShell(shell string) bool {
+	nonInteractive := []string{
+		"nologin",
+		"/bin/false",
+		"/usr/bin/false",
+		"/bin/sync",
+		"/usr/bin/sync",
+		"/sbin/halt",
+		"/sbin/shutdown",
 	}
-
-	for _, weakShell := range weakShells {
-		if strings.HasSuffix(shell, weakShell) {
-			return true
+	for _, s := range nonInteractive {
+		if strings.HasSuffix(shell, s) {
+			return false
 		}
 	}
-	return false
+	// empty shell field defaults to /bin/sh which is interactive
+	return true
 }
 
 func isSafeUsername(username string) bool {

--- a/internal/security/formatter/formatter.go
+++ b/internal/security/formatter/formatter.go
@@ -126,12 +126,15 @@ func (f *Formatter) prepareOutput(result *audit.Result) map[string]interface{} {
 
 	// Add summary
 	output["summary"] = map[string]interface{}{
-		"total_checks":   result.Summary.TotalChecks,
-		"passed_checks":  result.Summary.PassedChecks,
-		"warning_checks": result.Summary.WarningChecks,
-		"failed_checks":  result.Summary.FailedChecks,
-		"skipped_checks": result.Summary.SkippedChecks,
-		"duration":       result.Duration.String(),
+		"total_checks":      result.Summary.TotalChecks,
+		"passed_checks":     result.Summary.PassedChecks,
+		"skipped_checks":    result.Summary.SkippedChecks,
+		"total_findings":    result.Summary.TotalFindings,
+		"critical_findings": result.Summary.CriticalFindings,
+		"high_findings":     result.Summary.HighFindings,
+		"medium_findings":   result.Summary.MediumFindings,
+		"low_findings":      result.Summary.LowFindings,
+		"duration":          result.Duration.String(),
 	}
 
 	hasFindings := false
@@ -324,11 +327,15 @@ Enrichment:
 {{range .reference_errors}}    {{.}}
 {{end}}{{end}}{{end}}
 Summary:
-Checks Run: {{.summary.total_checks}}
-Passed:     {{.summary.passed_checks}}
-Warnings:   {{.summary.warning_checks}}
-Failed:     {{.summary.failed_checks}}
-Duration:   {{.summary.duration}}
+Checks Run:      {{.summary.total_checks}}
+Passed:          {{.summary.passed_checks}}
+Skipped:         {{.summary.skipped_checks}}
+Total Findings:  {{.summary.total_findings}}
+  Critical:      {{.summary.critical_findings}}
+  High:          {{.summary.high_findings}}
+  Medium:        {{.summary.medium_findings}}
+  Low:           {{.summary.low_findings}}
+Duration:        {{.summary.duration}}
 {{if and .non_verbose .has_findings}}
 Run with -v for full finding details, impact analysis, and remediation guidance.
 {{end}}`

--- a/internal/security/registry/data/linux_common.yaml
+++ b/internal/security/registry/data/linux_common.yaml
@@ -376,6 +376,34 @@ users.login_shell_present:
     - "NIST SP 800-53 Rev 5 AC-2 (Account Management)"
     - "https://cwe.mitre.org/data/definitions/272.html"
 
+users.no_password_login_shell:
+  title: "Account with no password set has a valid login shell"
+  severity: "HIGH"
+  cvss_score: 8.1
+  cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-287"
+  description: >
+    A user account has no password set in /etc/shadow and is assigned
+    an interactive login shell. An account with no password hash and a
+    valid shell can be accessed without any credential on systems where
+    password authentication is not explicitly required for all accounts.
+  impact: >
+    Any local or remote attacker can authenticate as this account without
+    providing a password if the authentication stack permits empty
+    credentials. Combined with an interactive shell, this grants an
+    attacker a full session under the affected account without any
+    exploitation required.
+  resolution: >
+    Either set a strong password for the account or replace the login
+    shell with a nologin variant: usermod -s /usr/sbin/nologin <username>.
+    If the account is no longer needed, lock or remove it: passwd -l
+    <username> or userdel <username>. Audit all accounts with empty
+    password fields: awk -F: '$2 == "" ' /etc/shadow.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.4.1"
+    - "NIST SP 800-53 Rev 5 IA-5 (Authenticator Management)"
+    - "https://cwe.mitre.org/data/definitions/287.html"
+
 # -------------------------
 # Permissions checker findings
 # -------------------------

--- a/internal/security/registry/data/linux_common.yaml
+++ b/internal/security/registry/data/linux_common.yaml
@@ -322,6 +322,60 @@ users.sssd_configured:
     - "NIST SP 800-53 Rev 5 IA-3 (Device Identification and Authentication)"
     - "https://cwe.mitre.org/data/definitions/287.html"
 
+users.regular_user_admin_privileges:
+  title: "Regular user account has administrative group membership"
+  severity: "MEDIUM"
+  cvss_score: 6.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N"
+  cwe: "CWE-250"
+  description: >
+    A non-system user account is a member of a privileged group (sudo or
+    wheel). Administrative group membership grants the ability to execute
+    commands as root via sudo. This may reflect intentional operator
+    access or an unauthorized privilege assignment.
+  impact: >
+    Any process or attacker that gains access to this account can escalate
+    to root via sudo without requiring additional exploitation. The risk
+    is proportional to the strength of the account's authentication and
+    whether the administrative access is operationally justified.
+  resolution: >
+    Review sudo and wheel group membership: getent group sudo wheel.
+    Remove any account from administrative groups that does not require
+    elevated access. Scope sudo rules to specific commands where full
+    root access is not required.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.4.1"
+    - "NIST SP 800-53 Rev 5 AC-6 (Least Privilege)"
+    - "https://cwe.mitre.org/data/definitions/250.html"
+
+users.login_shell_present:
+  title: "User account has an interactive login shell"
+  severity: "LOW"
+  cvss_score: 2.5
+  cvss_vector: "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N"
+  cwe: "CWE-272"
+  description: >
+    A user account has an interactive login shell assigned. For regular
+    operator accounts this is expected. For accounts that should not
+    require interactive access (service accounts, daemon accounts, or
+    legacy accounts), an interactive shell represents an unnecessary
+    attack surface. This finding is informational -- context determines
+    whether it is a misconfiguration or intended policy.
+  impact: >
+    An account with an interactive shell that is compromised or
+    misused provides an attacker with a full interactive session.
+    Service accounts with login shells are a common persistence and
+    lateral movement vector when combined with weak or absent passwords.
+  resolution: >
+    For accounts that do not require interactive access, set the shell
+    to a nologin or false variant: usermod -s /usr/sbin/nologin
+    <username>. Review all accounts with interactive shells and confirm
+    each is operationally justified.
+  references:
+    - "CIS Distribution Independent Linux Benchmark v2.0.0 §5.4.2"
+    - "NIST SP 800-53 Rev 5 AC-2 (Account Management)"
+    - "https://cwe.mitre.org/data/definitions/272.html"
+
 # -------------------------
 # Permissions checker findings
 # -------------------------


### PR DESCRIPTION
## Summary

A focused audit of the `security_audit` subcommand surface, completion command, and all associated flags. Registers `audit` as the primary command name with `security_audit` as an alias, fixes `--min-severity` filtering, verifies all flags end-to-end, and resolves three bugs discovered during verification via sub-issues.

## Changes

- `cmd/commands/security/security.go` -- registered `audit` as primary `Use` field with `security_audit` as alias; updated all `Example` block references to `audit`; added `severityLevel` and `meetsMinSeverity` helpers; wired `--min-severity` filter into `convertToFormattedResult` and `formatText`; updated `--skip-checks` flag description to list valid values; updated `formattedSummary` struct, `convertToFormattedResult`, and `formatText` summary block to reflect per-severity finding counts
- `cmd/commands/root.go` -- updated hint string to reference `audit` instead of `security_audit`
- `internal/security/audit/audit.go` -- redesigned `Summary` struct to per-severity finding-level counts; rewrote `calculateSummary` accordingly
- `internal/security/checker/users.go` -- fixed per-group `getent` queries; renamed `isWeakShell` to `isInteractiveShell` with corrected logic; added `shadowReadable` and `hasPassword` fields; added structured findings for admin group membership, interactive login shell, UID 0 non-root, and no-password accounts
- `internal/security/checker/permissions.go` -- added `ctx registry.OSContext` to `UnixPermissionChecker`; wired through constructor and `audit.go`; added structured findings to all four check functions
- `internal/security/formatter/formatter.go` -- updated `prepareOutput` summary map and `defaultTemplate` to reflect new summary field names 
- `internal/security/registry/data/linux_common.yaml` -- added `users.regular_user_admin_privileges`, `users.login_shell_present`, `users.uid_zero_non_root`, and `users.no_password_login_shell` registry
  entries with verified CIS and NIST citations
- `README.md` -- updated command references from `security_audit` to `audit`; added Shell Completion section with sourcing instructions for bash, zsh, fish, and PowerShell
- `docs/CONTRIBUTING.md` -- updated issue template list, branch naming types, workflow, pipeline gate, code conventions, godoc standards, and testing conventions

## Verified

- [x] `gofmt -w .`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gosec ./...`
- [x] `govulncheck ./...`
- [x] `golangci-lint run --timeout=5m`
- [x] `GOOS=windows go build ./...`

Closes #34 