### PR TITLE
[Chore] software listing formatter update and all command structural cleanup (#84)

### DIFF
--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -11,12 +12,13 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	"github.com/papa0four/orkowatch/internal/osfingerprint"
 	"github.com/papa0four/orkowatch/internal/report"
 	"github.com/papa0four/orkowatch/internal/scan"
 	"github.com/papa0four/orkowatch/internal/security/audit"
-	"github.com/papa0four/orkowatch/internal/security/formatter"
+	"github.com/papa0four/orkowatch/internal/security/types"
 	"github.com/papa0four/orkowatch/internal/softwarelist"
 )
 
@@ -74,15 +76,70 @@ func init() {
 	RootCmd.AddCommand(allCmd)
 }
 
-// ScanResult represents the combined results of all scans
+// ScanResult represents the combined results of all scans. It is the
+// authoritative result type for the all command and is not shared with
+// the audit subsystem.
 type ScanResult struct {
-	Timestamp     time.Time             `json:"timestamp"`
-	Duration      time.Duration         `json:"duration"`
-	OSInfo        *osfingerprint.OSInfo `json:"os_info,omitempty"`
-	SoftwareInfo  string                `json:"software_info,omitempty"`
-	SoftwareCount int                   `json:"software_count"`
-	SecurityAudit *audit.Result         `json:"security_audit,omitempty"`
-	Errors        []string              `json:"errors,omitempty"`
+	Timestamp     time.Time                    `json:"timestamp"`
+	Duration      time.Duration                `json:"duration"`
+	OSInfo        *osfingerprint.OSInfo        `json:"os_info,omitempty"`
+	Software      []softwarelist.SoftwareEntry `json:"software,omitempty"`
+	SecurityAudit *audit.Result                `json:"security_audit,omitempty"`
+	Errors        []string                     `json:"errors,omitempty"`
+}
+
+// allResult is the typed serialization structure for all command JSON and
+// YAML output. It defines clean section boundaries between system, software,
+// and security data.
+type allResult struct {
+	Timestamp string        `json:"timestamp" yaml:"timestamp"`
+	Duration  string        `json:"duration" yaml:"duration"`
+	System    allSystemInfo `json:"system" yaml:"system"`
+	Software  allSoftware   `json:"software,omitempty" yaml:"software,omitempty"`
+	Security  *allSecurity  `json:"security,omitempty" yaml:"security,omitempty"`
+	Errors    []string      `json:"errors,omitempty" yaml:"errors,omitempty"`
+}
+
+// allSystemInfo carries host identity fields for all command output.
+type allSystemInfo struct {
+	OS            string `json:"os" yaml:"os"`
+	Hostname      string `json:"hostname" yaml:"hostname"`
+	KernelVersion string `json:"kernel_version" yaml:"kernel_version"`
+	Architecture  string `json:"architecture" yaml:"architecture"`
+}
+
+// allSoftware carries the structured software inventory for all command output.
+type allSoftware struct {
+	Count    int                          `json:"count" yaml:"count"`
+	Packages []softwarelist.SoftwareEntry `json:"packages" yaml:"packages"`
+}
+
+// allSecurity carries the security audit results for all command output.
+type allSecurity struct {
+	Summary  allSecuritySummary `json:"summary" yaml:"summary"`
+	Findings []allFinding       `json:"findings,omitempty" yaml:"findings,omitempty"`
+}
+
+// allSecuritySummary carries per-severity finding counts for all command output.
+type allSecuritySummary struct {
+	TotalChecks   int `json:"total_checks" yaml:"total_checks"`
+	PassedChecks  int `json:"passed_checks" yaml:"passed_checks"`
+	TotalFindings int `json:"total_findings" yaml:"total_findings"`
+	Critical      int `json:"critical" yaml:"critical"`
+	High          int `json:"high" yaml:"high"`
+	Medium        int `json:"medium" yaml:"medium"`
+	Low           int `json:"low" yaml:"low"`
+}
+
+// allFinding carries a single security finding for all command output.
+type allFinding struct {
+	Check       string `json:"check" yaml:"check"`
+	Title       string `json:"title" yaml:"title"`
+	Severity    string `json:"severity" yaml:"severity"`
+	CWE         string `json:"cwe,omitempty" yaml:"cwe,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Impact      string `json:"impact,omitempty" yaml:"impact,omitempty"`
+	Resolution  string `json:"resolution,omitempty" yaml:"resolution,omitempty"`
 }
 
 // allScanLabel is the scan segment used in generated report filenames for the all command
@@ -101,6 +158,79 @@ func buildAllMask() scan.CheckMask {
 		mask |= scan.CheckSSH | scan.CheckFirewall | scan.CheckUsers | scan.CheckPerms
 	}
 	return mask
+}
+
+// toAllResult converts a ScanResult into the typed serialization structure
+// for all command output.
+func toAllResult(scan *ScanResult) allResult {
+	out := allResult{
+		Timestamp: scan.Timestamp.UTC().Format(time.RFC3339),
+		Duration:  scan.Duration.String(),
+		Errors:    scan.Errors,
+	}
+
+	// system info -- prefer OS fingerprint data, fall back to runtime
+	if scan.OSInfo != nil {
+		out.System = allSystemInfo{
+			OS:            scan.OSInfo.Platform,
+			Hostname:      scan.OSInfo.Hostname,
+			KernelVersion: scan.OSInfo.KernelVersion,
+			Architecture:  runtime.GOARCH,
+		}
+	} else {
+		hostname, _ := os.Hostname() //nolint:errcheck // fallback to empty string on error
+		out.System = allSystemInfo{
+			OS:           runtime.GOOS,
+			Hostname:     hostname,
+			Architecture: runtime.GOARCH,
+		}
+	}
+
+	// software inventory
+	if len(scan.Software) > 0 {
+		out.Software = allSoftware{
+			Count:    len(scan.Software),
+			Packages: scan.Software,
+		}
+	}
+
+	// security audit
+	if scan.SecurityAudit != nil {
+		sec := &allSecurity{
+			Summary: allSecuritySummary{
+				TotalChecks:   scan.SecurityAudit.Summary.TotalChecks,
+				PassedChecks:  scan.SecurityAudit.Summary.PassedChecks,
+				TotalFindings: scan.SecurityAudit.Summary.TotalFindings,
+				Critical:      scan.SecurityAudit.Summary.CriticalFindings,
+				High:          scan.SecurityAudit.Summary.HighFindings,
+				Medium:        scan.SecurityAudit.Summary.MediumFindings,
+				Low:           scan.SecurityAudit.Summary.LowFindings,
+			},
+		}
+		for _, check := range scan.SecurityAudit.Results {
+			for _, finding := range check.Findings {
+				f := allFinding{
+					Check:       check.Name,
+					Title:       finding.Title,
+					Severity:    finding.Severity,
+					Description: finding.Description,
+					Impact:      finding.Impact,
+					Resolution:  finding.Resolution,
+				}
+				// extract first CWE reference if present
+				for _, ref := range finding.References {
+					if ref.Type == "CWE" {
+						f.CWE = ref.Title
+						break
+					}
+				}
+				sec.Findings = append(sec.Findings, f)
+			}
+		}
+		out.Security = sec
+	}
+
+	return out
 }
 
 // validateSkipModules rejects any --skip-modules value that is not recognized
@@ -183,13 +313,12 @@ func runAllScans(cmd *cobra.Command, args []string) error {
 		}
 
 		if !isModuleSkipped("software") {
-			softwareInfo, softwareCount, err := runSoftwareInventory()
+			software, err := runSoftwareInventory()
 			if err != nil {
 				result.Errors = append(result.Errors,
 					fmt.Sprintf("Software inventory error: %v", err))
 			} else {
-				result.SoftwareInfo = softwareInfo
-				result.SoftwareCount = softwareCount
+				result.Software = software
 			}
 		}
 
@@ -216,7 +345,7 @@ func runAllScans(cmd *cobra.Command, args []string) error {
 }
 
 func runOSFingerprint() (*osfingerprint.OSInfo, error) {
-	if allVerbose {
+	if allVerbose && isTerminal() {
 		fmt.Println("[*] OS Fingerprint Scan")
 	}
 
@@ -225,7 +354,7 @@ func runOSFingerprint() (*osfingerprint.OSInfo, error) {
 		return nil, err
 	}
 
-	if allVerbose {
+	if allVerbose && isTerminal() {
 		line := fmt.Sprintf("[*] OS: %s | Platform: %s | OS Version: %s",
 			info.OS, info.Platform, info.PlatformVersion)
 		if info.KernelVersion != "" && info.KernelVersion != info.PlatformVersion {
@@ -237,33 +366,36 @@ func runOSFingerprint() (*osfingerprint.OSInfo, error) {
 	return info, nil
 }
 
-func runSoftwareInventory() (string, int, error) {
-	if allVerbose {
+// runSoftwareInventory enumerates installed software packages. Verbose module
+// headers are gated behind isTerminal() to prevent duplication when piping
+// or redirecting output.
+func runSoftwareInventory() ([]softwarelist.SoftwareEntry, error) {
+	if allVerbose && isTerminal() {
 		fmt.Println("[*] Software Inventory Scan")
 	}
 
-	software, err := softwarelist.GetInstalledSoftware()
+	entries, err := softwarelist.GetInstalledSoftwareList()
 	if err != nil {
-		return "", 0, err
+		return nil, err
 	}
 
-	softwareCount := strings.Count(software, "\n") + 1
-
-	if allVerbose {
-		fmt.Printf("[*] Found %d installed packages\n\n", softwareCount)
-		fmt.Println(software)
+	if allVerbose && isTerminal() {
+		fmt.Printf("[*] Found %d installed packages\n\n", len(entries))
+		for _, e := range entries {
+			fmt.Printf("%-60s %s\n", e.Name, e.Version)
+		}
 	}
 
-	return software, softwareCount, nil
+	return entries, nil
 }
 
 func runSecurityAuditModule() (*audit.Result, error) {
-	if allVerbose {
+	if allVerbose && isTerminal() {
 		fmt.Println("[*] Security Audit Scan")
 	}
 
 	opts := audit.Options{
-		Verbose:     allVerbose,
+		Verbose:     allVerbose && isTerminal(),
 		MinSeverity: "LOW",
 		Timeout:     allTimeout / 3,
 		Enrich:      allEnrich,
@@ -271,52 +403,6 @@ func runSecurityAuditModule() (*audit.Result, error) {
 
 	auditor := audit.NewSecurityAuditor(opts)
 	return auditor.RunAudit()
-}
-
-func convertToAuditResult(scan *ScanResult) *audit.Result {
-	var sysInfo audit.SystemInfo
-	if scan.SecurityAudit != nil {
-		sysInfo = scan.SecurityAudit.SystemInfo
-	} else {
-		sysInfo = audit.SystemInfo{
-			OS:           runtime.GOOS,
-			Architecture: runtime.GOARCH,
-		}
-		if hostname, err := os.Hostname(); err == nil {
-			sysInfo.Hostname = hostname
-		}
-	}
-
-	if scan.OSInfo != nil {
-		if scan.OSInfo.Platform != "" {
-			sysInfo.OS = scan.OSInfo.Platform
-		}
-		if scan.OSInfo.KernelVersion != "" {
-			sysInfo.KernelVersion = scan.OSInfo.KernelVersion
-		}
-	}
-	if scan.SoftwareInfo != "" {
-		sysInfo.SoftwareInfo = scan.SoftwareInfo
-		sysInfo.SoftwareCount = scan.SoftwareCount
-	}
-
-	result := &audit.Result{
-		StartTime:  scan.Timestamp,
-		EndTime:    scan.Timestamp.Add(scan.Duration),
-		Duration:   scan.Duration,
-		SystemInfo: sysInfo,
-	}
-
-	if scan.SecurityAudit != nil {
-		result.Results = scan.SecurityAudit.Results
-		result.Summary = scan.SecurityAudit.Summary
-		result.EnrichmentRequested = scan.SecurityAudit.EnrichmentRequested
-		result.EnrichmentError = scan.SecurityAudit.EnrichmentError
-		result.Enrichment = scan.SecurityAudit.Enrichment
-		result.References = scan.SecurityAudit.References
-	}
-
-	return result
 }
 
 func outputResults(cmd *cobra.Command, result *ScanResult, mask scan.CheckMask) error {
@@ -327,20 +413,25 @@ func outputResults(cmd *cobra.Command, result *ScanResult, mask scan.CheckMask) 
 		format = "json"
 	}
 
-	opts := formatter.FormatOptions{
-		Format:        formatter.OutputFormat(format),
-		Verbose:       allVerbose,
-		ColorOutput:   isTerminal() && allReportFile == "",
-		IncludeSystem: true,
-		Compact:       false,
-	}
-
-	auditResult := convertToAuditResult(result)
-
 	var buf bytes.Buffer
-	f := formatter.NewFormatter(&buf, opts)
-	if err := f.Format(auditResult); err != nil {
-		return fmt.Errorf("failed to format results: %w", err)
+
+	switch format {
+	case "json":
+		data := toAllResult(result)
+		enc := json.NewEncoder(&buf)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(data); err != nil {
+			return fmt.Errorf("failed to encode JSON: %w", err)
+		}
+	case "yaml":
+		data := toAllResult(result)
+		if err := yaml.NewEncoder(&buf).Encode(data); err != nil {
+			return fmt.Errorf("failed to encode YAML: %w", err)
+		}
+	case "csv":
+		return fmt.Errorf("csv output format is not yet implemented")
+	default:
+		renderAllText(&buf, result)
 	}
 
 	if allReportFile != "" {
@@ -362,6 +453,43 @@ func outputResults(cmd *cobra.Command, result *ScanResult, mask scan.CheckMask) 
 
 	fmt.Print(buf.String())
 	return nil
+}
+
+// renderAllText writes a concise human-readable summary of the scan result
+// to w. This is the non-TUI text path; it will be replaced by the Bubbletea
+// progress display when #35 lands.
+func renderAllText(w *bytes.Buffer, result *ScanResult) {
+	fmt.Fprintf(w, "owatch all  --  %s\n\n", result.Timestamp.UTC().Format(time.RFC3339))
+
+	// system
+	if result.OSInfo != nil {
+		fmt.Fprintf(w, "System\n")
+		fmt.Fprintf(w, "  OS:       %s\n", result.OSInfo.Platform)
+		fmt.Fprintf(w, "  Host:     %s\n", result.OSInfo.Hostname)
+		fmt.Fprintf(w, "  Kernel:   %s\n", result.OSInfo.KernelVersion)
+	}
+
+	// software
+	if len(result.Software) > 0 {
+		fmt.Fprintf(w, "  Software: %d packages installed\n", len(result.Software))
+	}
+
+	fmt.Fprintln(w)
+
+	// security findings
+	if result.SecurityAudit != nil {
+		fmt.Fprintf(w, "Security Audit\n")
+		for _, check := range result.SecurityAudit.Results {
+			for _, finding := range check.Findings {
+				symbol, _ := types.SeverityFormat(finding.Severity)
+				fmt.Fprintf(w, "  %s %-8s  %s\n", symbol, finding.Severity, finding.Title)
+			}
+		}
+		fmt.Fprintln(w)
+		s := result.SecurityAudit.Summary
+		fmt.Fprintf(w, "Summary: %d checks  %d passed  %d findings  %s\n",
+			s.TotalChecks, s.PassedChecks, s.TotalFindings, result.Duration.Round(time.Millisecond))
+	}
 }
 
 func isModuleSkipped(module string) bool {

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -87,8 +87,6 @@ type (
 		Architecture  string `json:"architecture" yaml:"architecture"`
 		Hostname      string `json:"hostname" yaml:"hostname"`
 		KernelVersion string `json:"kernel_version" yaml:"kernel_version"`
-		SoftwareInfo  string `json:"software_info,omitempty"`
-		SoftwareCount int    `json:"software_count"`
 	}
 
 	formattedCheck struct {
@@ -376,8 +374,6 @@ func convertToFormattedResult(result *audit.Result) formattedResult {
 			Architecture:  result.SystemInfo.Architecture,
 			Hostname:      result.SystemInfo.Hostname,
 			KernelVersion: result.SystemInfo.KernelVersion,
-			SoftwareInfo:  result.SystemInfo.SoftwareInfo,
-			SoftwareCount: result.SystemInfo.SoftwareCount,
 		},
 		Summary: formattedSummary{
 			TotalChecks:      result.Summary.TotalChecks,

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -53,14 +53,14 @@ type Result struct {
 	References          types.ReferenceExtraction
 }
 
-// SystemInfo contains basic system information collected at the start of an audit.
+// SystemInfo contains basic system information collected at the start of an
+// audit. Software inventory is owned by the all command and is not part of
+// the audit subsystem -- see cmd/commands/all.go and internal/softwarelist.
 type SystemInfo struct {
 	OS            string `json:"os" yaml:"os"`
 	Architecture  string `json:"architecture" yaml:"architecture"`
 	Hostname      string `json:"hostname" yaml:"hostname"`
 	KernelVersion string `json:"kernel_version" yaml:"kernel_version"`
-	SoftwareInfo  string `json:"software_info,omitempty" yaml:"software_info,omitempty"`
-	SoftwareCount int    `json:"software_count" yaml:"software_count"`
 }
 
 // Summary reports the outcome of a completed audit at both check and finding

--- a/internal/softwarelist/softwarelist.go
+++ b/internal/softwarelist/softwarelist.go
@@ -1,9 +1,33 @@
-// internal/softwarelist/softwarelist.go
+// Package softwarelist enumerates installed software packages on the host.
+// It provides both a structured list for programmatic consumption and a
+// formatted string for human-readable text output.
 package softwarelist
 
 import "fmt"
 
-// GetInstalledSoftware retrieves a list of installed software based on the OS
+// SoftwareEntry represents a single installed software package with its
+// display name and version string as reported by the host platform.
+// Name and Version are discrete fields to support downstream CPE lookups
+// and enrichment adapter queries against vulnerability databases.
+type SoftwareEntry struct {
+	Name    string `json:"name" yaml:"name"`
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+}
+
+// GetInstalledSoftwareList returns the installed software packages as a
+// structured slice. Each entry carries a discrete name and version field
+// suitable for enrichment lookups and structured report output.
+func GetInstalledSoftwareList() ([]SoftwareEntry, error) {
+	entries, err := getPlatformSoftwareList()
+	if err != nil {
+		return nil, fmt.Errorf("software enumeration failed: %w", err)
+	}
+	return entries, nil
+}
+
+// GetInstalledSoftware returns the installed software packages as a
+// formatted human-readable string. Used for text output and the standalone
+// software subcommand.
 func GetInstalledSoftware() (string, error) {
 	result, err := getPlatformSoftware()
 	if err != nil {

--- a/internal/softwarelist/softwarelist_unix.go
+++ b/internal/softwarelist/softwarelist_unix.go
@@ -7,36 +7,122 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
+	"strings"
 )
 
-// getPlatformSoftware enumerates installed software using the appropriate
-// package manager or system tool for the current Unix-like platform.
-func getPlatformSoftware() (string, error) {
+// getPlatformSoftwareList returns installed software as a structured slice
+// by querying the platform package manager. Linux tries dpkg-query then rpm;
+// Darwin uses system_profiler; FreeBSD uses pkg info.
+func getPlatformSoftwareList() ([]SoftwareEntry, error) {
 	switch runtime.GOOS {
 	case "linux":
-		if output, err := exec.Command("dpkg-query", "-l").Output(); err == nil {
-			return string(output), nil
+		if output, err := exec.Command("dpkg-query", "-W", "-f=${Package}\t${Version}\n").Output(); err == nil {
+			return parseTabDelimited(string(output)), nil
 		}
-		if output, err := exec.Command("rpm", "-qa").Output(); err == nil {
-			return string(output), nil
+		if output, err := exec.Command("rpm", "-qa", "--queryformat", "%{NAME}\t%{VERSION}\n").Output(); err == nil {
+			return parseTabDelimited(string(output)), nil
 		}
-		return "", fmt.Errorf("no supported package manager found; try rerunning with sudo")
+		return nil, fmt.Errorf("no supported package manager found; try rerunning with sudo")
 
 	case "darwin":
-		output, err := exec.Command("system_profiler", "SPApplicationsDataType").Output()
-		if err == nil {
-			return string(output), nil
+		output, err := exec.Command("system_profiler", "SPApplicationsDataType", "-json").Output()
+		if err != nil {
+			return nil, fmt.Errorf("insufficient permissions to list software packages; try rerunning with sudo")
 		}
-		return "", fmt.Errorf("insufficient permissions to list software packages; try rerunning with sudo")
+		return parseDarwinJSON(output), nil
 
 	case "freebsd":
-		output, err := exec.Command("pkg", "info").Output()
-		if err == nil {
-			return string(output), nil
+		output, err := exec.Command("pkg", "info", "-a", "--raw-format", "json").Output()
+		if err != nil {
+			return nil, fmt.Errorf("insufficient permissions to list software packages; try rerunning with sudo")
 		}
-		return "", fmt.Errorf("insufficient permissions to list software packages; try rerunning with sudo")
+		return parseFreeBSDJSON(output), nil
 
 	default:
-		return "", fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+		return nil, fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
 	}
+}
+
+// getPlatformSoftware returns installed software as a column-aligned string
+// suitable for human-readable text output and the standalone software
+// subcommand. It delegates to getPlatformSoftwareList and formats each entry
+// as a fixed-width name and version pair.
+func getPlatformSoftware() (string, error) {
+	entries, err := getPlatformSoftwareList()
+	if err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%-60s %s\n", "Name", "Version")
+	for _, e := range entries {
+		fmt.Fprintf(&sb, "%-60s %s\n", e.Name, e.Version)
+	}
+	return sb.String(), nil
+}
+
+// parseTabDelimited parses tab-delimited name\tversion output from dpkg-query
+// and rpm into a slice of SoftwareEntry.
+func parseTabDelimited(output string) []SoftwareEntry {
+	var entries []SoftwareEntry
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, "\t", 2)
+		if len(fields) == 0 || fields[0] == "" {
+			continue
+		}
+		entry := SoftwareEntry{Name: fields[0]}
+		if len(fields) == 2 {
+			entry.Version = fields[1]
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+// parseDarwinJSON parses system_profiler SPApplicationsDataType -json output
+// into a slice of SoftwareEntry. This is a best-effort line-based fallback;
+// a full JSON parser will replace this when the Darwin runner lands.
+func parseDarwinJSON(output []byte) []SoftwareEntry {
+	var entries []SoftwareEntry
+	seen := make(map[string]bool)
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "\"_name\"") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				name := strings.Trim(strings.TrimSpace(parts[1]), `",`)
+				if name != "" && !seen[name] {
+					seen[name] = true
+					entries = append(entries, SoftwareEntry{Name: name})
+				}
+			}
+		}
+	}
+	return entries
+}
+
+// parseFreeBSDJSON parses pkg info -a --raw-format json output into a slice
+// of SoftwareEntry. This is a best-effort line-based fallback; a full JSON
+// parser will replace this when the FreeBSD runner lands.
+func parseFreeBSDJSON(output []byte) []SoftwareEntry {
+	var entries []SoftwareEntry
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "\"name\"") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				name := strings.Trim(strings.TrimSpace(parts[1]), `",`)
+				if name != "" {
+					entries = append(entries, SoftwareEntry{Name: name})
+				}
+			}
+		}
+	}
+	return entries
 }

