### PR TITLE
updated security and its os-specific modules to utilize RunE and remo…

### DIFF
--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -41,11 +41,15 @@ var (
 	allowElevatedWrite bool
 )
 
-// SecurityCmd represents the security audit command
+// SecurityCmd represents the security audit command. RunE is assigned at the
+// declaration site from platformRunE, a symbol provided by exactly one
+// build-tagged platform file per compiled target. A target missing its
+// platform file fails to compile rather than shipping a nil RunE.
 var SecurityCmd = &cobra.Command{
 	Use:     "audit [flags] [check...]",
 	Aliases: []string{"security_audit"},
 	Short:   "Perform a security audit of the system",
+	RunE:    platformRunE,
 	Long: `Perform a comprehensive security audit of the system.
 This command checks various security aspects including:
 - SSH configuration

--- a/cmd/commands/security/security_unix.go
+++ b/cmd/commands/security/security_unix.go
@@ -11,11 +11,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	SecurityCmd.RunE = runUnixAudit
-}
-
-func runUnixAudit(cmd *cobra.Command, args []string) error {
+// platformRunE is the Unix entry point for the audit command, assigned to
+// SecurityCmd.RunE at its declaration site in security.go.
+func platformRunE(cmd *cobra.Command, args []string) error {
 	if err := validateFlags(cmd); err != nil {
 		return err
 	}

--- a/cmd/commands/security/security_windows.go
+++ b/cmd/commands/security/security_windows.go
@@ -11,11 +11,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	SecurityCmd.RunE = runWindowsAudit
-}
-
-func runWindowsAudit(cmd *cobra.Command, args []string) error {
+// platformRunE is the windows entry point for the audit command, assignment to
+// SecurityCmd.RunE at its declaration site in security.go
+func platformRunE(cmd *cobra.Command, args []string) error {
 	if err := validateFlags(cmd); err != nil {
 		return err
 	}
@@ -25,7 +23,7 @@ func runWindowsAudit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if verbose {
+	if verbose && reportFile == "" {
 		fmt.Printf("[*] Running security audit for OS: %s\n", runtime.GOOS)
 	}
 	logVerboseConfig(mask)

--- a/owatch-MSI-c.s-20260710T032521Z.json
+++ b/owatch-MSI-c.s-20260710T032521Z.json
@@ -1,0 +1,86 @@
+{
+  "timestamp": "2026-07-09T23:25:21-04:00",
+  "duration": "207.4988ms",
+  "system_info": {
+    "os": "windows",
+    "architecture": "amd64",
+    "hostname": "MSI",
+    "kernel_version": "10.0.26200 Build 26200"
+  },
+  "results": [
+    {
+      "name": "Windows SSH Configuration",
+      "status": "COMPLETED",
+      "description": "Windows SSH Configuration analysis complete",
+      "duration": "207.4988ms",
+      "findings": [
+        {
+          "title": "OpenSSH Server installed but not running",
+          "severity": "MEDIUM",
+          "description": "The OpenSSH Server (sshd) service is installed but currently stopped. An installed but inactive SSH daemon represents an unmanaged attack surface that any administrator-level process or user can start without additional installation steps.\n",
+          "impact": "If started, an unconfigured or default-configured SSH service may permit password authentication or expose the system to brute-force attacks. Presence alone indicates unreviewed remote access capability.\n",
+          "resolution": "If SSH is not required, remove the OpenSSH Server optional feature via Settings \u003e Apps \u003e Optional Features. If required, configure C:\\ProgramData\\ssh\\sshd_config before enabling the service and restrict access via Windows Firewall rules.\n",
+          "references": [
+            {
+              "Title": "CIS Windows 11 Benchmark v3.0.0 §18.10.56",
+              "URL": "",
+              "Type": "CIS"
+            },
+            {
+              "Title": "NIST SP 800-53 Rev 5 CM-7 (Least Functionality)",
+              "URL": "",
+              "Type": "NIST"
+            },
+            {
+              "Title": "https://cwe.mitre.org/data/definitions/16.html",
+              "URL": "https://cwe.mitre.org/data/definitions/16.html",
+              "Type": "CWE"
+            }
+          ]
+        },
+        {
+          "title": "OpenSSH configuration file not found",
+          "severity": "MEDIUM",
+          "description": "No sshd_config file was found at C:\\ProgramData\\ssh\\sshd_config. Without an explicit configuration file, sshd falls back to compiled-in defaults which may permit password authentication and use deprecated algorithms.\n",
+          "impact": "Default SSH configurations frequently fail CIS and DISA STIG requirements. An attacker who starts the SSH service inherits permissive defaults, potentially enabling credential-based remote access without restriction.\n",
+          "resolution": "Create C:\\ProgramData\\ssh\\sshd_config with explicit directives for PasswordAuthentication, PermitRootLogin, and AllowedUsers before enabling the sshd service.\n",
+          "references": [
+            {
+              "Title": "CIS Windows 11 Benchmark v3.0.0 §18.10.56.2",
+              "URL": "",
+              "Type": "CIS"
+            },
+            {
+              "Title": "NIST SP 800-53 Rev 5 CM-6 (Configuration Settings)",
+              "URL": "",
+              "Type": "NIST"
+            },
+            {
+              "Title": "https://cwe.mitre.org/data/definitions/16.html",
+              "URL": "https://cwe.mitre.org/data/definitions/16.html",
+              "Type": "CWE"
+            }
+          ]
+        }
+      ],
+      "details": [
+        "[!] OpenSSH Server is installed but not running",
+        "[!] WARNING: OpenSSH configuration file not found"
+      ]
+    }
+  ],
+  "summary": {
+    "total_checks": 1,
+    "passed_checks": 0,
+    "skipped_checks": 0,
+    "total_findings": 2,
+    "critical_findings": 0,
+    "high_findings": 0,
+    "medium_findings": 2,
+    "low_findings": 0
+  },
+  "enrichment_requested": false,
+  "reference_cwes": [
+    "CWE-16"
+  ]
+}


### PR DESCRIPTION
## Summary

`SecurityCmd` was declared in `security.go` with no `RunE`; each build-tagged platform file assigned it from its own `init()` as a cross-file side effect. Ownership of the command's entry point was split across three files with no signal at the declaration site, and the two platform handlers had silently diverged: Unix gated the OS banner behind `verbose && reportFile == ""` while Windows gated on `verbose` alone, leaking the banner into report runs.

Both platform files now export a single `platformRunE` symbol, and `security.go` assigns `RunE: platformRunE` in the declaration itself. Exactly one assignment exists per compiled target, and a target missing its platform file fails to compile rather than shipping a nil `RunE`. Supersedes the ownership decision in #23, which correctly resolved the struct-literal/init conflict by picking init ownership; this removes the conflict class entirely and adds the compile-time guarantee init ownership cannot provide.

## Changes

**`cmd/commands/security/security.go`**
- `RunE: platformRunE` assigned in the `SecurityCmd` struct literal, with a doc comment recording the build-tag contract

**`cmd/commands/security/security_unix.go`**
- `init()` deleted; `runUnixAudit` renamed to `platformRunE`

**`cmd/commands/security/security_windows.go`**
- `init()` deleted; `runWindowsAudit` renamed to `platformRunE`
- Banner gate aligned to Unix: `verbose && reportFile == ""`, closing the banner leak into `--report-file` runs

After convergence the only difference between the platform files is the build tag and doc comment platform word; no genuinely platform-specific entry logic exists yet, and the divergence point is structured for when it does.

## Verified

- `go build ./...` and cross-compile to the opposite GOOS clean on both machines: each target resolves exactly one `platformRunE`
- Symbol sweep over `cmd/commands/security/`: one `init()` remaining (flag registration in `security.go`), zero hits for `runUnixAudit`, `runWindowsAudit`, or assignment-statement `RunE =`
- `audit --ssh` non-verbose, verbose, and JSON output identical to pre-change on both machines
- jsabs: `audit --ssh -v -o json --report-file .` prints only the save line; banner no longer leaks into report runs (the deliberate behavior fix)
- defender: same command confirms no regression on the already-correct Unix gate
- `audit --ssh -o bogus` rejected by `validateFlags` through the new wiring, nonzero exit
- Full pipeline clean on defender and jsabs: gofmt, go build, go vet, gosec, govulncheck, golangci-lint, GOOS=windows go build

Closes #125