### PR TITLE
[Chore] Consolidate host identity into internal/osfingerprint as single source of truth

### DIFF
--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
 	"time"
 
@@ -99,12 +98,12 @@ type (
 	// YAML output. It defines clean section boundaries between system, software,
 	// and security data.
 	allResult struct {
-		Timestamp string        `json:"timestamp" yaml:"timestamp"`
-		Duration  string        `json:"duration" yaml:"duration"`
-		System    allSystemInfo `json:"system" yaml:"system"`
-		Software  *allSoftware  `json:"software,omitempty" yaml:"software,omitempty"`
-		Security  *allSecurity  `json:"security,omitempty" yaml:"security,omitempty"`
-		Errors    []string      `json:"errors,omitempty" yaml:"errors,omitempty"`
+		Timestamp string         `json:"timestamp" yaml:"timestamp"`
+		Duration  string         `json:"duration" yaml:"duration"`
+		System    *allSystemInfo `json:"system,omitempty" yaml:"system,omitempty"`
+		Software  *allSoftware   `json:"software,omitempty" yaml:"software,omitempty"`
+		Security  *allSecurity   `json:"security,omitempty" yaml:"security,omitempty"`
+		Errors    []string       `json:"errors,omitempty" yaml:"errors,omitempty"`
 	}
 
 	// allSystemInfo carries host identity fields for all command output.
@@ -226,20 +225,13 @@ func toAllResult(scan *ScanResult) allResult {
 		Errors:    scan.Errors,
 	}
 
-	// system info -- prefer OS fingerprint data, fall back to runtime
+	// system info
 	if scan.OSInfo != nil {
-		out.System = allSystemInfo{
+		out.System = &allSystemInfo{
 			OS:            scan.OSInfo.Platform,
 			Hostname:      scan.OSInfo.Hostname,
 			KernelVersion: scan.OSInfo.KernelVersion,
-			Architecture:  runtime.GOARCH,
-		}
-	} else {
-		hostname, _ := os.Hostname() //nolint:errcheck // fallback to empty string on error
-		out.System = allSystemInfo{
-			OS:           runtime.GOOS,
-			Hostname:     hostname,
-			Architecture: runtime.GOARCH,
+			Architecture:  scan.OSInfo.Architecture,
 		}
 	}
 
@@ -411,7 +403,7 @@ func runAllScans(cmd *cobra.Command, args []string) error {
 		}
 
 		if !isModuleSkipped("audit") {
-			if securityResult, err := runSecurityAuditModule(mask); err != nil {
+			if securityResult, err := runSecurityAuditModule(mask, result.OSInfo); err != nil {
 				result.Errors = append(result.Errors,
 					fmt.Sprintf("Security audit error: %v", err))
 			} else {
@@ -476,7 +468,7 @@ func runSoftwareInventory() ([]softwarelist.SoftwareEntry, error) {
 	return entries, nil
 }
 
-func runSecurityAuditModule(mask scan.CheckMask) (*audit.Result, error) {
+func runSecurityAuditModule(mask scan.CheckMask, hostInfo *osfingerprint.OSInfo) (*audit.Result, error) {
 	if allVerbose && isTerminal() && allReportFile == "" {
 		fmt.Println("[*] Security Audit Scan")
 	}
@@ -487,6 +479,7 @@ func runSecurityAuditModule(mask scan.CheckMask) (*audit.Result, error) {
 		Timeout:        allTimeout,
 		Enrich:         allEnrich,
 		SpecificChecks: scan.EnabledChecks(mask),
+		HostInfo:       hostInfo,
 	}
 
 	auditor := audit.NewSecurityAuditor(opts)

--- a/cmd/commands/osinfo.go
+++ b/cmd/commands/osinfo.go
@@ -2,6 +2,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/papa0four/orkowatch/internal/osfingerprint"
@@ -12,8 +14,12 @@ var osinfoCmd = &cobra.Command{
 	Use:   "osinfo",
 	Short: "Gather OS Fingerprint information",
 	Long:  `osinfo will scan the host machine and retrieve basic OS fingerprint information such as platform, version, and kernel details.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		osfingerprint.PrintOSInfo()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		info, err := osfingerprint.GetOSFingerprint()
+		if err != nil {
+			return fmt.Errorf("osinfo: %w", err)
+		}
+		return osfingerprint.WriteText(cmd.OutOrStdout(), info)
 	},
 }
 

--- a/internal/osfingerprint/osfingerprint.go
+++ b/internal/osfingerprint/osfingerprint.go
@@ -3,7 +3,9 @@ package osfingerprint
 
 import (
 	"fmt"
+	"io"
 	"runtime"
+	"sort"
 
 	"github.com/shirou/gopsutil/host"
 )
@@ -15,6 +17,7 @@ type OSInfo struct {
 	PlatformVersion string
 	KernelVersion   string
 	Hostname        string
+	Architecture    string
 	AdditionalInfo  map[string]string // store any additional OS-Specific details
 }
 
@@ -31,6 +34,7 @@ func GetOSFingerprint() (*OSInfo, error) {
 		PlatformVersion: info.PlatformVersion,
 		KernelVersion:   info.KernelVersion,
 		Hostname:        info.Hostname,
+		Architecture:    runtime.GOARCH,
 		AdditionalInfo:  make(map[string]string),
 	}
 
@@ -53,19 +57,30 @@ func GetOSFingerprint() (*OSInfo, error) {
 	return osInfo, nil
 }
 
-// PrintOSInfo prints the OS Fingerprint details in a formatted way
-func PrintOSInfo() {
-	osInfo, err := GetOSFingerprint()
-	if err != nil {
-		fmt.Printf("Error retrieving OS Information: %v\n", err)
-		return
+// WriteText writes o's fields to w as labeled lines in fixed order.
+// AdditionalInfo keys are sorted before writing so output is deterministic --
+// Go map iteration order is randomized and would otherwise produce
+// nondeterministic diffs in reports and tests.
+func WriteText(w io.Writer, o *OSInfo) error {
+	if o == nil {
+		return fmt.Errorf("osfingerprint: cannot render nil OSInfo")
 	}
 
-	fmt.Printf("OS: %s\nHostname: %s\nPlatform: %s\nVersion: %s\nKernel Version: %s\n",
-		osInfo.OS, osInfo.Hostname, osInfo.Platform, osInfo.PlatformVersion, osInfo.KernelVersion)
-
-	// Print additional OS-specific information
-	for key, value := range osInfo.AdditionalInfo {
-		fmt.Printf("%s: %s\n", key, value)
+	if _, err := fmt.Fprintf(w, "OS: %s\nHostname:%s\nPlatform: %s\nVersion: %s\nKernel Version: %s\nArchitecture: %s\n",
+		o.OS, o.Hostname, o.Platform, o.PlatformVersion, o.KernelVersion, o.Architecture); err != nil {
+		return fmt.Errorf("osfingerprint: write failed: %w", err)
 	}
+
+	keys := make([]string, 0, len(o.AdditionalInfo))
+	for key := range o.AdditionalInfo {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if _, err := fmt.Fprintf(w, "%s: %s\n", key, o.AdditionalInfo[key]); err != nil {
+			return fmt.Errorf("osfingerprint: write failed: %w", err)
+		}
+	}
+	return nil
 }

--- a/internal/report/write.go
+++ b/internal/report/write.go
@@ -100,6 +100,11 @@ func DefaultPath(dir, hostname, codes, format string) string {
 // ResolveHostname returns a filename-safe host identifier using a fallback
 // chain: sanitized os.Hostname(), then unknown-<mac> using the first valid
 // non-loopback MAC address (hex, no separators), then unknown.
+//
+// Exempt from the single-reader rule that makes internal/osfingerprint the
+// sole source of host identity: report naming must succeed even when
+// fingerprinting was skipped or failed, so it cannot depend on fingerprint
+// data existing.
 func ResolveHostname() string {
 	// hostnameRe retains only characters safe in filenames across all supported
 	// platforms; anything else becomes a hyphen.

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -4,13 +4,12 @@ package audit
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/exec"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/papa0four/orkowatch/internal/osfingerprint"
 	"github.com/papa0four/orkowatch/internal/security/checker"
 	"github.com/papa0four/orkowatch/internal/security/enrichment"
 	"github.com/papa0four/orkowatch/internal/security/registry"
@@ -37,6 +36,7 @@ type Options struct {
 	MinSeverity    string
 	Timeout        time.Duration
 	Enrich         bool
+	HostInfo       *osfingerprint.OSInfo
 }
 
 // Result represents the complete audit results
@@ -114,9 +114,17 @@ func NewSecurityAuditor(opts Options) *SecurityAuditor {
 
 // RunAudit performs the security audit with the specified options
 func (sa *SecurityAuditor) RunAudit() (*Result, error) {
+	fingerprint := sa.options.HostInfo
+	if fingerprint == nil {
+		var err error
+		if fingerprint, err = osfingerprint.GetOSFingerprint(); err != nil && sa.verbose {
+			fmt.Printf("[!] OS fingerprint unavailable: %v\n", err)
+		}
+	}
+
 	result := &Result{
 		StartTime:           time.Now(),
-		SystemInfo:          getSystemInfo(),
+		SystemInfo:          systemInfoFrom(fingerprint),
 		Results:             make([]types.AuditResult, 0),
 		EnrichmentRequested: sa.options.Enrich,
 	}
@@ -309,36 +317,21 @@ func (sa *SecurityAuditor) calculateSummary(results []types.AuditResult) Summary
 	return summary
 }
 
-func getSystemInfo() SystemInfo {
-	info := SystemInfo{
-		OS:           runtime.GOOS,
-		Architecture: runtime.GOARCH,
+// systemInfoFrom converts a host fingerprint into the audit's SystemInfo.
+// A nil fingerprint (fetch failed) yields identity fields left empty except
+// Architecture, which falls back to runtime.GOARCH as a fact about the
+// running binary rather than re-derived host identity: osfingerprint is the
+// single source of host identity, and a local fallback would reintroduce
+// the divergence this consolidation removes.
+func systemInfoFrom(info *osfingerprint.OSInfo) SystemInfo {
+	if info == nil {
+		return SystemInfo{Architecture: runtime.GOARCH}
 	}
-
-	if hostname, err := os.Hostname(); err == nil {
-		info.Hostname = hostname
-	}
-
-	if kernel, err := getKernelVersion(); err == nil {
-		info.KernelVersion = kernel
-	}
-	return info
-}
-
-func getKernelVersion() (string, error) {
-	switch runtime.GOOS {
-	case "windows":
-		output, err := exec.Command("cmd", "/c", "ver").CombinedOutput()
-		if err != nil {
-			return "", err
-		}
-		return strings.TrimSpace(string(output)), nil
-	default:
-		output, err := exec.Command("uname", "-r").CombinedOutput()
-		if err != nil {
-			return "", err
-		}
-		return strings.TrimSpace(string(output)), nil
+	return SystemInfo{
+		OS:            info.OS,
+		Architecture:  info.Architecture,
+		Hostname:      info.Hostname,
+		KernelVersion: info.KernelVersion,
 	}
 }
 

--- a/internal/security/registry/registry.go
+++ b/internal/security/registry/registry.go
@@ -200,6 +200,12 @@ func Lookup(ctx OSContext, key FindingKey) (FindingDefinition, bool) {
 
 // DetectOS identifies the current platform and, for Linux, resolves
 // the full distribution family chain from /etc/os-release.
+//
+// Deliberately independent of internal/osfingerprint: this resolves which
+// registry YAML files apply to the host (family-chain precision from
+// ID/ID_LIKE), not host identity for reporting, and wiring it to
+// osfingerprint would violate the pinned import direction (registry
+// imports types only).
 func DetectOS() OSContext {
 	switch platform := detectPlatform(); platform {
 	case PlatformLinux:


### PR DESCRIPTION
## Summary

Host identity was read by three independent code paths that could disagree on the same machine: `internal/osfingerprint` via gopsutil, `audit.go`'s private `getSystemInfo`/`getKernelVersion` shelling out to `uname -r` and `cmd /c ver`, and `all.go`'s runtime fallback when the osinfo module was skipped. Confirmed live on Windows, where audit reported `Microsoft Windows [Version ...]` while osinfo and all reported the gopsutil version string.

`internal/osfingerprint` is now the sole reader. The audit's exec-based path and all's runtime fallback are deleted. When `all` runs the audit module, the fingerprint fetched by the osinfo module is passed through `audit.Options.HostInfo` so identity is read once per process; standalone `audit` fetches its own through the same function. Two deliberate exceptions are documented at their declaration sites: `registry.DetectOS` (family-chain resolution for YAML lookup, pinned import direction forbids the dependency) and `report.ResolveHostname` (filename identity must succeed when fingerprinting is skipped or failed).

## Changes

**`internal/osfingerprint/osfingerprint.go`**
- `OSInfo` gains `Architecture`, populated from `runtime.GOARCH` (binary architecture; host-arch sourcing is fingerprint-fidelity work, out of scope)
- `PrintOSInfo` replaced by `WriteText(w io.Writer, o *OSInfo) error`: nil-guarded, deterministic `AdditionalInfo` ordering via sorted keys, no stdout coupling, no internal fetch

**`cmd/commands/osinfo.go`**
- `Run` replaced by `RunE`: fetch errors now reach stderr with a nonzero exit instead of printing to stdout and exiting zero
- Renders via `WriteText` to `cmd.OutOrStdout()`

**`internal/security/audit/audit.go`**
- `getSystemInfo` and `getKernelVersion` deleted; two `os/exec` invocations removed from the audit path
- `systemInfoFrom(*osfingerprint.OSInfo)` converts fingerprint data to the audit's `SystemInfo`; nil fingerprint degrades to empty identity fields with `runtime.GOARCH` as the only local fact
- `Options.HostInfo` added: optional pre-fetched fingerprint; `RunAudit` fetches only when nil

**`cmd/commands/all.go`**
- `toAllResult`'s runtime fallback branch deleted; `allResult.System` is now `*allSystemInfo` with `omitempty`
- `--skip-modules osinfo` produces no `system` section rather than locally re-derived identity; a present system block always means fingerprinting ran
- `runSecurityAuditModule` passes `result.OSInfo` through to `audit.Options.HostInfo`
- `system.architecture` sourced from fingerprint data instead of a local `runtime.GOARCH` read

**`internal/security/registry/registry.go`, `internal/report/write.go`**
- Doc comments recording the two deliberate exceptions to the single-reader rule and their reasons

## Verified

- osinfo, all, and audit report identical kernel version, hostname, and architecture on the same host, both machines
- defender: audit `kernel_version` equals `uname -r` output exactly, confirming byte-identical replacement of the deleted exec path
- jsabs: audit `kernel_version` changed from `Microsoft Windows [Version 10.0.26200.xxxx]` to `10.0.26200 Build 26200`, now matching osinfo and all (deliberate delta, the divergence this PR exists to remove)
- `all --skip-modules osinfo,software --skip-checks permissions -o json`: no `system` key present, findings render normally, audit's internal self-fetch path exercised
- `all --skip-modules software --skip-checks permissions -v`: single fingerprint read, pass-through path exercised
- Identity-derivation sweep (`uname|os.Hostname()|runtime.GOOS|runtime.GOARCH`) across cmd/ and internal/: every surviving hit is the source package, a documented exception, or platform dispatch that never ships in output
- Full pipeline clean on defender and jsabs: gofmt, go build, go vet, gosec, govulncheck, golangci-lint, GOOS=windows go build

Closes #123 