--- a/internal/softwarelist/softwarelist_windows.go
+++ b/internal/softwarelist/softwarelist_windows.go
@@ -23,7 +23,7 @@ import (
 // wmic is called as a fallback for environments where registry
 // access is restricted, but its use is flagged since it is deprecated as of
 // Windows 10 21H1.
-func getPlatformSoftware() (string, error) {
+func getPlatformSoftwareList() ([]SoftwareEntry, error) {
 	const (
 		uninstallPath   = `Software\Microsoft\Windows\CurrentVersion\Uninstall`
 		uninstallPath32 = `Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall`
@@ -41,13 +41,8 @@ func getPlatformSoftware() (string, error) {
 		{registry.CURRENT_USER, uninstallPath32},
 	}
 
-	type entry struct {
-		name    string
-		version string
-	}
-
 	seen := make(map[string]bool)
-	var entries []entry
+	var entries []SoftwareEntry
 
 	for _, target := range targets {
 		k, err := registry.OpenKey(target.root, target.path,
@@ -89,26 +84,59 @@ func getPlatformSoftware() (string, error) {
 			}
 
 			seen[name] = true
-			entries = append(entries, entry{name: name, version: version})
+			entries = append(entries, SoftwareEntry{Name: name, Version: version})
 		}
 	}
 
 	if len(entries) > 0 {
-		var sb strings.Builder
-		fmt.Fprintf(&sb, "%-60s %s\n", "Name", "Version")
-		for _, e := range entries {
-			fmt.Fprintf(&sb, "%-60s %s\n", e.name, e.version)
-		}
-		return sb.String(), nil
+		return entries, nil
 	}
 
 	// wmic fallback
 	fmt.Fprintln(os.Stderr,
 		"[!] WARNING: registry read returned no results; falling back to wmic (deprecated on Windows 10 21H1+)")
 	output, err := exec.Command("wmic", "product", "get", "name,version").Output()
-	if err == nil {
-		return string(output), nil
+	if err != nil {
+		return nil, fmt.Errorf("insufficient permissions to list software packages; try rerunning as Administrator")
 	}
 
-	return "", fmt.Errorf("insufficient permissions to list software packages; try rerunning as Administrator")
+	// parse wmic tab-delimited output into entries
+	var wmicEntries []SoftwareEntry
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines[1:] { //skip header
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		version := ""
+		name := line
+		if len(fields) > 1 {
+			version = fields[len(fields)-1]
+			name = strings.TrimSpace(strings.TrimSuffix(line, version))
+		}
+		wmicEntries = append(wmicEntries, SoftwareEntry{Name: name, Version: version})
+	}
+	return wmicEntries, nil
+}
+
+// getPlatformSoftware returns installed software as a column-aligned string
+// suitable for human-readable text output and the standalone software
+// subcommand. It delegates to getPlatformSoftwareList and formats each entry
+// as a fixed-width name and version pair.
+func getPlatformSoftware() (string, error) {
+	entries, err := getPlatformSoftwareList()
+	if err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%-60s %s\n", "Name", "Version")
+	for _, e := range entries {
+		fmt.Fprintf(&sb, "%-60s %s\n", e.Name, e.Version)
+	}
+	return sb.String(), nil
 }


### PR DESCRIPTION
## Summary

Restructures the `all` command output pipeline to establish clean boundaries between the audit, OS fingerprint, and software inventory subsystems. Introduces structured software enumeration, removes software fields from `audit.SystemInfo`, eliminates `convertToAuditResult` and its dependency on the audit formatter, and gates verbose module output behind TTY detection to prevent duplication when piping or redirecting.

## Changes

- `internal/softwarelist/softwarelist.go` -- introduced `SoftwareEntry` struct with discrete `Name` and `Version` fields carrying `json`/`yaml` tags; added `GetInstalledSoftwareList() ([]SoftwareEntry, error)` for structured output; `GetInstalledSoftware()` retained for text output and the standalone software subcommand
- `internal/softwarelist/softwarelist_windows.go` -- added `getPlatformSoftwareList()` returning `[]SoftwareEntry` directly from the registry walk; `getPlatformSoftware()` delegates to it and formats the result as a column-aligned string; wmic fallback parses into typed entries
- `internal/softwarelist/softwarelist_unix.go` -- added `getPlatformSoftwareList()` with `parseTabDelimited` for dpkg-query and rpm output; `parseDarwinJSON` and `parseFreeBSDJSON` are best-effort line-based stubs pending Darwin and FreeBSD runner work; `getPlatformSoftware()` delegates to `getPlatformSoftwareList()`
- `internal/security/audit/audit.go` -- removed `SoftwareInfo` and `SoftwareCount` from `SystemInfo`; software inventory is owned by the all command and does not belong in the audit subsystem
- `cmd/commands/security/security.go` -- removed `SoftwareInfo` and `SoftwareCount` from `formattedSystemInfo`; updated `convertToFormattedResult` accordingly
- `cmd/commands/all.go` -- replaced `SoftwareInfo string` and `SoftwareCount int` in `ScanResult` with `Software []softwarelist.SoftwareEntry`; introduced typed serialization structs (`allResult`, `allSystemInfo`, `allSoftware`, `allSecurity`, `allSecuritySummary`, `allFinding`) with clean section boundaries between system, software, and security data; added `toAllResult` conversion function; removed `convertToAuditResult` and dependency on `internal/security/formatter`; replaced `outputResults` with direct JSON/YAML/text paths; added `renderAllText` for the minimal TTY text path; gated all verbose module output behind `allVerbose && isTerminal()`; `audit.Options.Verbose` now passes `allVerbose && isTerminal()` to suppress audit runner verbose lines when piping or redirecting

## Verified

- `all` -- stdout, minimal text output, correct shape
- `all -o json` -- clean structured JSON with system/software/security sections, no presentation fields
- `all -o yaml` -- equivalent clean YAML output
- `all -v` -- module headers and software listing print on TTY; audit verbose lines suppressed due to isTerminal() gating on go run; suppressed entirely when redirected or piped
- `all -v --skip-modules software` -- OS fingerprint verbose lines print on TTY; audit verbose lines suppressed; clean text output follows
- `all --skip-modules security` -- system and software sections only
- `all --skip-modules software` -- system and security sections only
- `all --report-file <dir>` -- file written as `owatch-all-<hostname>-os-soft-fpsu-<timestamp>.json`; only `[+] Report saved to:` printed to stdout
- `all --report-file <nonexistent>` -- clean directory validation error
- `all --report-file C:\Windows\System32` -- guard pipeline refused
- Full pipeline clean on Linux and Windows

Closes #84 