### PR TITLE
[Chore] extract shared rendering into internal/render and consolidate duplicated output logic

### DIFF
--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/papa0four/orkowatch/internal/osfingerprint"
+	"github.com/papa0four/orkowatch/internal/render"
 	"github.com/papa0four/orkowatch/internal/report"
 	"github.com/papa0four/orkowatch/internal/scan"
 	"github.com/papa0four/orkowatch/internal/security/audit"
@@ -72,7 +73,7 @@ func init() {
 	allCmd.Flags().DurationVar(&allTimeout, "timeout", 30*time.Minute,
 		"Maximum time to run all scans")
 	allCmd.Flags().StringVar(&allMinSeverity, "min-severity", "LOW",
-		"Minimum severity level to report (LOW< MEDIUM, HIGH, CRITICAL)")
+		"Minimum severity level to report (LOW, MEDIUM, HIGH, CRITICAL)")
 	allCmd.Flags().BoolVarP(&allEnrich, "enrich", "e", false,
 		"Query external sources to annotate findings with CVEs mapped to referenced CWEs")
 	allCmd.Flags().BoolVar(&allAllowElevatedWrite, "allow-elevated-write", false,
@@ -128,16 +129,16 @@ type (
 	// --min-severity filtered out at least one finding, so a consumer can tell
 	// Findings is a partial view of Summary.TotalFindings without guessing.
 	allSecurity struct {
-		Summary             allSecuritySummary     `json:"summary" yaml:"summary"`
-		FindingsSuppressed  int                    `json:"findings_suppressed,omitempty" yaml:"findings_suppressed,omitempty"`
-		MinSeverityApplied  string                 `json:"min_severity_applied,omitempty" yaml:"min_severity_applied,omitempty"`
-		EnrichmentRequested bool                   `json:"enrichment_requested,omitempty" yaml:"enrichment_requested,omitempty"`
-		EnrichmentError     string                 `json:"enrichment_error,omitempty" yaml:"enrichment_error,omitempty"`
-		ReferenceCWEs       []string               `json:"reference_cwes,omitempty" yaml:"reference_cwes,omitempty"`
-		ReferenceErrors     []string               `json:"reference_errors,omitempty" yaml:"reference_errors,omitempty"`
-		EnrichmentEntries   []allEnrichmentEntry   `json:"enrichment_entries,omitempty" yaml:"enrichment_entries,omitempty"`
-		EnrichmentFailures  []allEnrichmentFailure `json:"enrichment_failures,omitempty" yaml:"enrichment_failures,omitempty"`
-		Findings            []allFinding           `json:"findings,omitempty" yaml:"findings,omitempty"`
+		Summary             allSecuritySummary         `json:"summary" yaml:"summary"`
+		FindingsSuppressed  int                        `json:"findings_suppressed,omitempty" yaml:"findings_suppressed,omitempty"`
+		MinSeverityApplied  string                     `json:"min_severity_applied,omitempty" yaml:"min_severity_applied,omitempty"`
+		EnrichmentRequested bool                       `json:"enrichment_requested,omitempty" yaml:"enrichment_requested,omitempty"`
+		EnrichmentError     string                     `json:"enrichment_error,omitempty" yaml:"enrichment_error,omitempty"`
+		ReferenceCWEs       []string                   `json:"reference_cwes,omitempty" yaml:"reference_cwes,omitempty"`
+		ReferenceErrors     []string                   `json:"reference_errors,omitempty" yaml:"reference_errors,omitempty"`
+		EnrichmentEntries   []render.EnrichmentEntry   `json:"enrichment_entries,omitempty" yaml:"enrichment_entries,omitempty"`
+		EnrichmentFailures  []render.EnrichmentFailure `json:"enrichment_failures,omitempty" yaml:"enrichment_failures,omitempty"`
+		Findings            []allFinding               `json:"findings,omitempty" yaml:"findings,omitempty"`
 	}
 
 	// allSecuritySummary carries per-severity finding counts for all command output.
@@ -160,36 +161,6 @@ type (
 		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 		Impact      string `json:"impact,omitempty" yaml:"impact,omitempty"`
 		Resolution  string `json:"resolution,omitempty" yaml:"resolution,omitempty"`
-	}
-
-	// allEnrichmentMatch is the typed representation of a single CVE match for
-	// all command output.
-	allEnrichmentMatch struct {
-		CVEID          string  `json:"cve_id" yaml:"cve_id"`
-		Source         string  `json:"source" yaml:"source"`
-		CVSSBaseScore  float64 `json:"cvss_base_score" yaml:"cvss_base_score"`
-		CVSSSeverity   string  `json:"cvss_severity" yaml:"cvss_severity"`
-		Description    string  `json:"description,omitempty" yaml:"description,omitempty"`
-		KnownExploited bool    `json:"known_exploited" yaml:"known_exploited"`
-		PatchAvailable bool    `json:"patch_available" yaml:"patch_available"`
-	}
-
-	// allEnrichmentEntry is the typed representation of a single CWE's
-	// enrichment result for all command output.
-	allEnrichmentEntry struct {
-		CWEID        string               `json:"cwe_id" yaml:"cwe_id"`
-		WeaknessName string               `json:"weakness_name,omitempty" yaml:"weakness_name,omitempty"`
-		NoMatches    bool                 `json:"no_matches" yaml:"no_matches"`
-		Matches      []allEnrichmentMatch `json:"matches,omitempty" yaml:"matches,omitempty"`
-	}
-
-	// allEnrichmentFailure is the typed representation of a failed per-CWE
-	// enrichment lookup for all command output.
-	allEnrichmentFailure struct {
-		CWEID     string `json:"cwe_id" yaml:"cwe_id"`
-		Source    string `json:"source" yaml:"source"`
-		Reason    string `json:"reason" yaml:"reason"`
-		Retryable bool   `json:"retryable" yaml:"retryable"`
 	}
 )
 
@@ -258,8 +229,8 @@ func toAllResult(scan *ScanResult) allResult {
 		}
 		for _, check := range scan.SecurityAudit.Results {
 			for _, finding := range check.Findings {
-				sev := effectiveSeverity(finding)
-				if !allMeetsMinSeverity(sev, allMinSeverity) {
+				sev := types.EffectiveSeverity(finding)
+				if !types.MeetsMinSeverity(sev, allMinSeverity) {
 					continue
 				}
 				f := allFinding{
@@ -292,9 +263,9 @@ func toAllResult(scan *ScanResult) allResult {
 			if len(scan.SecurityAudit.References.CWEs) > 0 {
 				sec.ReferenceCWEs = scan.SecurityAudit.References.CWEs
 			}
-			sec.ReferenceErrors = allFormatReferenceErrors(scan.SecurityAudit.References.Errors)
-			sec.EnrichmentEntries = buildAllEnrichmentEntries(scan.SecurityAudit)
-			sec.EnrichmentFailures = buildAllEnrichmentFailures(scan.SecurityAudit)
+			sec.ReferenceErrors = render.ReferenceErrorStrings(scan.SecurityAudit.References.Errors)
+			sec.EnrichmentEntries = render.EnrichmentEntries(scan.SecurityAudit.References, scan.SecurityAudit.Enrichment)
+			sec.EnrichmentFailures = render.EnrichmentFailures(scan.SecurityAudit.Enrichment)
 		}
 		out.Security = sec
 	}
@@ -375,6 +346,12 @@ func runAllScans(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Verbose module headers print only when writing to an interactive
+	// terminal without --report-file, preventing duplication when piping
+	// or redirecting output. Computed once here as the single suppression
+	// point for the whole run.
+	verboseHeaders := allVerbose && render.StdoutIsTerminal() && allReportFile == ""
+
 	results := make(chan *ScanResult, 1)
 
 	go func() {
@@ -384,7 +361,7 @@ func runAllScans(cmd *cobra.Command, args []string) error {
 		}
 
 		if !isModuleSkipped("osinfo") {
-			if osInfo, err := runOSFingerprint(); err != nil {
+			if osInfo, err := runOSFingerprint(verboseHeaders); err != nil {
 				result.Errors = append(result.Errors,
 					fmt.Sprintf("OS fingerprint error: %v", err))
 			} else {
@@ -393,7 +370,7 @@ func runAllScans(cmd *cobra.Command, args []string) error {
 		}
 
 		if !isModuleSkipped("software") {
-			software, err := runSoftwareInventory()
+			software, err := runSoftwareInventory(verboseHeaders)
 			if err != nil {
 				result.Errors = append(result.Errors,
 					fmt.Sprintf("Software inventory error: %v", err))
@@ -403,7 +380,7 @@ func runAllScans(cmd *cobra.Command, args []string) error {
 		}
 
 		if !isModuleSkipped("audit") {
-			if securityResult, err := runSecurityAuditModule(mask, result.OSInfo); err != nil {
+			if securityResult, err := runSecurityAuditModule(mask, result.OSInfo, verboseHeaders); err != nil {
 				result.Errors = append(result.Errors,
 					fmt.Sprintf("Security audit error: %v", err))
 			} else {
@@ -423,8 +400,8 @@ func runAllScans(cmd *cobra.Command, args []string) error {
 	}
 }
 
-func runOSFingerprint() (*osfingerprint.OSInfo, error) {
-	if allVerbose && isTerminal() && allReportFile == "" {
+func runOSFingerprint(verboseHeaders bool) (*osfingerprint.OSInfo, error) {
+	if verboseHeaders {
 		fmt.Println("[*] OS Fingerprint Scan")
 	}
 
@@ -433,7 +410,7 @@ func runOSFingerprint() (*osfingerprint.OSInfo, error) {
 		return nil, err
 	}
 
-	if allVerbose && isTerminal() && allReportFile == "" {
+	if verboseHeaders {
 		line := fmt.Sprintf("[*] OS: %s | Platform: %s | OS Version: %s",
 			info.OS, info.Platform, info.PlatformVersion)
 		if info.KernelVersion != "" && info.KernelVersion != info.PlatformVersion {
@@ -446,10 +423,10 @@ func runOSFingerprint() (*osfingerprint.OSInfo, error) {
 }
 
 // runSoftwareInventory enumerates installed software packages. Verbose module
-// headers are gated behind isTerminal() to prevent duplication when piping
+// headers are gated behind verboseHeaders to prevent duplication when piping
 // or redirecting output.
-func runSoftwareInventory() ([]softwarelist.SoftwareEntry, error) {
-	if allVerbose && isTerminal() && allReportFile == "" {
+func runSoftwareInventory(verboseHeaders bool) ([]softwarelist.SoftwareEntry, error) {
+	if verboseHeaders {
 		fmt.Println("[*] Software Inventory Scan")
 	}
 
@@ -458,23 +435,25 @@ func runSoftwareInventory() ([]softwarelist.SoftwareEntry, error) {
 		return nil, err
 	}
 
-	if allVerbose && isTerminal() && allReportFile == "" {
+	if verboseHeaders {
 		fmt.Printf("[*] Found %d installed packages\n\n", len(entries))
-		for _, e := range entries {
-			fmt.Printf("%-60s %s\n", e.Name, e.Version)
+		// Courtesy verbose listing only; a stdout write failure must not
+		// discard the already-collected inventory.
+		if err := softwarelist.WriteTable(os.Stdout, entries, false); err != nil {
+			fmt.Fprintf(os.Stderr, "[!] WARNING: software listing write failed: %v\n", err)
 		}
 	}
 
 	return entries, nil
 }
 
-func runSecurityAuditModule(mask scan.CheckMask, hostInfo *osfingerprint.OSInfo) (*audit.Result, error) {
-	if allVerbose && isTerminal() && allReportFile == "" {
+func runSecurityAuditModule(mask scan.CheckMask, hostInfo *osfingerprint.OSInfo, verboseHeaders bool) (*audit.Result, error) {
+	if verboseHeaders {
 		fmt.Println("[*] Security Audit Scan")
 	}
 
 	opts := audit.Options{
-		Verbose:        allVerbose && isTerminal() && allReportFile == "",
+		Verbose:        verboseHeaders,
 		MinSeverity:    allMinSeverity,
 		Timeout:        allTimeout,
 		Enrich:         allEnrich,
@@ -512,7 +491,9 @@ func outputResults(cmd *cobra.Command, result *ScanResult, mask scan.CheckMask) 
 	case "csv":
 		return fmt.Errorf("csv output format is not yet implemented")
 	default:
-		renderAllText(&buf, result)
+		if err := renderAllText(&buf, result); err != nil {
+			return fmt.Errorf("failed to render text output: %w", err)
+		}
 	}
 
 	if allReportFile != "" {
@@ -536,8 +517,10 @@ func outputResults(cmd *cobra.Command, result *ScanResult, mask scan.CheckMask) 
 
 // renderAllText writes a concise human-readable summary of the scan result
 // to w. This is the non-TUI text path; it will be replaced by the Bubbletea
-// progress display when #35 lands.
-func renderAllText(w *bytes.Buffer, result *ScanResult) {
+// progress display when #35 lands. Shared blocks (finding lines, the
+// enrichment six-state block, suppression disclosure, summary) come from
+// internal/render; the first write error from any of them is returned.
+func renderAllText(w *bytes.Buffer, result *ScanResult) error {
 	fmt.Fprintf(w, "owatch all  --  %s\n\n", result.Timestamp.UTC().Format(time.RFC3339))
 
 	// system
@@ -562,195 +545,42 @@ func renderAllText(w *bytes.Buffer, result *ScanResult) {
 		var shown int
 		for _, check := range result.SecurityAudit.Results {
 			for _, finding := range check.Findings {
-				sev := effectiveSeverity(finding)
-				if !allMeetsMinSeverity(sev, allMinSeverity) {
+				sev := types.EffectiveSeverity(finding)
+				if !types.MeetsMinSeverity(sev, allMinSeverity) {
 					continue
 				}
 				shown++
-				symbol, _ := types.SeverityFormat(sev)
-				fmt.Fprintf(w, "  %s %-8s  %s\n", symbol, sev, finding.Title)
+				if err := render.FindingLine(w, "  ", sev, finding.Title); err != nil {
+					return err
+				}
 			}
 		}
 		fmt.Fprintln(w)
 
-		renderAllEnrichmentBlock(w, result.SecurityAudit)
-
-		suppressed := s.TotalFindings - shown
-		if suppressed > 0 {
-			fmt.Fprintf(w, "%d of %d findings suppressed by --min-severity %s. "+
-				"Rerun with a lower threshold or without --min-severity to see all findings.\n\n",
-				suppressed, s.TotalFindings, strings.ToUpper(allMinSeverity))
-		}
-		if suppressed > 0 {
-			fmt.Fprintf(w, "Summary: %d checks  %d passed  %d findings total  %d present  %d suppressed  %s\n",
-				s.TotalChecks, s.PassedChecks, s.TotalFindings, shown, suppressed, result.Duration.Round(time.Millisecond))
-		} else {
-			fmt.Fprintf(w, "Summary: %d checks  %d passed  %d findings  %s\n",
-				s.TotalChecks, s.PassedChecks, s.TotalFindings, result.Duration.Round(time.Millisecond))
-		}
-	}
-}
-
-// buildAllEnrichmentEntries converts enrichment successes into typed
-// structs for all command output, in the same CWE order as
-// result.References.CWEs so output order is stable across runs.
-func buildAllEnrichmentEntries(result *audit.Result) []allEnrichmentEntry {
-	if result.Enrichment == nil {
-		return nil
-	}
-	out := make([]allEnrichmentEntry, 0, len(result.References.CWEs))
-	for _, cwe := range result.References.CWEs {
-		entry, ok := result.Enrichment.Successes[cwe]
-		if !ok {
-			continue
-		}
-		e := allEnrichmentEntry{
-			CWEID:        cwe,
-			WeaknessName: entry.WeaknessName,
-			NoMatches:    string(entry.Status) == "NO_MATCHES" || len(entry.MatchedCVEs) == 0,
-		}
-		for _, match := range entry.MatchedCVEs {
-			e.Matches = append(e.Matches, allEnrichmentMatch{
-				CVEID:          match.CVEID,
-				Source:         string(match.Source),
-				CVSSBaseScore:  match.CVSSBaseScore,
-				CVSSSeverity:   match.CVSSSeverity,
-				Description:    match.Description,
-				KnownExploited: match.KnownExploited,
-				PatchAvailable: match.PatchAvailable,
-			})
-		}
-		out = append(out, e)
-	}
-	return out
-}
-
-// buildAllEnrichmentFailures converts enrichment failures into typed
-// structs for all command output.
-func buildAllEnrichmentFailures(result *audit.Result) []allEnrichmentFailure {
-	if result.Enrichment == nil || len(result.Enrichment.Failures) == 0 {
-		return nil
-	}
-	out := make([]allEnrichmentFailure, 0, len(result.Enrichment.Failures))
-	for cwe, failure := range result.Enrichment.Failures {
-		out = append(out, allEnrichmentFailure{
-			CWEID:     cwe,
-			Source:    string(failure.Source),
-			Reason:    failure.Reason,
-			Retryable: failure.Retryable,
-		})
-	}
-	return out
-}
-
-// allFormatReferenceErrors converts reference parsing errors into strings
-// for all command output.
-func allFormatReferenceErrors(errs []error) []string {
-	if len(errs) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(errs))
-	for _, e := range errs {
-		out = append(out, e.Error())
-	}
-	return out
-}
-
-// renderAllEnrichmentBlock writes the six-state enrichment rendering for
-// all command text output, mirroring renderEnrichmentBlock in
-// cmd/commands/security/security.go. Kept separate since all.go owns its
-// own serialization path independent of the audit formatter.
-func renderAllEnrichmentBlock(w *bytes.Buffer, result *audit.Result) {
-	if !result.EnrichmentRequested {
-		return
-	}
-
-	fmt.Fprintf(w, "Enrichment:\n")
-
-	if result.EnrichmentError != nil {
-		fmt.Fprintf(w, "  Unavailable: %v\n\n", result.EnrichmentError)
-		renderAllReferenceErrors(w, result.References)
-		return
-	}
-
-	if len(result.References.CWEs) == 0 {
-		fmt.Fprintf(w, "  No CWE references found in current findings.\n\n")
-		renderAllReferenceErrors(w, result.References)
-		return
-	}
-
-	if result.Enrichment == nil {
-		fmt.Fprintf(w, "  No enrichment data returned.\n\n")
-		renderAllReferenceErrors(w, result.References)
-		return
-	}
-
-	rendered := 0
-	for _, cwe := range result.References.CWEs {
-		entry, ok := result.Enrichment.Successes[cwe]
-		if !ok {
-			continue
-		}
-		rendered++
-		fmt.Fprintf(w, "  %s", cwe)
-		if entry.WeaknessName != "" {
-			fmt.Fprintf(w, " - %s", entry.WeaknessName)
-		}
-		fmt.Fprintln(w)
-
-		if string(entry.Status) == "NO_MATCHES" || len(entry.MatchedCVEs) == 0 {
-			fmt.Fprintf(w, "    No CVE matches in queried sources.\n")
-			continue
+		if err := render.EnrichmentBlock(w, render.EnrichmentData{
+			Requested:  result.SecurityAudit.EnrichmentRequested,
+			Err:        result.SecurityAudit.EnrichmentError,
+			References: result.SecurityAudit.References,
+			Result:     result.SecurityAudit.Enrichment,
+			Verbose:    allVerbose,
+		}); err != nil {
+			return err
 		}
 
-		for _, match := range entry.MatchedCVEs {
-			symbol, label := types.SeverityFormat(match.CVSSSeverity)
-			fmt.Fprintf(w, "    %s %s  %s (%.1f) [%s]\n",
-				symbol, label, match.CVEID, match.CVSSBaseScore, match.Source)
-			if allVerbose {
-				if match.Description != "" {
-					fmt.Fprintf(w, "      Description: %s\n", match.Description)
-				}
-				if match.KnownExploited {
-					fmt.Fprintf(w, "      Known Exploited: yes\n")
-				}
-				if match.PatchAvailable {
-					fmt.Fprintf(w, "      Patch Available: yes\n")
-				}
-			}
+		if err := render.SuppressionNotice(w, s.TotalFindings-shown, s.TotalFindings, allMinSeverity); err != nil {
+			return err
+		}
+		if err := render.CompactSummary(w, render.SummaryData{
+			TotalChecks:   s.TotalChecks,
+			PassedChecks:  s.PassedChecks,
+			TotalFindings: s.TotalFindings,
+			Shown:         shown,
+			Duration:      result.Duration.Round(time.Millisecond),
+		}); err != nil {
+			return err
 		}
 	}
-
-	if rendered == 0 {
-		fmt.Fprintf(w, "  No enrichment data returned.\n")
-	}
-
-	if len(result.Enrichment.Failures) > 0 {
-		fmt.Fprintf(w, "\n  Failed enrichments:\n")
-		for cwe, failure := range result.Enrichment.Failures {
-			fmt.Fprintf(w, "    %s [%s]: %s", cwe, failure.Source, failure.Reason)
-			if failure.Retryable {
-				fmt.Fprintf(w, " (retryable)")
-			}
-			fmt.Fprintln(w)
-		}
-	}
-
-	fmt.Fprintln(w)
-	renderAllReferenceErrors(w, result.References)
-}
-
-// renderAllReferenceErrors writes reference parsing errors for all command
-// text output, mirroring renderReferenceErrors in security.go.
-func renderAllReferenceErrors(w *bytes.Buffer, refs types.ReferenceExtraction) {
-	if len(refs.Errors) == 0 {
-		return
-	}
-	fmt.Fprintf(w, "  Reference parsing errors:\n")
-	for _, err := range refs.Errors {
-		fmt.Fprintf(w, "    %v\n", err)
-	}
-	fmt.Fprintln(w)
+	return nil
 }
 
 func isModuleSkipped(module string) bool {
@@ -764,54 +594,4 @@ func isModuleSkipped(module string) bool {
 		}
 	}
 	return false
-}
-
-// isTerminal checks if the output is going to a terminal
-func isTerminal() bool {
-	fileInfo, err := os.Stdout.Stat()
-	if err != nil {
-		return false
-	}
-	return (fileInfo.Mode() & os.ModeCharDevice) != 0
-}
-
-// allSeverityLevel returns the numeric rank of a severity string for
-// threshold comparisons. Unknown values return -1 so they are never
-// silently dropped. Mirrors security.severityLevel; kept local since all.go
-// owns its own serialization path independent of the audit formatter.
-func allSeverityLevel(s string) int {
-	switch strings.ToUpper(s) {
-	case types.SeverityLow:
-		return 0
-	case types.SeverityMedium:
-		return 1
-	case types.SeverityHigh:
-		return 2
-	case types.SeverityCritical:
-		return 3
-	default:
-		return -1
-	}
-}
-
-// allMeetsMinSeverity reports whether findingSeverity is at or above the
-// min threshold. Unrecognized severity values pass through so findings are
-// never silently dropped.
-func allMeetsMinSeverity(findingSeverity, min string) bool {
-	fl := allSeverityLevel(findingSeverity)
-	ml := allSeverityLevel(min)
-	if fl < 0 || ml < 0 {
-		return true
-	}
-	return fl >= ml
-}
-
-// effectiveSeverity returns the severity value used for filtering and
-// display. It currently always returns the finding's static registry-
-// assigned severity. Once per-finding CVE/CVSS enrichment lands, this is
-// the single point where a live CVSS-derived severity would override the
-// static value. Callers should go through this rather than reading
-// finding.Severity directly, so severity sourcing only has to change here.
-func effectiveSeverity(finding types.Finding) string {
-	return finding.Severity
 }

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/papa0four/orkowatch/internal/render"
 	"github.com/papa0four/orkowatch/internal/report"
 	"github.com/papa0four/orkowatch/internal/scan"
 	"github.com/papa0four/orkowatch/internal/security/audit"
@@ -75,19 +76,19 @@ You can run all checks or specify individual checks to run.`,
 // Formatter types
 type (
 	formattedResult struct {
-		Timestamp           string                       `json:"timestamp" yaml:"timestamp"`
-		Duration            string                       `json:"duration" yaml:"duration"`
-		SystemInfo          formattedSystemInfo          `json:"system_info" yaml:"system_info"`
-		Results             []formattedCheck             `json:"results" yaml:"results"`
-		Summary             formattedSummary             `json:"summary" yaml:"summary"`
-		FindingsSuppressed  int                          `json:"findings_suppressed,omitempty" yaml:"findings_suppressed,omitempty"`
-		MinSeverityApplied  string                       `json:"min_severity_applied,omitempty" yaml:"min_severity_applied,omitempty"`
-		EnrichmentRequested bool                         `json:"enrichment_requested" yaml:"enrichment_requested"`
-		EnrichmentError     string                       `json:"enrichment_error,omitempty" yaml:"enrichment_error,omitempty"`
-		ReferenceCWEs       []string                     `json:"reference_cwes,omitempty" yaml:"reference_cwes,omitempty"`
-		ReferenceErrors     []string                     `json:"reference_errors,omitempty" yaml:"reference_errors,omitempty"`
-		EnrichmentEntries   []formattedEnrichmentEntry   `json:"enrichment_entries,omitempty" yaml:"enrichment_entries,omitempty"`
-		EnrichmentFailures  []formattedEnrichmentFailure `json:"enrichment_failures,omitempty" yaml:"enrichment_failures,omitempty"`
+		Timestamp           string                     `json:"timestamp" yaml:"timestamp"`
+		Duration            string                     `json:"duration" yaml:"duration"`
+		SystemInfo          formattedSystemInfo        `json:"system_info" yaml:"system_info"`
+		Results             []formattedCheck           `json:"results" yaml:"results"`
+		Summary             formattedSummary           `json:"summary" yaml:"summary"`
+		FindingsSuppressed  int                        `json:"findings_suppressed,omitempty" yaml:"findings_suppressed,omitempty"`
+		MinSeverityApplied  string                     `json:"min_severity_applied,omitempty" yaml:"min_severity_applied,omitempty"`
+		EnrichmentRequested bool                       `json:"enrichment_requested" yaml:"enrichment_requested"`
+		EnrichmentError     string                     `json:"enrichment_error,omitempty" yaml:"enrichment_error,omitempty"`
+		ReferenceCWEs       []string                   `json:"reference_cwes,omitempty" yaml:"reference_cwes,omitempty"`
+		ReferenceErrors     []string                   `json:"reference_errors,omitempty" yaml:"reference_errors,omitempty"`
+		EnrichmentEntries   []render.EnrichmentEntry   `json:"enrichment_entries,omitempty" yaml:"enrichment_entries,omitempty"`
+		EnrichmentFailures  []render.EnrichmentFailure `json:"enrichment_failures,omitempty" yaml:"enrichment_failures,omitempty"`
 	}
 
 	formattedSystemInfo struct {
@@ -128,34 +129,6 @@ type (
 		HighFindings     int `json:"high_findings" yaml:"high_findings"`
 		MediumFindings   int `json:"medium_findings" yaml:"medium_findings"`
 		LowFindings      int `json:"low_findings" yaml:"low_findings"`
-	}
-
-	formattedEnrichmentMatch struct {
-		CVEID          string  `json:"cve_id" yaml:"cve_id"`
-		Source         string  `json:"source" yaml:"source"`
-		CVSSBaseScore  float64 `json:"cvss_base_score" yaml:"cvss_base_score"`
-		CVSSSeverity   string  `json:"cvss_severity" yaml:"cvss_severity"`
-		Description    string  `json:"description,omitempty" yaml:"description,omitempty"`
-		KnownExploited bool    `json:"known_exploited" yaml:"known_exploited"`
-		PatchAvailable bool    `json:"patch_available" yaml:"patch_available"`
-	}
-
-	// formattedEnrichmentEntry is the typed representation of a single CWE's
-	// enrichment result for JSON/YAML audit output.
-	formattedEnrichmentEntry struct {
-		CWEID        string                     `json:"cwe_id" yaml:"cwe_id"`
-		WeaknessName string                     `json:"weakness_name,omitempty" yaml:"weakness_name,omitempty"`
-		NoMatches    bool                       `json:"no_matches" yaml:"no_matches"`
-		Matches      []formattedEnrichmentMatch `json:"matches,omitempty" yaml:"matches,omitempty"`
-	}
-
-	// formattedEnrichmentFailure is the typed representation of a failed
-	// per-CWE enrichment lookup for JSON/YAML audit output.
-	formattedEnrichmentFailure struct {
-		CWEID     string `json:"cwe_id" yaml:"cwe_id"`
-		Source    string `json:"source" yaml:"source"`
-		Reason    string `json:"reason" yaml:"reason"`
-		Retryable bool   `json:"retryable" yaml:"retryable"`
 	}
 )
 
@@ -432,9 +405,9 @@ func convertToFormattedResult(result *audit.Result) formattedResult {
 	if len(result.References.CWEs) > 0 {
 		formatted.ReferenceCWEs = result.References.CWEs
 	}
-	formatted.ReferenceErrors = formatReferenceErrors(result.References.Errors)
-	formatted.EnrichmentEntries = buildFormattedEnrichmentEntries(result)
-	formatted.EnrichmentFailures = buildFormattedEnrichmentFailures(result)
+	formatted.ReferenceErrors = render.ReferenceErrorStrings(result.References.Errors)
+	formatted.EnrichmentEntries = render.EnrichmentEntries(result.References, result.Enrichment)
+	formatted.EnrichmentFailures = render.EnrichmentFailures(result.Enrichment)
 
 	var shownFindings int
 	for _, check := range result.Results {
@@ -447,13 +420,14 @@ func convertToFormattedResult(result *audit.Result) formattedResult {
 		}
 
 		for _, finding := range check.Findings {
-			if !meetsMinSeverity(finding.Severity, minSeverity) {
+			sev := types.EffectiveSeverity(finding)
+			if !types.MeetsMinSeverity(sev, minSeverity) {
 				continue
 			}
 			shownFindings++
 			fc.Findings = append(fc.Findings, formattedFinding{
 				Title:       finding.Title,
-				Severity:    finding.Severity,
+				Severity:    sev,
 				Description: finding.Description,
 				Impact:      finding.Impact,
 				Resolution:  finding.Resolution,
@@ -472,103 +446,13 @@ func convertToFormattedResult(result *audit.Result) formattedResult {
 	return formatted
 }
 
-func renderEnrichmentBlock(builder *strings.Builder, result *audit.Result) {
-	if !result.EnrichmentRequested {
-		return
-	}
-
-	builder.WriteString("Enrichment:\n")
-
-	if result.EnrichmentError != nil {
-		fmt.Fprintf(builder, "  Unavailable: %v\n\n", result.EnrichmentError)
-		renderReferenceErrors(builder, result.References)
-		return
-	}
-
-	if len(result.References.CWEs) == 0 {
-		builder.WriteString("  No CWE references found in current findings.\n\n")
-		renderReferenceErrors(builder, result.References)
-		return
-	}
-
-	if result.Enrichment == nil {
-		builder.WriteString("  No enrichment data returned.\n\n")
-		renderReferenceErrors(builder, result.References)
-		return
-	}
-
-	rendered := 0
-	for _, cwe := range result.References.CWEs {
-		entry, ok := result.Enrichment.Successes[cwe]
-		if !ok {
-			continue
-		}
-		rendered++
-		fmt.Fprintf(builder, "  %s", cwe)
-		if entry.WeaknessName != "" {
-			fmt.Fprintf(builder, " - %s", entry.WeaknessName)
-		}
-		fmt.Fprintln(builder)
-
-		if entry.Status == "NO_MATCHES" || len(entry.MatchedCVEs) == 0 {
-			builder.WriteString("    No CVE matches in queried sources.\n")
-			continue
-		}
-
-		for _, match := range entry.MatchedCVEs {
-			symbol, label := types.SeverityFormat(match.CVSSSeverity)
-			fmt.Fprintf(builder, "    %s %s  %s (%.1f) [%s]\n",
-				symbol, label, match.CVEID, match.CVSSBaseScore, match.Source)
-			if verbose {
-				if match.Description != "" {
-					fmt.Fprintf(builder, "      Description: %s\n", match.Description)
-				}
-				if match.KnownExploited {
-					builder.WriteString("      Known Exploited: yes\n")
-				}
-				if match.PatchAvailable {
-					builder.WriteString("      Patch Available: yes\n")
-				}
-			}
-		}
-	}
-
-	if rendered == 0 {
-		builder.WriteString("  No enrichment data returned.\n")
-	}
-
-	if len(result.Enrichment.Failures) > 0 {
-		builder.WriteString("\n  Failed enrichments:\n")
-		for cwe, failure := range result.Enrichment.Failures {
-			fmt.Fprintf(builder, "    %s [%s]: %s",
-				cwe, failure.Source, failure.Reason)
-			if failure.Retryable {
-				builder.WriteString(" (retryable)")
-			}
-			fmt.Fprintln(builder)
-		}
-	}
-
-	builder.WriteString("\n")
-	renderReferenceErrors(builder, result.References)
-}
-
-func renderReferenceErrors(builder *strings.Builder, refs types.ReferenceExtraction) {
-	if len(refs.Errors) == 0 {
-		return
-	}
-	builder.WriteString("  Reference parsing errors:\n")
-	for _, err := range refs.Errors {
-		fmt.Fprintf(builder, "    %v\n", err)
-	}
-	builder.WriteString("\n")
-}
-
 // formatText renders result as human-readable text, applying the active
 // minSeverity filter to findings before output. Each check block includes
 // a clean-pass confirmation when no findings meet the threshold, ensuring
 // an empty findings block is never visually ambiguous. Verbose mode appends
-// finding details, impact, resolution, and raw diagnostic output.
+// finding details, impact, resolution, and raw diagnostic output. Shared
+// blocks (finding lines, the enrichment six-state block, suppression
+// disclosure, summary) come from internal/render.
 func formatText(result *audit.Result) (string, error) {
 	var builder strings.Builder
 	isComprehensive := len(result.Results) > 1
@@ -591,7 +475,7 @@ func formatText(result *audit.Result) (string, error) {
 
 		var filteredFindings []types.Finding
 		for _, finding := range checkResult.Findings {
-			if meetsMinSeverity(finding.Severity, minSeverity) {
+			if types.MeetsMinSeverity(types.EffectiveSeverity(finding), minSeverity) {
 				filteredFindings = append(filteredFindings, finding)
 			}
 		}
@@ -600,8 +484,9 @@ func formatText(result *audit.Result) (string, error) {
 			hasFindings = true
 			builder.WriteString("Findings:\n")
 			for _, finding := range filteredFindings {
-				symbol, label := types.SeverityFormat(finding.Severity)
-				fmt.Fprintf(&builder, "%s %s  %s\n", symbol, label, finding.Title)
+				if err := render.FindingLine(&builder, "", types.EffectiveSeverity(finding), finding.Title); err != nil {
+					return "", err
+				}
 				if verbose {
 					if finding.Description != "" {
 						fmt.Fprintf(&builder, "  Description: %s\n", finding.Description)
@@ -631,128 +516,38 @@ func formatText(result *audit.Result) (string, error) {
 		builder.WriteString("\n")
 	}
 
-	renderEnrichmentBlock(&builder, result)
-
-	suppressed := result.Summary.TotalFindings - shownFindings
-	if suppressed > 0 {
-		fmt.Fprintf(&builder, "%d of %d findings suppressed by --min-severity %s. "+
-			"Rerun with a lower threshold or without --min-severity to see all findings.\n\n",
-			suppressed, result.Summary.TotalFindings, strings.ToUpper(minSeverity))
+	if err := render.EnrichmentBlock(&builder, render.EnrichmentData{
+		Requested:  result.EnrichmentRequested,
+		Err:        result.EnrichmentError,
+		References: result.References,
+		Result:     result.Enrichment,
+		Verbose:    verbose,
+	}); err != nil {
+		return "", err
 	}
 
-	builder.WriteString("Summary:\n")
-	fmt.Fprintf(&builder, "Checks Run:      %d\n", result.Summary.TotalChecks)
-	fmt.Fprintf(&builder, "Passed:          %d\n", result.Summary.PassedChecks)
-	fmt.Fprintf(&builder, "Skipped:         %d\n", result.Summary.SkippedChecks)
-	if suppressed > 0 {
-		fmt.Fprintf(&builder, "Total Findings:  %d (%d present, %d suppressed)\n",
-			result.Summary.TotalFindings, shownFindings, suppressed)
-	} else {
-		fmt.Fprintf(&builder, "Total Findings:  %d\n", result.Summary.TotalFindings)
+	if err := render.SuppressionNotice(&builder, result.Summary.TotalFindings-shownFindings,
+		result.Summary.TotalFindings, minSeverity); err != nil {
+		return "", err
 	}
-	fmt.Fprintf(&builder, "  Critical:      %d\n", result.Summary.CriticalFindings)
-	fmt.Fprintf(&builder, "  High:          %d\n", result.Summary.HighFindings)
-	fmt.Fprintf(&builder, "  Medium:        %d\n", result.Summary.MediumFindings)
-	fmt.Fprintf(&builder, "  Low:           %d\n", result.Summary.LowFindings)
-	fmt.Fprintf(&builder, "Duration:        %v\n", result.Duration)
+	if err := render.DetailedSummary(&builder, render.SummaryData{
+		TotalChecks:   result.Summary.TotalChecks,
+		PassedChecks:  result.Summary.PassedChecks,
+		SkippedChecks: result.Summary.SkippedChecks,
+		TotalFindings: result.Summary.TotalFindings,
+		Shown:         shownFindings,
+		Critical:      result.Summary.CriticalFindings,
+		High:          result.Summary.HighFindings,
+		Medium:        result.Summary.MediumFindings,
+		Low:           result.Summary.LowFindings,
+		Duration:      result.Duration,
+	}); err != nil {
+		return "", err
+	}
 
 	if !verbose && hasFindings {
 		builder.WriteString("\nRun with -v for full finding details, impact analysis, and remediation guidance.\n")
 	}
 
 	return builder.String(), nil
-}
-
-// buildFormattedEnrichmentEntries converts enrichment successes into typed
-// structs, in the same CWE order as result.References.CWEs so output order
-// is stable across runs.
-func buildFormattedEnrichmentEntries(result *audit.Result) []formattedEnrichmentEntry {
-	if result.Enrichment == nil {
-		return nil
-	}
-	out := make([]formattedEnrichmentEntry, 0, len(result.References.CWEs))
-	for _, cwe := range result.References.CWEs {
-		entry, ok := result.Enrichment.Successes[cwe]
-		if !ok {
-			continue
-		}
-		e := formattedEnrichmentEntry{
-			CWEID:        cwe,
-			WeaknessName: entry.WeaknessName,
-			NoMatches:    string(entry.Status) == "NO_MATCHES" || len(entry.MatchedCVEs) == 0,
-		}
-		for _, match := range entry.MatchedCVEs {
-			e.Matches = append(e.Matches, formattedEnrichmentMatch{
-				CVEID:          match.CVEID,
-				Source:         string(match.Source),
-				CVSSBaseScore:  match.CVSSBaseScore,
-				CVSSSeverity:   match.CVSSSeverity,
-				Description:    match.Description,
-				KnownExploited: match.KnownExploited,
-				PatchAvailable: match.PatchAvailable,
-			})
-		}
-		out = append(out, e)
-	}
-	return out
-}
-
-// buildFormattedEnrichmentFailures converts enrichment failures into typed
-// structs for JSON/YAML audit output.
-func buildFormattedEnrichmentFailures(result *audit.Result) []formattedEnrichmentFailure {
-	if result.Enrichment == nil || len(result.Enrichment.Failures) == 0 {
-		return nil
-	}
-	out := make([]formattedEnrichmentFailure, 0, len(result.Enrichment.Failures))
-	for cwe, failure := range result.Enrichment.Failures {
-		out = append(out, formattedEnrichmentFailure{
-			CWEID:     cwe,
-			Source:    string(failure.Source),
-			Reason:    failure.Reason,
-			Retryable: failure.Retryable,
-		})
-	}
-	return out
-}
-
-// formatReferenceErrors converts reference parsing errors into strings for
-// JSON/YAML audit output.
-func formatReferenceErrors(errs []error) []string {
-	if len(errs) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(errs))
-	for _, e := range errs {
-		out = append(out, e.Error())
-	}
-	return out
-}
-
-// severityLevel returns the numeric rank of a severity string for threshold
-// comparisons. Unknown values return -1 so they are never silently dropped.
-func severityLevel(s string) int {
-	switch strings.ToUpper(s) {
-	case types.SeverityLow:
-		return 0
-	case types.SeverityMedium:
-		return 1
-	case types.SeverityHigh:
-		return 2
-	case types.SeverityCritical:
-		return 3
-	default:
-		return -1
-	}
-}
-
-// meetsMinSeverity reports whether findingSeverity is at or above the
-// minSeverity threshold. Unrecognized severity values pass through so
-// findings are never silently dropped.
-func meetsMinSeverity(findingSeverity, min string) bool {
-	fl := severityLevel(findingSeverity)
-	ml := severityLevel(min)
-	if fl < 0 || ml < 0 {
-		return true
-	}
-	return fl >= ml
 }

--- a/internal/render/doc.go
+++ b/internal/render/doc.go
@@ -1,0 +1,13 @@
+// Package render provides the shared output machinery for owatch commands:
+// parameterized text rendering for the blocks that appear in more than one
+// command's output (the enrichment six-state block, reference parsing
+// errors, finding lines, suppression disclosure, and summaries), the typed
+// serialization structures for enrichment data in JSON and YAML output, and
+// the single TTY detection helper.
+//
+// Text rendering functions take data and an io.Writer only; the package has
+// no dependency on cobra or on the audit engine. Command output schemas
+// remain owned by their commands under the additive-only output contract --
+// this package consolidates the logic beneath them, not the schemas
+// themselves.
+package render

--- a/internal/render/enrichment.go
+++ b/internal/render/enrichment.go
@@ -1,0 +1,218 @@
+// internal/render/enrichment.go
+package render
+
+import (
+	"io"
+
+	"github.com/papa0four/orkowatch/internal/security/enrichment"
+	"github.com/papa0four/orkowatch/internal/security/types"
+)
+
+// EnrichmentData carries everything the enrichment text block needs,
+// decoupled from the audit engine's result type so this package never
+// imports the orchestration layer.
+type EnrichmentData struct {
+	Requested  bool
+	Err        error
+	References types.ReferenceExtraction
+	Result     *enrichment.Result
+	Verbose    bool
+}
+
+type (
+	// EnrichmentMatch is the typed serialization of a single CVE match for
+	// JSON and YAML command output.
+	EnrichmentMatch struct {
+		CVEID          string  `json:"cve_id" yaml:"cve_id"`
+		Source         string  `json:"source" yaml:"source"`
+		CVSSBaseScore  float64 `json:"cvss_base_score" yaml:"cvss_base_score"`
+		CVSSSeverity   string  `json:"cvss_severity" yaml:"cvss_severity"`
+		Description    string  `json:"description,omitempty" yaml:"description,omitempty"`
+		KnownExploited bool    `json:"known_exploited" yaml:"known_exploited"`
+		PatchAvailable bool    `json:"patch_available" yaml:"patch_available"`
+	}
+
+	// EnrichmentEntry is the typed serialization of a single CWE's
+	// enrichment result for JSON and YAML command output.
+	EnrichmentEntry struct {
+		CWEID        string            `json:"cwe_id" yaml:"cwe_id"`
+		WeaknessName string            `json:"weakness_name,omitempty" yaml:"weakness_name,omitempty"`
+		NoMatches    bool              `json:"no_matches" yaml:"no_matches"`
+		Matches      []EnrichmentMatch `json:"matches,omitempty" yaml:"matches,omitempty"`
+	}
+
+	// EnrichmentFailure is the typed serialization of a failed per-CWE
+	// enrichment lookup for JSON and YAML command output.
+	EnrichmentFailure struct {
+		CWEID     string `json:"cwe_id" yaml:"cwe_id"`
+		Source    string `json:"source" yaml:"source"`
+		Reason    string `json:"reason" yaml:"reason"`
+		Retryable bool   `json:"retryable" yaml:"retryable"`
+	}
+)
+
+// EnrichmentBlock writes the six-state enrichment text rendering: not
+// requested (nothing), unavailable, no CWE references, no data returned,
+// per-CWE matches with optional verbose detail, and per-CWE failures.
+// Reference parsing errors are appended in every rendered state. The first
+// write error, if any, is returned.
+func EnrichmentBlock(w io.Writer, d EnrichmentData) error {
+	if !d.Requested {
+		return nil
+	}
+
+	ew := &errWriter{w: w}
+	ew.printf("Enrichment:\n")
+
+	if d.Err != nil {
+		ew.printf("  Unavailable: %v\n\n", d.Err)
+		referenceErrors(ew, d.References)
+		return ew.err
+	}
+
+	if len(d.References.CWEs) == 0 {
+		ew.printf("  No CWE references found in current findings.\n\n")
+		referenceErrors(ew, d.References)
+		return ew.err
+	}
+
+	if d.Result == nil {
+		ew.printf("  No enrichment data returned.\n\n")
+		referenceErrors(ew, d.References)
+		return ew.err
+	}
+
+	rendered := 0
+	for _, cwe := range d.References.CWEs {
+		entry, ok := d.Result.Successes[cwe]
+		if !ok {
+			continue
+		}
+		rendered++
+		ew.printf("  %s", cwe)
+		if entry.WeaknessName != "" {
+			ew.printf(" - %s", entry.WeaknessName)
+		}
+		ew.printf("\n")
+
+		if entry.Status == enrichment.StatusNoMatches || len(entry.MatchedCVEs) == 0 {
+			ew.printf("    No CVE matches in queried sources.\n")
+			continue
+		}
+
+		for _, match := range entry.MatchedCVEs {
+			symbol, label := types.SeverityFormat(match.CVSSSeverity)
+			ew.printf("    %s %s  %s (%.1f) [%s]\n",
+				symbol, label, match.CVEID, match.CVSSBaseScore, match.Source)
+			if d.Verbose {
+				if match.Description != "" {
+					ew.printf("      Description: %s\n", match.Description)
+				}
+				if match.KnownExploited {
+					ew.printf("      Known Exploited: yes\n")
+				}
+				if match.PatchAvailable {
+					ew.printf("      Patch Available: yes\n")
+				}
+			}
+		}
+	}
+
+	if rendered == 0 {
+		ew.printf("  No enrichment data returned.\n")
+	}
+
+	if len(d.Result.Failures) > 0 {
+		ew.printf("\n  Failed enrichments:\n")
+		for cwe, failure := range d.Result.Failures {
+			ew.printf("    %s [%s]: %s", cwe, failure.Source, failure.Reason)
+			if failure.Retryable {
+				ew.printf(" (retryable)")
+			}
+			ew.printf("\n")
+		}
+	}
+
+	ew.printf("\n")
+	referenceErrors(ew, d.References)
+	return ew.err
+}
+
+// referenceErrors writes reference parsing errors as an indented block,
+// or nothing when there are none. It is only reachable through
+// EnrichmentBlock, which owns the surrounding layout.
+func referenceErrors(ew *errWriter, refs types.ReferenceExtraction) {
+	if len(refs.Errors) == 0 {
+		return
+	}
+	ew.printf("  Reference parsing errors:\n")
+	for _, err := range refs.Errors {
+		ew.printf("    %v\n", err)
+	}
+	ew.printf("\n")
+}
+
+// EnrichmentEntries converts enrichment successes into typed serialization
+// structs, in the same CWE order as refs.CWEs so output order is stable
+// across runs.
+func EnrichmentEntries(refs types.ReferenceExtraction, res *enrichment.Result) []EnrichmentEntry {
+	if res == nil {
+		return nil
+	}
+	out := make([]EnrichmentEntry, 0, len(refs.CWEs))
+	for _, cwe := range refs.CWEs {
+		entry, ok := res.Successes[cwe]
+		if !ok {
+			continue
+		}
+		e := EnrichmentEntry{
+			CWEID:        cwe,
+			WeaknessName: entry.WeaknessName,
+			NoMatches:    entry.Status == enrichment.StatusNoMatches || len(entry.MatchedCVEs) == 0,
+		}
+		for _, match := range entry.MatchedCVEs {
+			e.Matches = append(e.Matches, EnrichmentMatch{
+				CVEID:          match.CVEID,
+				Source:         string(match.Source),
+				CVSSBaseScore:  match.CVSSBaseScore,
+				CVSSSeverity:   match.CVSSSeverity,
+				Description:    match.Description,
+				KnownExploited: match.KnownExploited,
+				PatchAvailable: match.PatchAvailable,
+			})
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// EnrichmentFailures converts enrichment failures into typed serialization
+// structs.
+func EnrichmentFailures(res *enrichment.Result) []EnrichmentFailure {
+	if res == nil || len(res.Failures) == 0 {
+		return nil
+	}
+	out := make([]EnrichmentFailure, 0, len(res.Failures))
+	for cwe, failure := range res.Failures {
+		out = append(out, EnrichmentFailure{
+			CWEID:     cwe,
+			Source:    string(failure.Source),
+			Reason:    failure.Reason,
+			Retryable: failure.Retryable,
+		})
+	}
+	return out
+}
+
+// ReferenceErrorStrings converts reference parsing errors into strings for
+// JSON and YAML output.
+func ReferenceErrorStrings(errs []error) []string {
+	if len(errs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(errs))
+	for _, e := range errs {
+		out = append(out, e.Error())
+	}
+	return out
+}

--- a/internal/render/errwriter.go
+++ b/internal/render/errwriter.go
@@ -1,0 +1,24 @@
+// internal/render/errwriter.go
+package render
+
+import (
+	"fmt"
+	"io"
+)
+
+// errWriter wraps an io.Writer and remembers the first write error, letting
+// rendering code write unconditionally and report the error once. This is
+// the same pattern bufio.Writer and text/tabwriter use internally.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+// printf formats to the underlying writer unless a previous write failed,
+// in which case it is a no-op.
+func (ew *errWriter) printf(format string, args ...any) {
+	if ew.err != nil {
+		return
+	}
+	_, ew.err = fmt.Fprintf(ew.w, format, args...)
+}

--- a/internal/render/finding.go
+++ b/internal/render/finding.go
@@ -1,0 +1,18 @@
+// internal/render/finding.go
+package render
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/papa0four/orkowatch/internal/security/types"
+)
+
+// FindingLine writes a single finding as symbol, fixed-width severity
+// label, and title, prefixed by indent. Severity symbol and label come
+// from types.SeverityFormat so every command renders findings identically.
+func FindingLine(w io.Writer, indent, severity, title string) error {
+	symbol, label := types.SeverityFormat(severity)
+	_, err := fmt.Fprintf(w, "%s%s %s  %s\n", indent, symbol, label, title)
+	return err
+}

--- a/internal/render/summary.go
+++ b/internal/render/summary.go
@@ -1,0 +1,80 @@
+// internal/render/summary.go
+package render
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// SummaryData carries the counts and duration both summary layouts render.
+// Shown is the number of findings that survived the active min-severity
+// threshold; the suppressed count is derived from it.
+type SummaryData struct {
+	TotalChecks   int
+	PassedChecks  int
+	SkippedChecks int
+	TotalFindings int
+	Shown         int
+	Critical      int
+	High          int
+	Medium        int
+	Low           int
+	Duration      time.Duration
+}
+
+// suppressed returns how many findings the active min-severity threshold
+// filtered out of the displayed set.
+func (d SummaryData) suppressed() int {
+	return d.TotalFindings - d.Shown
+}
+
+// SuppressionNotice writes the min-severity suppression disclosure, or
+// nothing when no findings were suppressed.
+func SuppressionNotice(w io.Writer, suppressed, total int, minSeverity string) error {
+	if suppressed <= 0 {
+		return nil
+	}
+	_, err := fmt.Fprintf(w, "%d of %d findings suppressed by --min-severity %s. "+
+		"Rerun with a lower threshold or without --min-severity to see all findings.\n\n",
+		suppressed, total, strings.ToUpper(minSeverity))
+	return err
+}
+
+// CompactSummary writes the single-line summary used by the all command,
+// expanding to total/present/suppressed counts when the min-severity
+// threshold filtered out findings.
+func CompactSummary(w io.Writer, d SummaryData) error {
+	if s := d.suppressed(); s > 0 {
+		_, err := fmt.Fprintf(w, "Summary: %d checks  %d passed  %d findings total  %d present  %d suppressed  %s\n",
+			d.TotalChecks, d.PassedChecks, d.TotalFindings, d.Shown, s, d.Duration)
+		return err
+	}
+	_, err := fmt.Fprintf(w, "Summary: %d checks  %d passed  %d findings  %s\n",
+		d.TotalChecks, d.PassedChecks, d.TotalFindings, d.Duration)
+	return err
+}
+
+// DetailedSummary writes the multi-line summary block used by the audit
+// command, with per-severity finding counts and check-level totals. The
+// first write error, if any, is returned.
+func DetailedSummary(w io.Writer, d SummaryData) error {
+	ew := &errWriter{w: w}
+	ew.printf("Summary:\n")
+	ew.printf("Checks Run:      %d\n", d.TotalChecks)
+	ew.printf("Passed:          %d\n", d.PassedChecks)
+	ew.printf("Skipped:         %d\n", d.SkippedChecks)
+	if s := d.suppressed(); s > 0 {
+		ew.printf("Total Findings:  %d (%d present, %d suppressed)\n",
+			d.TotalFindings, d.Shown, s)
+	} else {
+		ew.printf("Total Findings:  %d\n", d.TotalFindings)
+	}
+	ew.printf("  Critical:      %d\n", d.Critical)
+	ew.printf("  High:          %d\n", d.High)
+	ew.printf("  Medium:        %d\n", d.Medium)
+	ew.printf("  Low:           %d\n", d.Low)
+	ew.printf("Duration:        %v\n", d.Duration)
+	return ew.err
+}

--- a/internal/render/tty.go
+++ b/internal/render/tty.go
@@ -1,0 +1,17 @@
+// internal/render/tty.go
+package render
+
+import "os"
+
+// StdoutIsTerminal reports whether standard output is attached to a
+// character device. It is the single TTY detection point in the tree;
+// commands combine it with their own verbose and report-file state to
+// gate progress headers, and #35's progress display consumes this same
+// seam.
+func StdoutIsTerminal() bool {
+	fileInfo, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return (fileInfo.Mode() & os.ModeCharDevice) != 0
+}

--- a/internal/security/types/types.go
+++ b/internal/security/types/types.go
@@ -3,6 +3,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/papa0four/orkowatch/internal/security/enrichment"
@@ -89,6 +90,45 @@ type ReferenceExtraction struct {
 
 func (e *ValidationError) Error() string {
 	return fmt.Sprintf("validation error in %s: %s - %s", e.Checker, e.Field, e.Message)
+}
+
+// SeverityLevel returns the numeric rank of a severity string for threshold
+// comparisons. Unknown values return -1 so they are never silently dropped.
+func SeverityLevel(s string) int {
+	switch strings.ToUpper(s) {
+	case SeverityLow:
+		return 0
+	case SeverityMedium:
+		return 1
+	case SeverityHigh:
+		return 2
+	case SeverityCritical:
+		return 3
+	default:
+		return -1
+	}
+}
+
+// MeetsMinSeverity reports whether findingSeverity is at or above the min
+// threshold. Unrecognized severity values pass through so findings are
+// never silently dropped.
+func MeetsMinSeverity(findingSeverity, min string) bool {
+	fl := SeverityLevel(findingSeverity)
+	ml := SeverityLevel(min)
+	if fl < 0 || ml < 0 {
+		return true
+	}
+	return fl >= ml
+}
+
+// EffectiveSeverity returns the severity value used for filtering and
+// display. It currently always returns the finding's static registry-
+// assigned severity. Once per-finding CVE/CVSS enrichment lands, this is
+// the single point where a live CVSS-derived severity would override the
+// static value. Callers should go through this rather than reading
+// finding.Severity directly, so severity sourcing only has to change here.
+func EffectiveSeverity(f Finding) string {
+	return f.Severity
 }
 
 // SeverityFormat returns the display symbol and fixed-width padded severity label

--- a/internal/softwarelist/softwarelist.go
+++ b/internal/softwarelist/softwarelist.go
@@ -3,7 +3,11 @@
 // formatted string for human-readable text output.
 package softwarelist
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+	"strings"
+)
 
 // SoftwareEntry represents a single installed software package with its
 // display name and version string as reported by the host platform.
@@ -29,9 +33,32 @@ func GetInstalledSoftwareList() ([]SoftwareEntry, error) {
 // formatted human-readable string. Used for text output and the standalone
 // software subcommand.
 func GetInstalledSoftware() (string, error) {
-	result, err := getPlatformSoftware()
+	entries, err := getPlatformSoftwareList()
 	if err != nil {
 		return "", fmt.Errorf("software enumeration failed: %w", err)
 	}
-	return result, nil
+	var sb strings.Builder
+	if err := WriteTable(&sb, entries, true); err != nil {
+		return "", err
+	}
+	return sb.String(), nil
+}
+
+// WriteTable writes entries to w as fixed-width name and version columns,
+// one package per line. withHeader controls the leading column header row:
+// the standalone software subcommand prints it, while the all command's
+// verbose listing omits it. This is the single definition of the software
+// table row format.
+func WriteTable(w io.Writer, entries []SoftwareEntry, withHeader bool) error {
+	if withHeader {
+		if _, err := fmt.Fprintf(w, "%-60s %s\n", "Name", "Version"); err != nil {
+			return fmt.Errorf("software table write failed: %w", err)
+		}
+	}
+	for _, e := range entries {
+		if _, err := fmt.Fprintf(w, "%-60s %s\n", e.Name, e.Version); err != nil {
+			return fmt.Errorf("software table write failed: %w", err)
+		}
+	}
+	return nil
 }

--- a/internal/softwarelist/softwarelist_unix.go
+++ b/internal/softwarelist/softwarelist_unix.go
@@ -43,24 +43,6 @@ func getPlatformSoftwareList() ([]SoftwareEntry, error) {
 	}
 }
 
-// getPlatformSoftware returns installed software as a column-aligned string
-// suitable for human-readable text output and the standalone software
-// subcommand. It delegates to getPlatformSoftwareList and formats each entry
-// as a fixed-width name and version pair.
-func getPlatformSoftware() (string, error) {
-	entries, err := getPlatformSoftwareList()
-	if err != nil {
-		return "", err
-	}
-
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "%-60s %s\n", "Name", "Version")
-	for _, e := range entries {
-		fmt.Fprintf(&sb, "%-60s %s\n", e.Name, e.Version)
-	}
-	return sb.String(), nil
-}
-
 // parseTabDelimited parses tab-delimited name\tversion output from dpkg-query
 // and rpm into a slice of SoftwareEntry.
 func parseTabDelimited(output string) []SoftwareEntry {

--- a/internal/softwarelist/softwarelist_windows.go
+++ b/internal/softwarelist/softwarelist_windows.go
@@ -122,21 +122,3 @@ func getPlatformSoftwareList() ([]SoftwareEntry, error) {
 	}
 	return wmicEntries, nil
 }
-
-// getPlatformSoftware returns installed software as a column-aligned string
-// suitable for human-readable text output and the standalone software
-// subcommand. It delegates to getPlatformSoftwareList and formats each entry
-// as a fixed-width name and version pair.
-func getPlatformSoftware() (string, error) {
-	entries, err := getPlatformSoftwareList()
-	if err != nil {
-		return "", err
-	}
-
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "%-60s %s\n", "Name", "Version")
-	for _, e := range entries {
-		fmt.Fprintf(&sb, "%-60s %s\n", e.Name, e.Version)
-	}
-	return sb.String(), nil
-}


### PR DESCRIPTION
## Summary

`all` and `audit` each maintained an independent rendering stack over substantially identical data: duplicated severity ranking and threshold helpers, twin text renderers for the enrichment six-state block and reference errors, duplicated suppression disclosure and summary logic, duplicated enrichment serialization structs and builders, and uncoordinated TTY/verbose-header gating. This PR extracts the shared machinery into a new `internal/render` package and consolidates severity logic into `internal/security/types`, per the #124 scope. Second sub-issue of #54, built on the merged result of #123.

Command output schemas (`allResult`, `formattedResult`) remain separate types owned by their commands under the additive-only output contract; consolidation targets the logic beneath them, not the schemas. Default text, JSON, and YAML output of both commands is byte-identical to pre-change output across the full #37 composition matrix (23 scenarios: default runs, `--skip-modules`/`--skip-checks` combinations, audit-only reduction, `--min-severity` suppression, `--enrich`, both all-skipped refusal cases, verbose), confirmed by normalized diff of stdout, stderr, and exit codes between pre- and post-change binaries.

## Changes

- `internal/render` -- new package: `EnrichmentBlock` (six-state text rendering, now using the `enrichment.StatusNoMatches` constant instead of raw string comparisons), `FindingLine`, `SuppressionNotice`, `CompactSummary`/`DetailedSummary` over a shared `SummaryData`, `StdoutIsTerminal` (the tree's single TTY helper), and the shared enrichment serialization types and builders (`EnrichmentEntry`/`EnrichmentMatch`/`EnrichmentFailure`, `EnrichmentEntries`, `EnrichmentFailures`, `ReferenceErrorStrings`). Imports `types` and `enrichment` only; no cobra, no audit engine. Every rendering function takes data and an `io.Writer` and returns the first write error via an internal `errWriter` (the bufio/tabwriter pattern), since errcheck's default exclusions cover writes to concrete buffer types but not `io.Writer`
- `internal/security/types` -- `SeverityLevel`, `MeetsMinSeverity`, and the `effectiveSeverity` CVSS-override seam (now `EffectiveSeverity`) consolidated alongside the severity constants; both commands route filtering and display through the seam, so it exists once with two consumers
- `cmd/commands/all.go` -- local renderers, severity helpers, enrichment structs/builders, and `isTerminal` deleted; verbose-header gate computed once in `runAllScans` and threaded through the module runners, replacing six inline `allVerbose && isTerminal() && allReportFile == ""` repetitions; verbose software listing via `softwarelist.WriteTable`; `--min-severity` help text typo fixed (`LOW<` to `LOW,`)
- `cmd/commands/security/security.go` -- same removals; `formatText` and `convertToFormattedResult` consume `internal/render` and the types severity seam
- `internal/softwarelist` -- the `%-60s %s` row format existed in four places (both platform `getPlatformSoftware` copies, the header variant, and all.go's verbose listing); now one `WriteTable(w, entries, withHeader)` in `softwarelist.go`, platform files keep only list enumeration, `GetInstalledSoftware` delegates
- `cmd/commands/osinfo.go` -- no change needed; #123 already consolidated its rendering and nothing it outputs overlaps a consolidated block

Acceptance criteria confirmed by grep: zero switches over severity constants remain in `cmd/`, exactly one TTY-detection helper exists in the tree, no rendering function in `cmd/` duplicates a render block, and every exported `internal/render` symbol has a live caller in both commands or its owning command.

Surfaced during this work, not acted on here: `security_windows.go` prints its verbose header even when `--report-file` is set while the Unix path suppresses it (belongs with #111), and enrichment failure output order is nondeterministic map iteration in both the old and new code, unobservable until a real enrichment adapter exists.

## Verified

- [x] `gofmt -w .`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gosec ./...`
- [x] `govulncheck ./...`
- [x] `golangci-lint run --timeout=5m`
- [x] `GOOS=windows go build ./...` (cross-platform changes)

Full pipeline clean on defender; jsabs pipeline to be run before merge.

Closes #124