### PR TITLE
[Chore] flag semantics, output selector, and report path wiring (#82)

### DIFF
--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/papa0four/orkowatch/internal/osfingerprint"
 	"github.com/papa0four/orkowatch/internal/report"
+	"github.com/papa0four/orkowatch/internal/scan"
 	"github.com/papa0four/orkowatch/internal/security/audit"
 	"github.com/papa0four/orkowatch/internal/security/formatter"
 	"github.com/papa0four/orkowatch/internal/softwarelist"
@@ -49,8 +50,8 @@ Results can be output in various formats and saved to a file.`,
   # Skip specific modules
   owatch all --skip-modules security,software
 
-  # Save report to file in JSON format
-  owatch all -o json --report-file system-scan.json`,
+  # Save report to directory in JSON format
+  owatch all -o json --report-file /path/to/reports`,
 	RunE: runAllScans,
 }
 
@@ -58,9 +59,9 @@ func init() {
 	allCmd.Flags().BoolVarP(&allVerbose, "verbose", "v", false,
 		"Enable verbose output for all scans")
 	allCmd.Flags().StringVarP(&allOutputFormat, "output", "o", "text",
-		"Output format (text, json, yaml)")
+		"Output format (json, yaml, text, csv)")
 	allCmd.Flags().StringVar(&allReportFile, "report-file", "",
-		"Save complete report to file")
+		"Save complete report to the specified directory; filename is generated automatically")
 	allCmd.Flags().StringSliceVar(&skipModules, "skip-modules", []string{},
 		"Modules to skip (comma-separated: os,software,security)")
 	allCmd.Flags().DurationVar(&allTimeout, "timeout", 30*time.Minute,
@@ -84,6 +85,24 @@ type ScanResult struct {
 	Errors        []string              `json:"errors,omitempty"`
 }
 
+// allScanLabel is the scan segment used in generated report filenames for the all command
+const allScanLabel = "all"
+
+// buildAllMask composes a CheckMask from the active module and security check flags
+func buildAllMask() scan.CheckMask {
+	var mask scan.CheckMask
+	if !isModuleSkipped("os") {
+		mask |= scan.ModuleOS
+	}
+	if !isModuleSkipped("software") {
+		mask |= scan.ModuleSoftware
+	}
+	if !isModuleSkipped("security") {
+		mask |= scan.CheckSSH | scan.CheckFirewall | scan.CheckUsers | scan.CheckPerms
+	}
+	return mask
+}
+
 // validateSkipModules rejects any --skip-modules value that is not recognized
 func validateSkipModules() error {
 	valid := map[string]bool{
@@ -99,10 +118,46 @@ func validateSkipModules() error {
 	return nil
 }
 
+// validateAllFlags rejects invalid flag combinations for the all command.
+func validateAllFlags(cmd *cobra.Command) error {
+	switch allOutputFormat {
+	case "json", "yaml", "text", "csv":
+		// accepted
+	default:
+		return fmt.Errorf("invalid output format: %s (valid: json, yaml, text, csv)", allOutputFormat)
+	}
+
+	if cmd.Flags().Changed("report-file") {
+		if err := validateAllReportDir(allReportFile); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateAllReportDir confirms that the value passed to --report-file is an
+// existing directory. The program generates the filename inside it; the caller
+// supplies only the destination directory.
+func validateAllReportDir(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("--report-file: directory is not accessible: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("--report-file: %s is not a directory", path)
+	}
+	return nil
+}
+
 func runAllScans(cmd *cobra.Command, args []string) error {
 	startTime := time.Now()
 
 	if err := validateSkipModules(); err != nil {
+		return err
+	}
+
+	if err := validateAllFlags(cmd); err != nil {
 		return err
 	}
 
@@ -151,9 +206,10 @@ func runAllScans(cmd *cobra.Command, args []string) error {
 		results <- result
 	}()
 
+	mask := buildAllMask()
 	select {
 	case result := <-results:
-		return outputResults(result)
+		return outputResults(cmd, result, mask)
 	case <-time.After(allTimeout):
 		return fmt.Errorf("scan timed out after %v", allTimeout)
 	}
@@ -263,9 +319,16 @@ func convertToAuditResult(scan *ScanResult) *audit.Result {
 	return result
 }
 
-func outputResults(result *ScanResult) error {
+func outputResults(cmd *cobra.Command, result *ScanResult, mask scan.CheckMask) error {
+	format := "text"
+	if cmd.Flags().Changed("output") {
+		format = allOutputFormat
+	} else if allReportFile != "" {
+		format = "json"
+	}
+
 	opts := formatter.FormatOptions{
-		Format:        formatter.OutputFormat(allOutputFormat),
+		Format:        formatter.OutputFormat(format),
 		Verbose:       allVerbose,
 		ColorOutput:   isTerminal() && allReportFile == "",
 		IncludeSystem: true,
@@ -280,21 +343,24 @@ func outputResults(result *ScanResult) error {
 		return fmt.Errorf("failed to format results: %w", err)
 	}
 
-	if allReportFile == "" {
-		fmt.Print(buf.String())
+	if allReportFile != "" {
+		hostname := report.ResolveHostname()
+		codes := scan.Codes(mask)
+		path := report.DefaultPath(allReportFile, allScanLabel, hostname, codes, format)
+		wOpts := report.Options{AllowElevatedWrite: allAllowElevatedWrite}
+		if err := report.Write(path, buf.Bytes(), wOpts); err != nil {
+			if errors.Is(err, report.ErrElevatedWriteDenied) {
+				return fmt.Errorf("%w; pass --allow-elevated-write to permit it", err)
+			}
+			return fmt.Errorf("failed to write report file: %w", err)
+		}
+		if allVerbose {
+			fmt.Printf("[+] Report saved to: %s\n", path)
+		}
 		return nil
 	}
 
-	wOpts := report.Options{AllowElevatedWrite: allAllowElevatedWrite}
-	if err := report.Write(allReportFile, buf.Bytes(), wOpts); err != nil {
-		if errors.Is(err, report.ErrElevatedWriteDenied) {
-			return fmt.Errorf("%w; pass --allow-elevated-write to permit it", err)
-		}
-		return fmt.Errorf("failed to write report file: %w", err)
-	}
-	if allVerbose {
-		fmt.Printf("[+] Report saved to: %s\n", allReportFile)
-	}
+	fmt.Print(buf.String())
 	return nil
 }
 

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/papa0four/orkowatch/internal/report"
+	"github.com/papa0four/orkowatch/internal/scan"
 	"github.com/papa0four/orkowatch/internal/security/audit"
 	"github.com/papa0four/orkowatch/internal/security/types"
 )
@@ -124,13 +125,16 @@ type (
 	}
 )
 
+// scanLabel is the scan segment used in generated report filenames.
+const scanLabel = "audit"
+
 func init() {
 	SecurityCmd.Flags().BoolVarP(&verbose, "verbose", "v", false,
 		"Enable verbose output")
 	SecurityCmd.Flags().StringVarP(&outputFormat, "output", "o", "text",
 		"Output format (text, json, yaml)")
 	SecurityCmd.Flags().StringVar(&reportFile, "report-file", "",
-		"Save audit report to file")
+		"Save audit report to the specified directory; filename is generated automatically")
 	SecurityCmd.Flags().StringSliceVar(&skipChecks, "skip-checks", []string{},
 		"Checks to skip (comma-separated: ssh, firewall, users, permissions)")
 	SecurityCmd.Flags().StringVar(&minSeverity, "min-severity", "LOW",
@@ -151,31 +155,30 @@ func init() {
 		"Permit an elevated write outside the allowlisted directories")
 }
 
-func buildChecks() []string {
-	var checks []string
+// buildMask composes a CheckMask from the active flag values
+func buildMask() scan.CheckMask {
+	var mask scan.CheckMask
 	if checkSSH {
-		checks = append(checks, "ssh")
+		mask |= scan.CheckSSH
 	}
 	if checkFirewall {
-		checks = append(checks, "firewall")
+		mask |= scan.CheckFirewall
 	}
 	if checkUsers {
-		checks = append(checks, "users")
+		mask |= scan.CheckUsers
 	}
 	if checkFilePerms != "" {
-		checks = append(checks, "permissions")
+		mask |= scan.CheckPerms
 	}
-	return checks
+	return mask
 }
 
 func validateFlags(cmd *cobra.Command) error {
-	validFormats := map[string]bool{
-		"text": true,
-		"json": true,
-		"yaml": true,
-	}
-	if !validFormats[outputFormat] {
-		return fmt.Errorf("invalid output format: %s", outputFormat)
+	switch outputFormat {
+	case "json", "yaml", "text", "csv":
+		// accepted
+	default:
+		return fmt.Errorf("invalid output format: %s (valid: json, yaml, text)", outputFormat)
 	}
 
 	validSeverities := map[string]bool{
@@ -190,6 +193,12 @@ func validateFlags(cmd *cobra.Command) error {
 
 	if err := validateFilePermsPath(cmd); err != nil {
 		return err
+	}
+
+	if cmd.Flags().Changed("report-file") {
+		if err := validateReportDir(reportFile); err != nil {
+			return err
+		}
 	}
 
 	validChecks := map[string]bool{
@@ -207,6 +216,19 @@ func validateFlags(cmd *cobra.Command) error {
 	return nil
 }
 
+// validateReportDir confirms that the value passed to --report-file is an existing directory.
+// The program generates the filename inside it; the caller supplies only the destination directory.
+func validateReportDir(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("--report-file: directory is not accessible: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("--report-file: %s is not a directory", path)
+	}
+	return nil
+}
+
 // validateFilePermsPath enforces existing path and file rejecting explicit empty value
 func validateFilePermsPath(cmd *cobra.Command) error {
 	if !cmd.Flags().Changed("fperms") {
@@ -221,10 +243,11 @@ func validateFilePermsPath(cmd *cobra.Command) error {
 	return nil
 }
 
-func logVerboseConfig(checks []string) {
+func logVerboseConfig(mask scan.CheckMask) {
 	if !verbose {
 		return
 	}
+	checks := scan.EnabledChecks(mask)
 	if len(checks) > 0 {
 		fmt.Printf("[*] Running checks: %s\n", strings.Join(checks, ", "))
 	} else {
@@ -239,14 +262,14 @@ func logVerboseConfig(checks []string) {
 	fmt.Println()
 }
 
-func runAuditWithTimeout(checks []string) error {
+func runAuditWithTimeout(cmd *cobra.Command, mask scan.CheckMask) error {
 	opts := audit.Options{
 		Verbose:        verbose,
 		SkipChecks:     skipChecks,
 		FilePermsPath:  checkFilePerms,
 		MinSeverity:    minSeverity,
 		Timeout:        timeout,
-		SpecificChecks: checks,
+		SpecificChecks: scan.EnabledChecks(mask),
 		Enrich:         enrich,
 	}
 
@@ -266,7 +289,7 @@ func runAuditWithTimeout(checks []string) error {
 
 	select {
 	case result := <-resultChan:
-		return outputResults(result)
+		return outputResults(cmd, result, mask)
 	case err := <-errorChan:
 		return fmt.Errorf("audit failed: %w", err)
 	case <-time.After(timeout):
@@ -274,20 +297,29 @@ func runAuditWithTimeout(checks []string) error {
 	}
 }
 
-func outputResults(result *audit.Result) error {
+func outputResults(cmd *cobra.Command, result *audit.Result, mask scan.CheckMask) error {
 	if result == nil || len(result.Results) == 0 {
 		fmt.Println("No results to display.")
 		return nil
 	}
 
+	format := "text"
+	if cmd.Flags().Changed("output") {
+		format = outputFormat
+	} else if reportFile != "" {
+		format = "json"
+	}
+
 	var output string
 	var err error
 
-	switch outputFormat {
+	switch format {
 	case "json":
 		output, err = formatJSON(result)
 	case "yaml":
 		output, err = formatYAML(result)
+	case "csv":
+		return fmt.Errorf("csv output format is not yet implemented")
 	default:
 		output, err = formatText(result)
 	}
@@ -297,22 +329,23 @@ func outputResults(result *audit.Result) error {
 	}
 
 	if reportFile != "" {
+		hostname := report.ResolveHostname()
+		codes := scan.Codes(mask)
+		path := report.DefaultPath(reportFile, scanLabel, hostname, codes, format)
 		opts := report.Options{AllowElevatedWrite: allowElevatedWrite}
-		if err := report.Write(reportFile, []byte(output), opts); err != nil {
+		if err := report.Write(path, []byte(output), opts); err != nil {
 			if errors.Is(err, report.ErrElevatedWriteDenied) {
 				return fmt.Errorf("%w; pass --allow-elevated-write to permit it", err)
 			}
 			return fmt.Errorf("failed to write report file: %w", err)
 		}
 		if verbose {
-			fmt.Printf("[+] Report saved to: %s\n", reportFile)
+			fmt.Printf("[+] Report saved to: %s\n", path)
 		}
+		return nil
 	}
 
-	if reportFile == "" || verbose {
-		fmt.Println(output)
-	}
-
+	fmt.Println(output)
 	return nil
 }
 

--- a/cmd/commands/security/security_unix.go
+++ b/cmd/commands/security/security_unix.go
@@ -16,7 +16,7 @@ func init() {
 }
 
 func runUnixAudit(cmd *cobra.Command, args []string) error {
-	checks := buildChecks()
+	mask := buildMask()
 
 	if err := validateFlags(cmd); err != nil {
 		return err
@@ -25,7 +25,7 @@ func runUnixAudit(cmd *cobra.Command, args []string) error {
 	if verbose {
 		fmt.Printf("[*] Running security audit for OS: %s\n", runtime.GOOS)
 	}
-	logVerboseConfig(checks)
+	logVerboseConfig(mask)
 
-	return runAuditWithTimeout(checks)
+	return runAuditWithTimeout(cmd, mask)
 }

--- a/cmd/commands/security/security_windows.go
+++ b/cmd/commands/security/security_windows.go
@@ -16,7 +16,7 @@ func init() {
 }
 
 func runWindowsAudit(cmd *cobra.Command, args []string) error {
-	checks := buildChecks()
+	mask := buildMask()
 
 	if err := validateFlags(cmd); err != nil {
 		return err
@@ -25,7 +25,7 @@ func runWindowsAudit(cmd *cobra.Command, args []string) error {
 	if verbose {
 		fmt.Printf("[*] Running security audit for OS: %s\n", runtime.GOOS)
 	}
-	logVerboseConfig(checks)
+	logVerboseConfig(mask)
 
-	return runAuditWithTimeout(checks)
+	return runAuditWithTimeout(cmd, mask)
 }

--- a/internal/report/write.go
+++ b/internal/report/write.go
@@ -4,8 +4,10 @@ package report
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -79,10 +81,50 @@ func Write(path string, data []byte, opts Options) error {
 	return openAndWrite(target, data)
 }
 
-// DefaultPath returns a generated report destination in CWD
-func DefaultPath(scan, format string) string {
+// DefaultPath returns the full path for a generated report file inside dir.
+// The filename follows the pattern owatch-<scan>-<hostname>-<codes>-<timestamp>.<ext>.
+// dir must be an existing directory; the caller is responsible for validating it.
+func DefaultPath(dir, scan, hostname, codes, format string) string {
 	stamp := time.Now().UTC().Format("20060102T150405Z")
-	return fmt.Sprintf("owatch-%s-%s.%s", scan, stamp, extension(format))
+	name := fmt.Sprintf("owatch-%s-%s-%s-%s.%s", scan, hostname, codes, stamp, extension(format))
+	return filepath.Join(dir, name)
+}
+
+// ResolveHostname returns a filename-safe host identifier using a fallback
+// chain: sanitized os.Hostname(), then unknown-<mac> using the first valid
+// non-loopback MAC address (hex, no separators), then unknown.
+func ResolveHostname() string {
+	// hostnameRe retains only characters safe in filenames across all supported
+	// platforms; anything else becomes a hyphen.
+	hostnameRe := regexp.MustCompile(`[^a-zA-Z0-9\-.]`)
+
+	if h, err := os.Hostname(); err == nil && h != "" {
+		sanitized := hostnameRe.ReplaceAllString(h, "-")
+		if len(sanitized) > 63 {
+			sanitized = sanitized[:63]
+		}
+		if sanitized != "" {
+			return sanitized
+		}
+	}
+
+	ifaces, err := net.Interfaces()
+	if err == nil {
+		for _, iface := range ifaces {
+			if iface.Flags&net.FlagLoopback != 0 {
+				continue
+			}
+			if len(iface.HardwareAddr) == 0 {
+				continue
+			}
+			mac := strings.ReplaceAll(iface.HardwareAddr.String(), ":", "")
+			if mac != "" {
+				return "unknown-" + mac
+			}
+		}
+	}
+
+	return "unknown"
 }
 
 func extension(format string) string {

--- a/internal/scan/checks.go
+++ b/internal/scan/checks.go
@@ -12,15 +12,21 @@ import "strings"
 type CheckMask uint64
 
 const (
-	CheckSSH      CheckMask = 1 << iota
+	// CheckSSH identifies the SSH configuration security check.
+	CheckSSH CheckMask = 1 << iota
+	// CheckFirewall identifies the firewall configuration security check.
 	CheckFirewall
-	CheckUsers
+	// CheckPerms identifies the file permissions security check.
 	CheckPerms
+	// CheckUsers identifies the user account security check.
+	CheckUsers
 
-	// Module bits occupy the upper 32 positions
-	ModuleOS       CheckMask = 1 << 32
+	// ModuleOS identifies the OS fingerprint module.
+	// Module bits are offset to bit 32 to avoid collision with security check bits.
+	ModuleOS CheckMask = 1 << 32
+	// ModuleSoftware identifies the software inventory module.
 	ModuleSoftware CheckMask = 1 << 33
-	// TODO: ModuleNetwork, ModuleSyslog, ModuleListeners
+	// TODO: ModuleNetwork, ModuleSyslog, ModuleListeners, etc.
 )
 
 // Codes returns a filename-safe string encoding the enabled checks within the
@@ -32,7 +38,9 @@ func Codes(mask CheckMask) string {
 	if mask&ModuleOS != 0 {
 		segments = append(segments, "os")
 	}
-	if mask&Mo
+	if mask&ModuleSoftware != 0 {
+		segments = append(segments, "soft")
+	}
 
 	var letters strings.Builder
 	if mask&CheckFirewall != 0 {

--- a/internal/scan/checks.go
+++ b/internal/scan/checks.go
@@ -1,0 +1,75 @@
+// Package `scan` defines the CheckMask type and constants used to identify
+// which audit checks are enabled for a given scan. The bitmask representation
+// keeps check composition O(1) and scales to 64 discrete check types without
+// structural changes.
+package scan
+
+import "strings"
+
+// CheckMask is a bitmask of enabled audit checks. Each bit represents a single
+// check type. Callers compose a mask by OR-ing the constants defined in this
+// package.
+type CheckMask uint64
+
+const (
+	CheckSSH      CheckMask = 1 << iota
+	CheckFirewall
+	CheckUsers
+	CheckPerms
+
+	// Module bits occupy the upper 32 positions
+	ModuleOS       CheckMask = 1 << 32
+	ModuleSoftware CheckMask = 1 << 33
+	// TODO: ModuleNetwork, ModuleSyslog, ModuleListeners
+)
+
+// Codes returns a filename-safe string encoding the enabled checks within the
+// mask. Module-level segments (os, soft) are joined by hyphens; security check
+// letters are alphabetically ordered and concatenated without a delimiter.
+func Codes(mask CheckMask) string {
+	var segments []string
+
+	if mask&ModuleOS != 0 {
+		segments = append(segments, "os")
+	}
+	if mask&Mo
+
+	var letters strings.Builder
+	if mask&CheckFirewall != 0 {
+		letters.WriteByte('f')
+	}
+	if mask&CheckPerms != 0 {
+		letters.WriteByte('p')
+	}
+	if mask&CheckSSH != 0 {
+		letters.WriteByte('s')
+	}
+	if mask&CheckUsers != 0 {
+		letters.WriteByte('u')
+	}
+	if letters.Len() > 0 {
+		segments = append(segments, letters.String())
+	}
+
+	return strings.Join(segments, "-")
+}
+
+// EnabledChecks returns a slice of check name strings for the enabled security
+// checks in mask. The returned slice is used by the audit runner to select
+// which checks to execute.
+func EnabledChecks(mask CheckMask) []string {
+	var checks []string
+	if mask&CheckSSH != 0 {
+		checks = append(checks, "ssh")
+	}
+	if mask&CheckFirewall != 0 {
+		checks = append(checks, "firewall")
+	}
+	if mask&CheckUsers != 0 {
+		checks = append(checks, "users")
+	}
+	if mask&CheckPerms != 0 {
+		checks = append(checks, "permissions")
+	}
+	return checks
+}


### PR DESCRIPTION
## Summary

Standardizes `-o/--output` as the format selector across `audit` and `all`, redesigns `--report-file` to accept a destination directory with auto-generated filenames, and introduces `internal/scan` and `internal/report.ResolveHostname` as the foundational infrastructure for consistent, host-identified report output.

## Changes

- `internal/report/write.go` -- extended `DefaultPath` to accept `dir`, `hostname`, and `codes` parameters and return a full path;
  added `ResolveHostname` with fallback chain: sanitized `os.Hostname()`, then `unknown-<mac>` (first valid non-loopback MAC, hex no separators), then `unknown`
- `internal/scan/scan.go` -- new package defining `CheckMask` (`uint64` bitmask), security check constants (`CheckSSH`, `CheckFirewall`, `CheckPerms`, `CheckUsers`) in lower bits, module constants (`ModuleOS`, `ModuleSoftware`) offset to bits 32+, and `Codes`/`EnabledChecks` functions
- `cmd/commands/security/security.go` -- replaced `buildChecks` with `buildMask`; added `scanLabel` constant; added `validateReportDir`; updated `validateFlags` to accept `csv` as a valid format value; updated `--report-file` flag to accept a directory; wired `resolveFormat`, `ResolveHostname`, `scan.Codes`, and `report.DefaultPath` into `outputResults`; format resolves as: explicit `-o` wins, `--report-file` without `-o` defaults to `json`, neither defaults to `text` for stdout
- `cmd/commands/security/security_unix.go` -- updated to use `buildMask` and pass `cmd` through to `runAuditWithTimeout`
- `cmd/commands/security/security_windows.go` -- same as unix platform file
- `cmd/commands/all.go` -- added `allScanLabel`, `buildAllMask`, `validateAllFlags`, `validateAllReportDir`; wired same format resolution and report path logic as `audit`; fixed `allOutputFormat` vs `format` variable mismatch in formatter options; fixed `"Software"` casing in `buildAllMask`

## Verified

- `audit --ssh` -- stdout, text format
- `audit --ssh -o json` -- stdout, json format
- `audit --ssh -o yaml` -- stdout, yaml format
- `audit --ssh --report-file <dir>` -- file written as `owatch-audit-MSI-s-<timestamp>.json`
- `audit --ssh -o yaml --report-file <dir>` -- file written as `.yaml`
- `audit --ssh --report-file <dir> -v` -- file written, `[+] Report saved to:` printed
- `audit --ssh -o csv` -- clean "not yet implemented" error
- `audit --ssh --report-file <nonexistent>` -- clean directory validation error
- `audit --ssh --report-file C:\Windows\System32` -- guard pipeline refused
- `all` -- stdout, text format
- `all -o json` -- stdout, json format
- `all -o yaml` -- stdout, yaml format
- `all --report-file <dir> -v` -- file written as `owatch-all-MSI-os-soft-fpsu-<timestamp>.json`
- `all -o yaml --report-file <dir>` -- file written as `.yaml`
- `all --skip-modules security --report-file <dir>` -- file written as `owatch-all-MSI-os-soft-<timestamp>.json`
- `all --skip-modules os,software --report-file <dir>` -- file written as `owatch-all-MSI-fpsu-<timestamp>.json`
- `all --report-file <nonexistent>` -- clean directory validation error
- `all --report-file C:\Windows\System32` -- guard pipeline refused

Closes #82 