### PR TITLE
[Chore] function hardening pass -- validation, error branches, context propagation, unverified file audit

### DIFF
--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -63,7 +64,7 @@ func init() {
 	allCmd.Flags().BoolVarP(&allVerbose, "verbose", "v", false,
 		"Enable verbose output for all scans")
 	allCmd.Flags().StringVarP(&allOutputFormat, "output", "o", "text",
-		"Output format (json, yaml, text, csv)")
+		"Output format (json, yaml, text)")
 	allCmd.Flags().StringVar(&allReportFile, "report-file", "",
 		"Save complete report to the specified directory; filename is generated automatically")
 	allCmd.Flags().StringSliceVar(&allSkipModules, "skip-modules", []string{},
@@ -284,10 +285,10 @@ func validateSkipModules() error {
 // validateAllFlags rejects invalid flag combinations for the all command.
 func validateAllFlags(cmd *cobra.Command) error {
 	switch allOutputFormat {
-	case "json", "yaml", "text", "csv":
+	case "json", "yaml", "text":
 		// accepted
 	default:
-		return fmt.Errorf("invalid output format: %s (valid: json, yaml, text, csv)", allOutputFormat)
+		return fmt.Errorf("invalid output format: %s (valid: json, yaml, or text)", allOutputFormat)
 	}
 
 	if cmd.Flags().Changed("report-file") {
@@ -352,52 +353,53 @@ func runAllScans(cmd *cobra.Command, args []string) error {
 	// point for the whole run.
 	verboseHeaders := allVerbose && render.StdoutIsTerminal() && allReportFile == ""
 
-	results := make(chan *ScanResult, 1)
+	// The whole scan runs synchronously under one deadline. Cancellation
+	// reaches the audit's checkers and the software module's package-manager
+	// invocations, so a timed-out scan leaves nothing running -- the prior
+	// goroutine-and-select pattern reported the timeout but abandoned the
+	// scan to keep executing against the host.
+	ctx, cancel := context.WithTimeout(cmd.Context(), allTimeout)
+	defer cancel()
 
-	go func() {
-		result := &ScanResult{
-			Timestamp: startTime,
-			Errors:    make([]string, 0),
+	result := &ScanResult{
+		Timestamp: startTime,
+		Errors:    make([]string, 0),
+	}
+
+	if !isModuleSkipped("osinfo") {
+		if osInfo, err := runOSFingerprint(verboseHeaders); err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("OS fingerprint error: %v", err))
+		} else {
+			result.OSInfo = osInfo
 		}
+	}
 
-		if !isModuleSkipped("osinfo") {
-			if osInfo, err := runOSFingerprint(verboseHeaders); err != nil {
-				result.Errors = append(result.Errors,
-					fmt.Sprintf("OS fingerprint error: %v", err))
-			} else {
-				result.OSInfo = osInfo
-			}
+	if !isModuleSkipped("software") {
+		software, err := runSoftwareInventory(ctx, verboseHeaders)
+		if err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("Software inventory error: %v", err))
+		} else {
+			result.Software = software
 		}
+	}
 
-		if !isModuleSkipped("software") {
-			software, err := runSoftwareInventory(verboseHeaders)
-			if err != nil {
-				result.Errors = append(result.Errors,
-					fmt.Sprintf("Software inventory error: %v", err))
-			} else {
-				result.Software = software
-			}
+	if !isModuleSkipped("audit") {
+		if securityResult, err := runSecurityAuditModule(ctx, mask, result.OSInfo, verboseHeaders); err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("Security audit error: %v", err))
+		} else {
+			result.SecurityAudit = securityResult
 		}
+	}
 
-		if !isModuleSkipped("audit") {
-			if securityResult, err := runSecurityAuditModule(mask, result.OSInfo, verboseHeaders); err != nil {
-				result.Errors = append(result.Errors,
-					fmt.Sprintf("Security audit error: %v", err))
-			} else {
-				result.SecurityAudit = securityResult
-			}
-		}
-
-		result.Duration = time.Since(startTime)
-		results <- result
-	}()
-
-	select {
-	case result := <-results:
-		return outputResults(cmd, result, mask)
-	case <-time.After(allTimeout):
+	if ctx.Err() == context.DeadlineExceeded {
 		return fmt.Errorf("scan timed out after %v", allTimeout)
 	}
+
+	result.Duration = time.Since(startTime)
+	return outputResults(cmd, result, mask)
 }
 
 func runOSFingerprint(verboseHeaders bool) (*osfingerprint.OSInfo, error) {
@@ -425,12 +427,12 @@ func runOSFingerprint(verboseHeaders bool) (*osfingerprint.OSInfo, error) {
 // runSoftwareInventory enumerates installed software packages. Verbose module
 // headers are gated behind verboseHeaders to prevent duplication when piping
 // or redirecting output.
-func runSoftwareInventory(verboseHeaders bool) ([]softwarelist.SoftwareEntry, error) {
+func runSoftwareInventory(ctx context.Context, verboseHeaders bool) ([]softwarelist.SoftwareEntry, error) {
 	if verboseHeaders {
 		fmt.Println("[*] Software Inventory Scan")
 	}
 
-	entries, err := softwarelist.GetInstalledSoftwareList()
+	entries, err := softwarelist.GetInstalledSoftwareList(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +449,7 @@ func runSoftwareInventory(verboseHeaders bool) ([]softwarelist.SoftwareEntry, er
 	return entries, nil
 }
 
-func runSecurityAuditModule(mask scan.CheckMask, hostInfo *osfingerprint.OSInfo, verboseHeaders bool) (*audit.Result, error) {
+func runSecurityAuditModule(ctx context.Context, mask scan.CheckMask, hostInfo *osfingerprint.OSInfo, verboseHeaders bool) (*audit.Result, error) {
 	if verboseHeaders {
 		fmt.Println("[*] Security Audit Scan")
 	}
@@ -455,14 +457,13 @@ func runSecurityAuditModule(mask scan.CheckMask, hostInfo *osfingerprint.OSInfo,
 	opts := audit.Options{
 		Verbose:        verboseHeaders,
 		MinSeverity:    allMinSeverity,
-		Timeout:        allTimeout,
 		Enrich:         allEnrich,
 		SpecificChecks: scan.EnabledChecks(mask),
 		HostInfo:       hostInfo,
 	}
 
 	auditor := audit.NewSecurityAuditor(opts)
-	return auditor.RunAudit()
+	return auditor.RunAudit(ctx)
 }
 
 func outputResults(cmd *cobra.Command, result *ScanResult, mask scan.CheckMask) error {
@@ -488,8 +489,6 @@ func outputResults(cmd *cobra.Command, result *ScanResult, mask scan.CheckMask) 
 		if err := yaml.NewEncoder(&buf).Encode(data); err != nil {
 			return fmt.Errorf("failed to encode YAML: %w", err)
 		}
-	case "csv":
-		return fmt.Errorf("csv output format is not yet implemented")
 	default:
 		if err := renderAllText(&buf, result); err != nil {
 			return fmt.Errorf("failed to render text output: %w", err)

--- a/cmd/commands/all.go
+++ b/cmd/commands/all.go
@@ -109,9 +109,9 @@ type (
 	}
 
 	// allSystemInfo carries host identity fields for all command output.
-	// KernelVersion is omitted when empty -- it is only populated from
-	// osfingerprint data, not from the runtime-only fallback used when the
-	// osinfo module is skipped.
+	// Populated exclusively from osfingerprint data; absent entirely when the
+	// osinfo module is skipped, matching how software and security sections
+	// behave. A present system block always means fingerprinting ran.
 	allSystemInfo struct {
 		OS            string `json:"os" yaml:"os"`
 		Hostname      string `json:"hostname" yaml:"hostname"`
@@ -254,7 +254,7 @@ func toAllResult(scan *ScanResult) allResult {
 		}
 		if suppressed := sec.Summary.TotalFindings - len(sec.Findings); suppressed > 0 {
 			sec.FindingsSuppressed = suppressed
-			sec.MinSeverityApplied = strings.ToUpper(allMinSeverity)
+			sec.MinSeverityApplied = allMinSeverity
 		}
 		if scan.SecurityAudit.EnrichmentRequested {
 			sec.EnrichmentRequested = true
@@ -307,7 +307,10 @@ func validateAllFlags(cmd *cobra.Command) error {
 		}
 	}
 
-	switch strings.ToUpper(allMinSeverity) {
+	// Normalize once at the boundary so every downstream consumer sees the
+	// canonical form; validation and storage happen in the same step.
+	allMinSeverity = strings.ToUpper(allMinSeverity)
+	switch allMinSeverity {
 	case "LOW", "MEDIUM", "HIGH", "CRITICAL":
 		// accepted
 	default:

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -18,11 +18,11 @@ var RootCmd = &cobra.Command{
 	Long:          `orkowatch helps engineers and architects scan for vulnerabilities in OS, software, and security protocols`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("owatch requires a subcommand (e.g., all, osinfo, audit, software).")
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := cmd.Help(); err != nil {
-			fmt.Fprintf(os.Stderr, "error displaying help: %v\n", err)
+			return fmt.Errorf("displaying help: %w", err)
 		}
+		return fmt.Errorf("owatch requires a subcommand (e.g., all, osinfo, audit, software)")
 	},
 }
 
@@ -31,10 +31,13 @@ func init() {
 	RootCmd.Flags().BoolP("version", "V", false, "version for owatch")
 }
 
-// Execute runs the root command and exits with a non-zero status on error
+// Execute runs the root command and exits with a non-zero status on error.
+// SilenceErrors is set on RootCmd, so this is the single error-reporting
+// point for the binary; errors go to stderr, never stdout, so they cannot
+// interleave with report output or escape 2> redirection.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -2,6 +2,7 @@
 package security
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -196,10 +197,10 @@ func buildMask() (scan.CheckMask, error) {
 
 func validateFlags(cmd *cobra.Command) error {
 	switch outputFormat {
-	case "json", "yaml", "text", "csv":
+	case "json", "yaml", "text":
 		// accepted
 	default:
-		return fmt.Errorf("invalid output format: %s (valid: json, yaml, text)", outputFormat)
+		return fmt.Errorf("invalid output format: %s (valid: json, yaml, or text)", outputFormat)
 	}
 
 	validSeverities := map[string]bool{
@@ -275,39 +276,35 @@ func logVerboseConfig(mask scan.CheckMask) {
 	fmt.Println()
 }
 
+// runAuditWithTimeout executes the audit synchronously under a deadline.
+// Cancellation propagates through RunAudit into checker exec and filesystem
+// work, so on timeout nothing owatch started is left running -- the prior
+// goroutine-and-select pattern reported the timeout but abandoned the scan
+// to keep executing against the host.
 func runAuditWithTimeout(cmd *cobra.Command, mask scan.CheckMask) error {
 	opts := audit.Options{
 		Verbose:        verbose && reportFile == "",
 		SkipChecks:     skipChecks,
 		FilePermsPath:  checkFilePerms,
 		MinSeverity:    minSeverity,
-		Timeout:        timeout,
 		SpecificChecks: scan.EnabledChecks(mask),
 		Enrich:         enrich,
 	}
 
 	auditor := audit.NewSecurityAuditor(opts)
 
-	resultChan := make(chan *audit.Result, 1)
-	errorChan := make(chan error, 1)
+	ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
+	defer cancel()
 
-	go func() {
-		result, err := auditor.RunAudit()
-		if err != nil {
-			errorChan <- err
-			return
-		}
-		resultChan <- result
-	}()
-
-	select {
-	case result := <-resultChan:
-		return outputResults(cmd, result, mask)
-	case err := <-errorChan:
-		return fmt.Errorf("audit failed: %w", err)
-	case <-time.After(timeout):
+	result, err := auditor.RunAudit(ctx)
+	if ctx.Err() == context.DeadlineExceeded {
 		return fmt.Errorf("audit timeout after %v", timeout)
 	}
+	if err != nil {
+		return fmt.Errorf("audit failed: %w", err)
+	}
+
+	return outputResults(cmd, result, mask)
 }
 
 func outputResults(cmd *cobra.Command, result *audit.Result, mask scan.CheckMask) error {
@@ -331,8 +328,6 @@ func outputResults(cmd *cobra.Command, result *audit.Result, mask scan.CheckMask
 		output, err = formatJSON(result)
 	case "yaml":
 		output, err = formatYAML(result)
-	case "csv":
-		return fmt.Errorf("csv output format is not yet implemented")
 	default:
 		output, err = formatText(result)
 	}

--- a/cmd/commands/security/security.go
+++ b/cmd/commands/security/security.go
@@ -203,13 +203,16 @@ func validateFlags(cmd *cobra.Command) error {
 		return fmt.Errorf("invalid output format: %s (valid: json, yaml, or text)", outputFormat)
 	}
 
+	// Normalize once at the boundary so every downstream consumer sees the
+	// canonical form; validation and storage happen in the same step.
+	minSeverity = strings.ToUpper(minSeverity)
 	validSeverities := map[string]bool{
 		"LOW":      true,
 		"MEDIUM":   true,
 		"HIGH":     true,
 		"CRITICAL": true,
 	}
-	if !validSeverities[strings.ToUpper(minSeverity)] {
+	if !validSeverities[minSeverity] {
 		return fmt.Errorf("invalid severity level: %s", minSeverity)
 	}
 
@@ -309,8 +312,7 @@ func runAuditWithTimeout(cmd *cobra.Command, mask scan.CheckMask) error {
 
 func outputResults(cmd *cobra.Command, result *audit.Result, mask scan.CheckMask) error {
 	if result == nil || len(result.Results) == 0 {
-		fmt.Println("No results to display.")
-		return nil
+		return fmt.Errorf("audit produced no results")
 	}
 
 	format := "text"

--- a/cmd/commands/software.go
+++ b/cmd/commands/software.go
@@ -14,13 +14,16 @@ var softwareCmd = &cobra.Command{
 	Use:   "software",
 	Short: "List installed software on the host",
 	Long:  `The software command gathers and lists the installed software packages from the host operating system, including version details where available.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		software, err := softwarelist.GetInstalledSoftware()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		software, err := softwarelist.GetInstalledSoftware(cmd.Context())
 		if err != nil {
-			fmt.Println("Error fetching installed software:", err)
-			return
+			return fmt.Errorf("software: %w", err)
 		}
-		fmt.Println(software)
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), software)
+		if err != nil {
+			return fmt.Errorf("failed to write message: %w", err)
+		}
+		return nil
 	},
 }
 

--- a/cmd/owatch/main.go
+++ b/cmd/owatch/main.go
@@ -1,4 +1,4 @@
-// cmd/orkowatch/main.go
+// cmd/owatch/main.go
 package main
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/papa0four/orkowatch
 
 go 1.26.3
 
+toolchain go1.26.5
+
 require (
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/spf13/cobra v1.10.2

--- a/internal/render/enrichment.go
+++ b/internal/render/enrichment.go
@@ -3,6 +3,7 @@ package render
 
 import (
 	"io"
+	"sort"
 
 	"github.com/papa0four/orkowatch/internal/security/enrichment"
 	"github.com/papa0four/orkowatch/internal/security/types"
@@ -124,7 +125,8 @@ func EnrichmentBlock(w io.Writer, d EnrichmentData) error {
 
 	if len(d.Result.Failures) > 0 {
 		ew.printf("\n  Failed enrichments:\n")
-		for cwe, failure := range d.Result.Failures {
+		for _, cwe := range sortedFailureKeys(d.Result.Failures) {
+			failure := d.Result.Failures[cwe]
 			ew.printf("    %s [%s]: %s", cwe, failure.Source, failure.Reason)
 			if failure.Retryable {
 				ew.printf(" (retryable)")
@@ -136,6 +138,18 @@ func EnrichmentBlock(w io.Writer, d EnrichmentData) error {
 	ew.printf("\n")
 	referenceErrors(ew, d.References)
 	return ew.err
+}
+
+// sortedFailureKeys returns the failure map's CWE keys in ascending order,
+// giving both the text block and the serialization converters one shared
+// definition of failure ordering.
+func sortedFailureKeys(failures map[string]enrichment.Failure) []string {
+	keys := make([]string, 0, len(failures))
+	for cwe := range failures {
+		keys = append(keys, cwe)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // referenceErrors writes reference parsing errors as an indented block,
@@ -187,13 +201,16 @@ func EnrichmentEntries(refs types.ReferenceExtraction, res *enrichment.Result) [
 }
 
 // EnrichmentFailures converts enrichment failures into typed serialization
-// structs.
+// structs, sorted by CWE ID so serialized output order is stable across
+// runs -- Go map iteration order is randomized and would otherwise produce
+// nondeterministic diffs in reports.
 func EnrichmentFailures(res *enrichment.Result) []EnrichmentFailure {
 	if res == nil || len(res.Failures) == 0 {
 		return nil
 	}
 	out := make([]EnrichmentFailure, 0, len(res.Failures))
-	for cwe, failure := range res.Failures {
+	for _, cwe := range sortedFailureKeys(res.Failures) {
+		failure := res.Failures[cwe]
 		out = append(out, EnrichmentFailure{
 			CWEID:     cwe,
 			Source:    string(failure.Source),

--- a/internal/report/report_unix.go
+++ b/internal/report/report_unix.go
@@ -47,14 +47,19 @@ func refusedReason(target string) string {
 		}
 	}
 
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return ""
+	homes := make([]string, 0, maxOperatorHomes)
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		homes = append(homes, home)
 	}
-	for _, rel := range userPersistence {
-		base := filepath.Join(home, rel)
-		if pathWithin(target, base) {
-			return base
+	if invoker := invokingUserHome(); invoker != "" && (len(homes) == 0 || invoker != homes[0]) {
+		homes = append(homes, invoker)
+	}
+	for _, home := range homes {
+		for _, rel := range userPersistence {
+			base := filepath.Join(home, rel)
+			if pathWithin(target, base) {
+				return base
+			}
 		}
 	}
 	return ""
@@ -81,7 +86,7 @@ func withinAllowlist(target string) (bool, error) {
 }
 
 func allowlistRoots() []string {
-	roots := make([]string, 0, 2)
+	roots := make([]string, 0, maxOperatorHomes)
 	if cwd, err := os.Getwd(); err == nil {
 		roots = append(roots, cwd)
 	}
@@ -127,6 +132,14 @@ func openAndWrite(target string, data []byte) (err error) {
 			err = cerr
 		}
 	}()
+
+	finfo, serr := f.Stat()
+	if serr != nil {
+		return fmt.Errorf("stat opened destination: %w", serr)
+	}
+	if !finfo.Mode().IsRegular() {
+		return fmt.Errorf("%w: destination replaced during open", ErrNotRegularFile)
+	}
 
 	if _, werr := f.Write(data); werr != nil {
 		return fmt.Errorf("write report: %w", werr)

--- a/internal/report/report_windows.go
+++ b/internal/report/report_windows.go
@@ -34,7 +34,7 @@ func refusedReason(target string) string {
 func refusedBases() []string {
 	startupRel := filepath.Join("Microsoft", "Windows", "Start Menu", "Programs", "Startup")
 
-	bases := make([]string, 0, 5)
+	var bases []string
 	for _, env := range []string{"SystemRoot", "ProgramFiles", "ProgramFiles(x86)"} {
 		if v := os.Getenv(env); v != "" {
 			bases = append(bases, v)
@@ -52,7 +52,7 @@ func refusedBases() []string {
 // canonicalParent returns the OS-resolved long-form path of parent so the
 // location checks cannot be evaded by 8.3 short names, links, or trailing dots
 // and spaces.
-func canonicalParent(parent string) (string, error) {
+func canonicalParent(parent string) (final string, err error) {
 	if strings.HasPrefix(parent, `\\?\`) || strings.HasPrefix(parent, `\\.\`) {
 		return "", fmt.Errorf("%w: extended-length or device path", ErrRefusedLocation)
 	}
@@ -94,7 +94,7 @@ func canonicalParent(parent string) (string, error) {
 		}
 	}
 
-	final := windows.UTF16ToString(buf)
+	final = windows.UTF16ToString(buf)
 	if rest := strings.TrimPrefix(final, `\\?\UNC\`); rest != final {
 		return `\\` + rest, nil
 	}
@@ -124,7 +124,7 @@ func withinAllowlist(target string) (bool, error) {
 }
 
 func allowlistRoots() []string {
-	roots := make([]string, 0, 2)
+	roots := make([]string, 0, maxOperatorHomes)
 	if cwd, err := os.Getwd(); err == nil {
 		roots = append(roots, cwd)
 	}
@@ -232,7 +232,7 @@ func sidTrusted(sid *windows.SID, trusted []*windows.SID) bool {
 }
 
 // openAndWrite writes data to target without traversing a reparse point
-func openAndWrite(target string, data []byte) error {
+func openAndWrite(target string, data []byte) (err error) {
 	if info, err := os.Lstat(target); err == nil {
 		if info.Mode()&(os.ModeSymlink|os.ModeIrregular) != 0 {
 			return fmt.Errorf("%w: reparse point", ErrNotRegularFile)
@@ -271,7 +271,7 @@ func openAndWrite(target string, data []byte) error {
 	}()
 
 	var fi windows.ByHandleFileInformation
-	if ierr := windows.GetFileInformationByHandle(handle, &fi); err != nil {
+	if ierr := windows.GetFileInformationByHandle(handle, &fi); ierr != nil {
 		return fmt.Errorf("inspect destination: %w", ierr)
 	}
 	if fi.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {

--- a/internal/report/write.go
+++ b/internal/report/write.go
@@ -21,6 +21,12 @@ var (
 	ErrElevatedExposedDir  = errors.New("elevated write refused: destination directory is writable by other users")
 )
 
+// maxOperatorHomes bounds the operator identities a write is judged
+// against: the effective user's and, on Unix under sudo, the invoking
+// user's. Windows has no effective/invoking split, but the same bound
+// covers its cwd-plus-home allowlist roots.
+const maxOperatorHomes = 2
+
 // Options carries caller decisions that affect write policy.
 type Options struct {
 	// AllowElevatedWrite is set when --allow-elevated-write is passed

--- a/internal/scan/checks.go
+++ b/internal/scan/checks.go
@@ -97,12 +97,12 @@ const (
 	CategoryEnrichment
 	// CategoryMITRE identifies a composing flag bit (bits 62 - 63)
 	CategoryMITRE
-)
 
-// categoryCount is the number of defined CheckCategory values. It bounds the
-// segments slice in Codes and must be updated if new categories are added to
-// the CheckCategory const block.
-const categoryCount = 4
+	// categoryCount bounds the segments slice in Codes. It is derived from
+	// iota, so it tracks the const block automatically: it must remain the
+	// final entry, and every category above it must remain contiguous.
+	categoryCount
+)
 
 // registryEntry is a single record in the canonical check registry. It binds
 // a CheckMask bit to its short filename code, canonical name, CLI flag name,
@@ -280,7 +280,7 @@ func Codes(mask CheckMask) string {
 			prefixed = append(prefixed, seg...)
 			parts = append(parts, string(prefixed))
 		} else {
-			// unprefixes segment
+			// unprefixed segment
 			parts = append(parts, string(seg))
 		}
 	}
@@ -306,10 +306,13 @@ func EnabledChecks(mask CheckMask) []string {
 // OR-ing the bits of all matching registry entries within category. Only
 // entries whose category matches the supplied category are accepted; entries
 // from other categories are rejected to prevent callers from accidentally
-// setting bits outside the intended range. The valid name set is derived
-// dynamically from the registry so the error message stays accurate as new
-// entries are added. It returns an error naming the first unrecognized entry
-// alongside the full valid set for that category.
+// setting bits outside the intended range. CLI flag aliases are deliberately
+// accepted alongside canonical names (e.g. --skip-checks fwall resolves to
+// firewall), so an analyst can skip a check by the same token used to enable
+// it; error messages and help text advertise canonical names only. The valid
+// name set is derived dynamically from the registry so the error message
+// stays accurate as new entries are added. It returns an error naming the
+// first unrecognized entry alongside the full valid set for that category.
 func MaskFromNames(names []string, category CheckCategory) (CheckMask, error) {
 	var mask CheckMask
 	for _, name := range names {

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -91,25 +91,25 @@ type (
 
 // NewSecurityAuditor creates a new security auditor based on the OS
 func NewSecurityAuditor(opts Options) *SecurityAuditor {
-	ctx := registry.DetectOS()
+	osCtx := registry.DetectOS()
 
 	auditor := &SecurityAuditor{
 		verbose:   opts.Verbose,
 		options:   opts,
-		osContext: ctx,
+		osContext: osCtx,
 	}
 
 	switch runtime.GOOS {
 	case "windows":
-		auditor.sshChecker = checker.NewWindowsSSHChecker(ctx)
-		auditor.firewallChecker = checker.NewWindowsFirewallChecker(ctx)
-		auditor.userChecker = checker.NewWindowsUserChecker(ctx)
-		auditor.permissionChecker = checker.NewWindowsPermissionChecker(ctx, opts.FilePermsPath)
+		auditor.sshChecker = checker.NewWindowsSSHChecker(osCtx)
+		auditor.firewallChecker = checker.NewWindowsFirewallChecker(osCtx)
+		auditor.userChecker = checker.NewWindowsUserChecker(osCtx)
+		auditor.permissionChecker = checker.NewWindowsPermissionChecker(osCtx, opts.FilePermsPath)
 	default:
-		auditor.sshChecker = checker.NewUnixSSHChecker(ctx)
-		auditor.firewallChecker = checker.NewUnixFirewallChecker(ctx)
-		auditor.userChecker = checker.NewUnixUserChecker(ctx)
-		auditor.permissionChecker = checker.NewUnixPermissionChecker(ctx, opts.FilePermsPath)
+		auditor.sshChecker = checker.NewUnixSSHChecker(osCtx)
+		auditor.firewallChecker = checker.NewUnixFirewallChecker(osCtx)
+		auditor.userChecker = checker.NewUnixUserChecker(osCtx)
+		auditor.permissionChecker = checker.NewUnixPermissionChecker(osCtx, opts.FilePermsPath)
 	}
 
 	return auditor
@@ -277,7 +277,6 @@ func aggregateReferences(results []types.AuditResult) types.ReferenceExtraction 
 			ext.CWEs = append(ext.CWEs, id)
 		}
 		ext.Errors = append(ext.Errors, sub.Errors...)
-		ext.Other = append(ext.Other, sub.Other...)
 	}
 	return ext
 }

--- a/internal/security/audit/audit.go
+++ b/internal/security/audit/audit.go
@@ -16,75 +16,78 @@ import (
 	"github.com/papa0four/orkowatch/internal/security/types"
 )
 
-// SecurityAuditor handles the orchestration of security checks
-type SecurityAuditor struct {
-	sshChecker        checker.SSHChecker
-	firewallChecker   checker.FirewallChecker
-	userChecker       checker.UserChecker
-	permissionChecker checker.PermissionChecker
-	verbose           bool
-	options           Options
-	osContext         registry.OSContext
-}
+type (
+	// SecurityAuditor handles the orchestration of security checks
+	SecurityAuditor struct {
+		sshChecker        checker.SSHChecker
+		firewallChecker   checker.FirewallChecker
+		userChecker       checker.UserChecker
+		permissionChecker checker.PermissionChecker
+		verbose           bool
+		options           Options
+		osContext         registry.OSContext
+	}
 
-// Options configures the audit process
-type Options struct {
-	Verbose        bool
-	SpecificChecks []string
-	SkipChecks     []string
-	FilePermsPath  string
-	MinSeverity    string
-	Timeout        time.Duration
-	Enrich         bool
-	HostInfo       *osfingerprint.OSInfo
-}
+	// Options configures the audit process. The run's deadline is not part of
+	// Options: it arrives as the context passed to RunAudit, owned by the
+	// command layer, and bounds checks and enrichment together as one budget.
+	Options struct {
+		Verbose        bool
+		SpecificChecks []string
+		SkipChecks     []string
+		FilePermsPath  string
+		MinSeverity    string
+		Enrich         bool
+		HostInfo       *osfingerprint.OSInfo
+	}
 
-// Result represents the complete audit results
-type Result struct {
-	StartTime           time.Time
-	EndTime             time.Time
-	Duration            time.Duration
-	Results             []types.AuditResult
-	SystemInfo          SystemInfo
-	Summary             Summary
-	EnrichmentRequested bool
-	EnrichmentError     error
-	Enrichment          *enrichment.Result
-	References          types.ReferenceExtraction
-}
+	// Result represents the complete audit results
+	Result struct {
+		StartTime           time.Time
+		EndTime             time.Time
+		Duration            time.Duration
+		Results             []types.AuditResult
+		SystemInfo          SystemInfo
+		Summary             Summary
+		EnrichmentRequested bool
+		EnrichmentError     error
+		Enrichment          *enrichment.Result
+		References          types.ReferenceExtraction
+	}
 
-// SystemInfo contains basic system information collected at the start of an
-// audit. Software inventory is owned by the all command and is not part of
-// the audit subsystem -- see cmd/commands/all.go and internal/softwarelist.
-type SystemInfo struct {
-	OS            string `json:"os" yaml:"os"`
-	Architecture  string `json:"architecture" yaml:"architecture"`
-	Hostname      string `json:"hostname" yaml:"hostname"`
-	KernelVersion string `json:"kernel_version" yaml:"kernel_version"`
-}
+	// SystemInfo contains basic system information collected at the start of an
+	// audit. Software inventory is owned by the all command and is not part of
+	// the audit subsystem -- see cmd/commands/all.go and internal/softwarelist.
+	SystemInfo struct {
+		OS            string `json:"os" yaml:"os"`
+		Architecture  string `json:"architecture" yaml:"architecture"`
+		Hostname      string `json:"hostname" yaml:"hostname"`
+		KernelVersion string `json:"kernel_version" yaml:"kernel_version"`
+	}
 
-// Summary reports the outcome of a completed audit at both check and finding
-// level. PassedChecks counts checks that completed with zero findings.
-// SkippedChecks counts checks excluded via --skip-checks. Finding counts are
-// broken down by severity so the analyst can assess exposure at a glance
-// without reading individual check output. TotalFindings is the sum of all
-// severity buckets.
-type Summary struct {
-	TotalChecks      int
-	PassedChecks     int
-	SkippedChecks    int
-	TotalFindings    int
-	CriticalFindings int
-	HighFindings     int
-	MediumFindings   int
-	LowFindings      int
-}
+	// Summary reports the outcome of a completed audit at both check and finding
+	// level. PassedChecks counts checks that completed with zero findings.
+	// SkippedChecks counts checks excluded via --skip-checks. Finding counts are
+	// broken down by severity so the analyst can assess exposure at a glance
+	// without reading individual check output. TotalFindings is the sum of all
+	// severity buckets.
+	Summary struct {
+		TotalChecks      int
+		PassedChecks     int
+		SkippedChecks    int
+		TotalFindings    int
+		CriticalFindings int
+		HighFindings     int
+		MediumFindings   int
+		LowFindings      int
+	}
 
-// checkRunner pairs a check's canonical name with its execution function
-type checkRunner struct {
-	name string
-	run  func() types.AuditResult
-}
+	// checkRunner pairs a check's canonical name with its execution function
+	checkRunner struct {
+		name string
+		run  func(ctx context.Context) types.AuditResult
+	}
+)
 
 // NewSecurityAuditor creates a new security auditor based on the OS
 func NewSecurityAuditor(opts Options) *SecurityAuditor {
@@ -112,8 +115,10 @@ func NewSecurityAuditor(opts Options) *SecurityAuditor {
 	return auditor
 }
 
-// RunAudit performs the security audit with the specified options
-func (sa *SecurityAuditor) RunAudit() (*Result, error) {
+// RunAudit performs the security audit with the specified options. ctx
+// bounds the entire run -- checks and enrichment share its deadline -- and
+// cancellation propagates into checker exec and filesystem work.
+func (sa *SecurityAuditor) RunAudit(ctx context.Context) (*Result, error) {
 	fingerprint := sa.options.HostInfo
 	if fingerprint == nil {
 		var err error
@@ -138,27 +143,27 @@ func (sa *SecurityAuditor) RunAudit() (*Result, error) {
 			var checkResult types.AuditResult
 			switch check {
 			case "ssh":
-				checkResult = timeCheck(sa.sshChecker.Check)
+				checkResult = timeCheck(ctx, sa.sshChecker.Check)
 				result.Results = append(result.Results, checkResult)
 			case "firewall":
-				checkResult = timeCheck(sa.firewallChecker.Check)
+				checkResult = timeCheck(ctx, sa.firewallChecker.Check)
 				result.Results = append(result.Results, checkResult)
 			case "users":
-				checkResult = timeCheck(sa.userChecker.Check)
+				checkResult = timeCheck(ctx, sa.userChecker.Check)
 				result.Results = append(result.Results, checkResult)
 			case "permissions":
-				checkResult = timeCheck(sa.permissionChecker.Check)
+				checkResult = timeCheck(ctx, sa.permissionChecker.Check)
 				result.Results = append(result.Results, checkResult)
 			}
 		}
-		sa.finalize(result)
+		sa.finalize(ctx, result)
 		return result, nil
 	}
 
-	return sa.runAllChecks(result)
+	return sa.runAllChecks(ctx, result)
 }
 
-func (sa *SecurityAuditor) runAllChecks(result *Result) (*Result, error) {
+func (sa *SecurityAuditor) runAllChecks(ctx context.Context, result *Result) (*Result, error) {
 	if sa.verbose {
 		fmt.Println("[*] Starting comprehensive security audit...")
 	}
@@ -178,7 +183,7 @@ func (sa *SecurityAuditor) runAllChecks(result *Result) (*Result, error) {
 			if sa.verbose {
 				fmt.Printf("[*] Running %s check...\n", c.name)
 			}
-			resultsChan <- timeCheck(c.run)
+			resultsChan <- timeCheck(ctx, c.run)
 		}(check)
 	}
 
@@ -191,7 +196,7 @@ func (sa *SecurityAuditor) runAllChecks(result *Result) (*Result, error) {
 		result.Results = append(result.Results, checkResult)
 	}
 
-	sa.finalize(result)
+	sa.finalize(ctx, result)
 	return result, nil
 }
 
@@ -222,7 +227,11 @@ func (sa *SecurityAuditor) activeChecks() []checkRunner {
 	return active
 }
 
-func (sa *SecurityAuditor) finalize(result *Result) {
+// finalize computes duration, summary, and reference aggregation, then runs
+// enrichment when requested. Enrichment shares the caller's ctx rather than
+// opening a fresh deadline: --timeout is one budget for the whole run, not
+// a separate window per phase.
+func (sa *SecurityAuditor) finalize(ctx context.Context, result *Result) {
 	result.EndTime = time.Now()
 	result.Duration = result.EndTime.Sub(result.StartTime)
 	result.Summary = sa.calculateSummary(result.Results)
@@ -241,9 +250,6 @@ func (sa *SecurityAuditor) finalize(result *Result) {
 	if len(result.References.CWEs) == 0 {
 		return
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), sa.options.Timeout)
-	defer cancel()
 
 	req := enrichment.EnrichRequest{
 		CWEs:        result.References.CWEs,
@@ -335,9 +341,9 @@ func systemInfoFrom(info *osfingerprint.OSInfo) SystemInfo {
 	}
 }
 
-func timeCheck(fn func() types.AuditResult) types.AuditResult {
+func timeCheck(ctx context.Context, fn func(context.Context) types.AuditResult) types.AuditResult {
 	start := time.Now()
-	result := fn()
+	result := fn(ctx)
 	end := time.Now()
 	result.StartTime = start
 	result.EndTime = end

--- a/internal/security/checker/constants.go
+++ b/internal/security/checker/constants.go
@@ -11,22 +11,16 @@ const (
 	passwdFieldHomeDir  = 5
 	passwdFieldShell    = 6
 	passwdFieldCount    = 7
-)
 
-// Minimum field counts for Unix authentication files.
-const (
+	// Minimum field counts for Unix authentication files.
 	shadowMinFields       = 2
 	passwdMinFieldsForUID = 3
-)
 
-// /etc/group field indices and minimum field count as defined by POSIX.
-const (
+	// /etc/group field indices and minimum field count as defined by POSIX.
 	groupFieldMembers = 3
 	groupFieldCount   = 4
-)
 
-// macOS starts regular user UIDs at 500; Linux and BSD start at 1000.
-const (
+	// macOS starts regular user UIDs at 500; Linux and BSD start at 1000.
 	minUIDMacOS   = 500
 	minUIDDefault = 1000
 	rootUID       = 0

--- a/internal/security/checker/firewall.go
+++ b/internal/security/checker/firewall.go
@@ -18,22 +18,22 @@ type FirewallChecker interface {
 
 // UnixFirewallChecker implements FirewallChecker for Unix-like systems
 type UnixFirewallChecker struct {
-	ctx registry.OSContext
+	osCtx registry.OSContext
 }
 
 // WindowsFirewallChecker implements FirewallChecker for Windows systems
 type WindowsFirewallChecker struct {
-	ctx registry.OSContext
+	osCtx registry.OSContext
 }
 
 // NewUnixFirewallChecker creates a new Unix firewall checker
-func NewUnixFirewallChecker(ctx registry.OSContext) *UnixFirewallChecker {
-	return &UnixFirewallChecker{ctx: ctx}
+func NewUnixFirewallChecker(osCtx registry.OSContext) *UnixFirewallChecker {
+	return &UnixFirewallChecker{osCtx: osCtx}
 }
 
 // NewWindowsFirewallChecker creates a new Windows firewall checker
-func NewWindowsFirewallChecker(ctx registry.OSContext) *WindowsFirewallChecker {
-	return &WindowsFirewallChecker{ctx: ctx}
+func NewWindowsFirewallChecker(osCtx registry.OSContext) *WindowsFirewallChecker {
+	return &WindowsFirewallChecker{osCtx: osCtx}
 }
 
 // firewallTool represents a firewall management tool
@@ -97,7 +97,7 @@ func (f *UnixFirewallChecker) Check(ctx context.Context) types.AuditResult {
 		result.Description = "No active firewall detected"
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s WARNING: No active firewall detected", types.SymbolWarning))
-		if def, ok := registry.Lookup(f.ctx, "firewall.no_active_manager"); ok {
+		if def, ok := registry.Lookup(f.osCtx, "firewall.no_active_manager"); ok {
 			result.Findings = append(result.Findings, types.Finding{
 				Title:       def.Title,
 				Severity:    def.Severity,
@@ -159,7 +159,7 @@ func (f *WindowsFirewallChecker) Check(ctx context.Context) types.AuditResult {
 
 	// One finding per inactive profile
 	if inactiveProfiles > 0 && activeProfiles > 0 {
-		if def, ok := registry.Lookup(f.ctx, "firewall.profile_inactive"); ok {
+		if def, ok := registry.Lookup(f.osCtx, "firewall.profile_inactive"); ok {
 			result.Findings = append(result.Findings, types.Finding{
 				Title:       def.Title,
 				Severity:    def.Severity,
@@ -191,7 +191,7 @@ func (f *WindowsFirewallChecker) Check(ctx context.Context) types.AuditResult {
 		result.Description = "Windows Firewall is disabled for all profiles"
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s CRITICAL: Windows Firewall is completely disabled", types.SymbolCritical))
-		if def, ok := registry.Lookup(f.ctx, "firewall.all_profiles_disabled"); ok {
+		if def, ok := registry.Lookup(f.osCtx, "firewall.all_profiles_disabled"); ok {
 			result.Findings = append(result.Findings, types.Finding{
 				Title:       def.Title,
 				Severity:    def.Severity,

--- a/internal/security/checker/firewall.go
+++ b/internal/security/checker/firewall.go
@@ -2,6 +2,7 @@
 package checker
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -12,7 +13,7 @@ import (
 
 // FirewallChecker defines interface for Firewall configuration checking
 type FirewallChecker interface {
-	Check() types.AuditResult
+	Check(ctx context.Context) types.AuditResult
 }
 
 // UnixFirewallChecker implements FirewallChecker for Unix-like systems
@@ -43,7 +44,7 @@ type firewallTool struct {
 }
 
 // Check implements FirewallChecker interface for Unix systems
-func (f *UnixFirewallChecker) Check() types.AuditResult {
+func (f *UnixFirewallChecker) Check(ctx context.Context) types.AuditResult {
 	result := types.AuditResult{
 		Name:        "Firewall Configuration",
 		Status:      "CHECKING",
@@ -77,7 +78,7 @@ func (f *UnixFirewallChecker) Check() types.AuditResult {
 
 	activeFirewalls := 0
 	for _, fw := range firewalls {
-		cmd := exec.Command(fw.command[0], fw.command[1:]...) // #nosec G204 -- command args sourced from hardcoded firewallTool struct definitions, not user input
+		cmd := exec.CommandContext(ctx, fw.command[0], fw.command[1:]...) // #nosec G204 -- command args sourced from hardcoded firewallTool struct definitions, not user input
 		output, err := cmd.CombinedOutput()
 
 		if err == nil && len(output) > 0 {
@@ -120,7 +121,7 @@ func (f *UnixFirewallChecker) Check() types.AuditResult {
 }
 
 // Check implements FirewallChecker interface for Windows systems
-func (f *WindowsFirewallChecker) Check() types.AuditResult {
+func (f *WindowsFirewallChecker) Check(ctx context.Context) types.AuditResult {
 	result := types.AuditResult{
 		Name:        "Windows Firewall Configuration",
 		Status:      "CHECKING",
@@ -130,7 +131,7 @@ func (f *WindowsFirewallChecker) Check() types.AuditResult {
 	}
 
 	// Check firewall status for all profiles
-	cmd := exec.Command("netsh", "advfirewall", "show", "allprofiles", "state")
+	cmd := exec.CommandContext(ctx, "netsh", "advfirewall", "show", "allprofiles", "state")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		result.Status = "ERROR"
@@ -172,7 +173,7 @@ func (f *WindowsFirewallChecker) Check() types.AuditResult {
 
 	// Check firewall rules if at least one profile is active
 	if activeProfiles > 0 {
-		cmd = exec.Command("netsh", "advfirewall", "firewall", "show", "rule", "name=all", "verbose")
+		cmd = exec.CommandContext(ctx, "netsh", "advfirewall", "firewall", "show", "rule", "name=all", "verbose")
 		output, err := cmd.CombinedOutput()
 		if err == nil {
 			rules := parseWindowsFirewallRules(string(output))

--- a/internal/security/checker/firewall.go
+++ b/internal/security/checker/firewall.go
@@ -175,7 +175,10 @@ func (f *WindowsFirewallChecker) Check(ctx context.Context) types.AuditResult {
 	if activeProfiles > 0 {
 		cmd = exec.CommandContext(ctx, "netsh", "advfirewall", "firewall", "show", "rule", "name=all", "verbose")
 		output, err := cmd.CombinedOutput()
-		if err == nil {
+		if err != nil {
+			result.Details = append(result.Details,
+				fmt.Sprintf("%s Error enumerating firewall rules: %v", types.SymbolError, err))
+		} else {
 			rules := parseWindowsFirewallRules(string(output))
 			result.Details = append(result.Details, "\nActive Firewall Rules:")
 			for _, rule := range rules {

--- a/internal/security/checker/permissions.go
+++ b/internal/security/checker/permissions.go
@@ -43,6 +43,38 @@ const (
 // findScanTimeout bounds each FS-wide find operation to prevent audit hang
 const findScanTimeout = 60 * time.Second
 
+type (
+	// PermissionChecker defines interface for permission checking. Check
+	// honors ctx cancellation: exec invocations and filesystem walks stop
+	// when the caller's deadline expires.
+	PermissionChecker interface {
+		Check(ctx context.Context) types.AuditResult
+	}
+
+	// UnixPermissionChecker implements PermissionChecker for Unix-like systems
+	UnixPermissionChecker struct {
+		paths    []criticalPath
+		osType   string
+		scanRoot string
+		ctx      registry.OSContext
+	}
+
+	// WindowsPermissionChecker implements PermissionChecker for Windows systems
+	WindowsPermissionChecker struct {
+		Paths    []string
+		ctx      registry.OSContext
+		scanRoot string
+	}
+
+	// criticalPath represents a path that needs permission checking
+	criticalPath struct {
+		path        string
+		description string
+		expected    os.FileMode
+		recursive   bool
+	}
+)
+
 // countUnreadablePaths counts the paths find could not read, i.e. permission denied
 func countUnreadablePaths(stderr []byte) int {
 	if len(stderr) == 0 {
@@ -58,8 +90,8 @@ func countUnreadablePaths(stderr []byte) int {
 }
 
 // runBoundedFind executes find rooted at "/" and is bounded by findScanTimeout
-func runBoundedFind(root string, args []string) (output []byte, skipped int, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), findScanTimeout)
+func runBoundedFind(ctx context.Context, root string, args []string) (output []byte, skipped int, err error) {
+	ctx, cancel := context.WithTimeout(ctx, findScanTimeout)
 	defer cancel()
 
 	full := append([]string{root, "-xdev"}, args...)
@@ -106,34 +138,6 @@ func appendSkippedNote(result *types.AuditResult, scan string, skipped int) {
 			types.SymbolInfo, scan, skipped))
 }
 
-// PermissionChecker defines interface for permission checking
-type PermissionChecker interface {
-	Check() types.AuditResult
-}
-
-// UnixPermissionChecker implements PermissionChecker for Unix-like systems
-type UnixPermissionChecker struct {
-	paths    []criticalPath
-	osType   string
-	scanRoot string
-	ctx      registry.OSContext
-}
-
-// WindowsPermissionChecker implements PermissionChecker for Windows systems
-type WindowsPermissionChecker struct {
-	Paths    []string
-	ctx      registry.OSContext
-	scanRoot string
-}
-
-// criticalPath represents a path that needs permission checking
-type criticalPath struct {
-	path        string
-	description string
-	expected    os.FileMode
-	recursive   bool
-}
-
 // NewUnixPermissionChecker creates a new Unix permission checker
 func NewUnixPermissionChecker(ctx registry.OSContext, scanRoot string) *UnixPermissionChecker {
 	checker := &UnixPermissionChecker{
@@ -163,7 +167,7 @@ func NewWindowsPermissionChecker(ctx registry.OSContext, scanRoot string) *Windo
 }
 
 // Check implements PermissionChecker interface for Unix systems
-func (p *UnixPermissionChecker) Check() types.AuditResult {
+func (p *UnixPermissionChecker) Check(ctx context.Context) types.AuditResult {
 	result := types.AuditResult{
 		Name:        "File Permissions Security",
 		Status:      "CHECKING",
@@ -173,7 +177,7 @@ func (p *UnixPermissionChecker) Check() types.AuditResult {
 
 	if p.scanRoot == "" {
 		for _, cpath := range p.paths {
-			if err := p.checkPathPermissions(cpath, &result); err != nil {
+			if err := p.checkPathPermissions(ctx, cpath, &result); err != nil {
 				result.Details = append(result.Details,
 					fmt.Sprintf("%s Error checking %s: %v",
 						types.SymbolError, cpath.path, err))
@@ -181,9 +185,9 @@ func (p *UnixPermissionChecker) Check() types.AuditResult {
 		}
 	}
 
-	p.checkSUIDFiles(&result)
-	p.checkWorldWritableFiles(&result)
-	p.checkUnownedFiles(&result)
+	p.checkSUIDFiles(ctx, &result)
+	p.checkWorldWritableFiles(ctx, &result)
+	p.checkUnownedFiles(ctx, &result)
 
 	result.Status = "COMPLETED"
 	return result
@@ -234,7 +238,7 @@ func (p *UnixPermissionChecker) getCriticalPathConfigs() []criticalPath {
 	return configs
 }
 
-func (p *UnixPermissionChecker) checkPathPermissions(cp criticalPath, result *types.AuditResult) error {
+func (p *UnixPermissionChecker) checkPathPermissions(ctx context.Context, cp criticalPath, result *types.AuditResult) error {
 	info, err := os.Stat(cp.path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -268,6 +272,11 @@ func (p *UnixPermissionChecker) checkPathPermissions(cp criticalPath, result *ty
 
 	if cp.recursive && info.IsDir() {
 		return filepath.Walk(cp.path, func(path string, info os.FileInfo, err error) error {
+			// Abort the walk as soon as the caller's deadline expires;
+			// returning the ctx error stops filepath.Walk immediately.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
 			if err != nil {
 				return nil // Skip files we can't access
 			}
@@ -285,9 +294,9 @@ func (p *UnixPermissionChecker) checkPathPermissions(cp criticalPath, result *ty
 	return nil
 }
 
-func (p *UnixPermissionChecker) checkSUIDFiles(result *types.AuditResult) {
+func (p *UnixPermissionChecker) checkSUIDFiles(ctx context.Context, result *types.AuditResult) {
 	const scan string = "SUID/SGID scan"
-	output, skipped, err := runBoundedFind(p.effectiveRoot(), []string{
+	output, skipped, err := runBoundedFind(ctx, p.effectiveRoot(), []string{
 		"-type", "f",
 		"(", "-perm", findPermSUID, "-o", "-perm", findPermSGID, ")",
 	})
@@ -318,9 +327,9 @@ func (p *UnixPermissionChecker) checkSUIDFiles(result *types.AuditResult) {
 	appendSkippedNote(result, scan, skipped)
 }
 
-func (p *UnixPermissionChecker) checkWorldWritableFiles(result *types.AuditResult) {
+func (p *UnixPermissionChecker) checkWorldWritableFiles(ctx context.Context, result *types.AuditResult) {
 	const scan string = "World-writable scan"
-	output, skipped, err := runBoundedFind(p.effectiveRoot(), []string{
+	output, skipped, err := runBoundedFind(ctx, p.effectiveRoot(), []string{
 		"-type", "f",
 		"-perm", findPermWorldWritable,
 		"-not", "-type", "l",
@@ -353,9 +362,9 @@ func (p *UnixPermissionChecker) checkWorldWritableFiles(result *types.AuditResul
 	appendSkippedNote(result, scan, skipped)
 }
 
-func (p *UnixPermissionChecker) checkUnownedFiles(result *types.AuditResult) {
+func (p *UnixPermissionChecker) checkUnownedFiles(ctx context.Context, result *types.AuditResult) {
 	const scan string = "Unowned-files scan"
-	output, skipped, err := runBoundedFind(p.effectiveRoot(), []string{
+	output, skipped, err := runBoundedFind(ctx, p.effectiveRoot(), []string{
 		"-nouser", "-o", "-nogroup",
 		"-ls",
 	})
@@ -387,7 +396,7 @@ func (p *UnixPermissionChecker) checkUnownedFiles(result *types.AuditResult) {
 }
 
 // Check implements PermissionChecker interface for Windows systems
-func (p *WindowsPermissionChecker) Check() types.AuditResult {
+func (p *WindowsPermissionChecker) Check(ctx context.Context) types.AuditResult {
 	result := types.AuditResult{
 		Name:        "Windows File Permissions Security",
 		Status:      "CHECKING",
@@ -397,7 +406,7 @@ func (p *WindowsPermissionChecker) Check() types.AuditResult {
 	}
 
 	if p.scanRoot != "" {
-		if err := p.checkWindowsPermissions(p.scanRoot, true, &result); err != nil {
+		if err := p.checkWindowsPermissions(ctx, p.scanRoot, true, &result); err != nil {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s Error checking %s, %v",
 					types.SymbolError, p.scanRoot, err))
@@ -407,7 +416,7 @@ func (p *WindowsPermissionChecker) Check() types.AuditResult {
 	}
 
 	for _, path := range p.Paths {
-		if err := p.checkWindowsPermissions(path, false, &result); err != nil {
+		if err := p.checkWindowsPermissions(ctx, path, false, &result); err != nil {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s Error checking %s: %v",
 					types.SymbolError, path, err))
@@ -415,15 +424,15 @@ func (p *WindowsPermissionChecker) Check() types.AuditResult {
 	}
 
 	// Check for potentially insecure shares
-	p.checkNetworkShares(&result)
+	p.checkNetworkShares(ctx, &result)
 
 	result.Status = "COMPLETED"
 	return result
 }
 
-func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, recursive bool, result *types.AuditResult) error {
+func (p *WindowsPermissionChecker) checkWindowsPermissions(ctx context.Context, path string, recursive bool, result *types.AuditResult) error {
 	const scan string = "ACL traversal"
-	output, skipped, err := runICACLS(path, recursive)
+	output, skipped, err := runICACLS(ctx, path, recursive)
 	if err != nil {
 		return fmt.Errorf("failed to check permissions: %w", err)
 	}
@@ -485,13 +494,15 @@ func (p *WindowsPermissionChecker) checkWindowsPermissions(path string, recursiv
 	return nil
 }
 
-// runICACLS executes against the given path with optional recursion for tree traversal
-func runICACLS(path string, recursive bool) (output []byte, skipped int, err error) {
+// runICACLS executes against the given path with optional recursion for tree
+// traversal. ctx bounds the invocation; icacls /T over a large tree is the
+// slowest operation in the Windows permission path.
+func runICACLS(ctx context.Context, path string, recursive bool) (output []byte, skipped int, err error) {
 	args := []string{path}
 	if recursive {
 		args = append(args, "/T")
 	}
-	cmd := exec.Command("icacls", args...) // #nosec G204 -- path validated by caller; flags are fixed literals
+	cmd := exec.CommandContext(ctx, "icacls", args...) // #nosec G204 -- path validated by caller; flags are fixed literals
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -521,7 +532,7 @@ func countDeniedPaths(stderr []byte) int {
 	return count
 }
 
-func (p *WindowsPermissionChecker) checkNetworkShares(result *types.AuditResult) {
+func (p *WindowsPermissionChecker) checkNetworkShares(ctx context.Context, result *types.AuditResult) {
 	cmd := exec.Command("net", "share")
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/security/checker/permissions.go
+++ b/internal/security/checker/permissions.go
@@ -26,15 +26,11 @@ const (
 	permStandardDir    os.FileMode = 0755
 	permPrivateDir     os.FileMode = 0700
 	permReadOnlyDir    os.FileMode = 0555
-)
 
-// Permission bit masks
-const (
+	// Permission bit masks
 	bitWorldWritable os.FileMode = 0002
-)
 
-// find command permission arguments
-const (
+	// find command permission arguments
 	findPermSUID          = "-4000"
 	findPermSGID          = "-2000"
 	findPermWorldWritable = "-0002"
@@ -56,13 +52,13 @@ type (
 		paths    []criticalPath
 		osType   string
 		scanRoot string
-		ctx      registry.OSContext
+		osCtx    registry.OSContext
 	}
 
 	// WindowsPermissionChecker implements PermissionChecker for Windows systems
 	WindowsPermissionChecker struct {
 		Paths    []string
-		ctx      registry.OSContext
+		osCtx    registry.OSContext
 		scanRoot string
 	}
 
@@ -139,11 +135,11 @@ func appendSkippedNote(result *types.AuditResult, scan string, skipped int) {
 }
 
 // NewUnixPermissionChecker creates a new Unix permission checker
-func NewUnixPermissionChecker(ctx registry.OSContext, scanRoot string) *UnixPermissionChecker {
+func NewUnixPermissionChecker(osCtx registry.OSContext, scanRoot string) *UnixPermissionChecker {
 	checker := &UnixPermissionChecker{
 		osType:   runtime.GOOS,
 		scanRoot: scanRoot,
-		ctx:      ctx,
+		osCtx:    osCtx,
 	}
 
 	// Set default critical paths based on OS
@@ -152,7 +148,7 @@ func NewUnixPermissionChecker(ctx registry.OSContext, scanRoot string) *UnixPerm
 }
 
 // NewWindowsPermissionChecker creates a new Windows permission checker
-func NewWindowsPermissionChecker(ctx registry.OSContext, scanRoot string) *WindowsPermissionChecker {
+func NewWindowsPermissionChecker(osCtx registry.OSContext, scanRoot string) *WindowsPermissionChecker {
 	return &WindowsPermissionChecker{
 		Paths: []string{
 			"C:\\Windows\\System32",
@@ -161,7 +157,7 @@ func NewWindowsPermissionChecker(ctx registry.OSContext, scanRoot string) *Windo
 			"C:\\ProgramData",
 			"C:\\Users",
 		},
-		ctx:      ctx,
+		osCtx:    osCtx,
 		scanRoot: scanRoot,
 	}
 }
@@ -254,7 +250,7 @@ func (p *UnixPermissionChecker) checkPathPermissions(ctx context.Context, cp cri
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s WARNING: %s (%s) has permissions %v, expected %v",
 				types.SymbolWarning, cp.path, cp.description, mode.Perm(), cp.expected))
-		if def, ok := registry.Lookup(p.ctx, "permissions.path_exceeds_expected_mode"); ok {
+		if def, ok := registry.Lookup(p.osCtx, "permissions.path_exceeds_expected_mode"); ok {
 			result.Findings = append(result.Findings, types.Finding{
 				Title:       def.Title,
 				Severity:    def.Severity,
@@ -313,7 +309,7 @@ func (p *UnixPermissionChecker) checkSUIDFiles(ctx context.Context, result *type
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
-		if def, ok := registry.Lookup(p.ctx, "permissions.suid_sgid_binary"); ok {
+		if def, ok := registry.Lookup(p.osCtx, "permissions.suid_sgid_binary"); ok {
 			result.Findings = append(result.Findings, types.Finding{
 				Title:       def.Title,
 				Severity:    def.Severity,
@@ -348,7 +344,7 @@ func (p *UnixPermissionChecker) checkWorldWritableFiles(ctx context.Context, res
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
-		if def, ok := registry.Lookup(p.ctx, "permissions.world_writable_file"); ok {
+		if def, ok := registry.Lookup(p.osCtx, "permissions.world_writable_file"); ok {
 			result.Findings = append(result.Findings, types.Finding{
 				Title:       def.Title,
 				Severity:    def.Severity,
@@ -381,7 +377,7 @@ func (p *UnixPermissionChecker) checkUnownedFiles(ctx context.Context, result *t
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolWarning, file))
 		}
-		if def, ok := registry.Lookup(p.ctx, "permissions.unowned_file"); ok {
+		if def, ok := registry.Lookup(p.osCtx, "permissions.unowned_file"); ok {
 			result.Findings = append(result.Findings, types.Finding{
 				Title:       def.Title,
 				Severity:    def.Severity,
@@ -408,7 +404,7 @@ func (p *WindowsPermissionChecker) Check(ctx context.Context) types.AuditResult 
 	if p.scanRoot != "" {
 		if err := p.checkWindowsPermissions(ctx, p.scanRoot, true, &result); err != nil {
 			result.Details = append(result.Details,
-				fmt.Sprintf("%s Error checking %s, %v",
+				fmt.Sprintf("%s Error checking %s: %v",
 					types.SymbolError, p.scanRoot, err))
 		}
 		result.Status = "COMPLETED"
@@ -454,7 +450,7 @@ func (p *WindowsPermissionChecker) checkWindowsPermissions(ctx context.Context, 
 				fmt.Sprintf("%s WARNING: Full control granted to Everyone group on %s",
 					types.SymbolWarning, line))
 			if !everyoneFindingAdded {
-				if def, ok := registry.Lookup(p.ctx, "permissions.everyone_full_control"); ok {
+				if def, ok := registry.Lookup(p.osCtx, "permissions.everyone_full_control"); ok {
 					result.Findings = append(result.Findings, types.Finding{
 						Title:       def.Title,
 						Severity:    def.Severity,
@@ -472,7 +468,7 @@ func (p *WindowsPermissionChecker) checkWindowsPermissions(ctx context.Context, 
 				fmt.Sprintf("%s WARNING: Full control granted to Users group on %s",
 					types.SymbolWarning, line))
 			if !usersFindingAdded {
-				if def, ok := registry.Lookup(p.ctx, "permissions.users_full_control"); ok {
+				if def, ok := registry.Lookup(p.osCtx, "permissions.users_full_control"); ok {
 					result.Findings = append(result.Findings, types.Finding{
 						Title:       def.Title,
 						Severity:    def.Severity,
@@ -510,6 +506,11 @@ func runICACLS(ctx context.Context, path string, recursive bool) (output []byte,
 
 	runErr := cmd.Run()
 
+	// icacls exits nonzero when any subtree entry is denied while still
+	// emitting valid ACL lines for everything it could read. An ExitError is
+	// therefore deliberately tolerated: partial output plus the denied-path
+	// count is the correct result, and only non-exit failures (binary
+	// missing, ctx kill) abort.
 	var exitErr *exec.ExitError
 	if runErr != nil && !errors.As(runErr, &exitErr) {
 		return nil, 0, runErr
@@ -533,7 +534,7 @@ func countDeniedPaths(stderr []byte) int {
 }
 
 func (p *WindowsPermissionChecker) checkNetworkShares(ctx context.Context, result *types.AuditResult) {
-	cmd := exec.Command("net", "share")
+	cmd := exec.CommandContext(ctx, "net", "share")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		result.Details = append(result.Details,
@@ -560,7 +561,7 @@ func (p *WindowsPermissionChecker) checkNetworkShares(ctx context.Context, resul
 				fmt.Sprintf("%s Administrative share: %s",
 					types.SymbolWarning, share))
 			if !adminShareFindingAdded {
-				if def, ok := registry.Lookup(p.ctx, "permissions.admin_share_present"); ok {
+				if def, ok := registry.Lookup(p.osCtx, "permissions.admin_share_present"); ok {
 					result.Findings = append(result.Findings, types.Finding{
 						Title:       def.Title,
 						Severity:    def.Severity,

--- a/internal/security/checker/ssh.go
+++ b/internal/security/checker/ssh.go
@@ -21,19 +21,19 @@ type SSHChecker interface {
 // UnixSSHChecker implements SSHChecker for Unix-like systems
 type UnixSSHChecker struct {
 	ConfigPaths []string
-	ctx         registry.OSContext
+	osCtx       registry.OSContext
 }
 
 // WindowsSSHChecker implements SSHChecker for Windows systems
 type WindowsSSHChecker struct {
 	ConfigPath string
-	ctx        registry.OSContext
+	osCtx      registry.OSContext
 }
 
 // NewUnixSSHChecker creates a new Unix SSH checker with default paths
-func NewUnixSSHChecker(ctx registry.OSContext) *UnixSSHChecker {
+func NewUnixSSHChecker(osCtx registry.OSContext) *UnixSSHChecker {
 	return &UnixSSHChecker{
-		ctx: ctx,
+		osCtx: osCtx,
 		ConfigPaths: []string{
 			"/etc/ssh/sshd_config",
 			"/private/etc/ssh/sshd_config", // macOS path
@@ -42,10 +42,10 @@ func NewUnixSSHChecker(ctx registry.OSContext) *UnixSSHChecker {
 }
 
 // NewWindowsSSHChecker creates a new Windows SSH checker
-func NewWindowsSSHChecker(ctx registry.OSContext) *WindowsSSHChecker {
+func NewWindowsSSHChecker(osCtx registry.OSContext) *WindowsSSHChecker {
 	return &WindowsSSHChecker{
 		ConfigPath: "C:\\ProgramData\\ssh\\sshd_config",
-		ctx:        ctx,
+		osCtx:      osCtx,
 	}
 }
 
@@ -85,7 +85,7 @@ func (s *UnixSSHChecker) Check(ctx context.Context) types.AuditResult {
 		result.Description = fmt.Sprintf("SSH configuration file not found in any of: %v", s.ConfigPaths)
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s ERROR: No SSH configuration file found", types.SymbolError))
-		if def, ok := registry.Lookup(s.ctx, "ssh.config_not_found"); ok {
+		if def, ok := registry.Lookup(s.osCtx, "ssh.config_not_found"); ok {
 			result.Findings = append(result.Findings, types.Finding{
 				Title:       def.Title,
 				Severity:    def.Severity,
@@ -139,7 +139,7 @@ func (s *UnixSSHChecker) Check(ctx context.Context) types.AuditResult {
 		if config.rootLogin {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: Root login is permitted", types.SymbolWarning))
-			if def, ok := registry.Lookup(s.ctx, "ssh.root_login_permitted"); ok {
+			if def, ok := registry.Lookup(s.osCtx, "ssh.root_login_permitted"); ok {
 				result.Findings = append(result.Findings, types.Finding{
 					Title:       def.Title,
 					Severity:    def.Severity,
@@ -156,7 +156,7 @@ func (s *UnixSSHChecker) Check(ctx context.Context) types.AuditResult {
 	} else {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s WARNING: PermitRootLogin setting not found (defaults may apply)", types.SymbolWarning))
-		if def, ok := registry.Lookup(s.ctx, "ssh.permit_root_login_not_set"); ok {
+		if def, ok := registry.Lookup(s.osCtx, "ssh.permit_root_login_not_set"); ok {
 			result.Findings = append(result.Findings, types.Finding{
 				Title:       def.Title,
 				Severity:    def.Severity,
@@ -173,7 +173,7 @@ func (s *UnixSSHChecker) Check(ctx context.Context) types.AuditResult {
 		if config.passwordAuth {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: Password authentication is enabled", types.SymbolWarning))
-			if def, ok := registry.Lookup(s.ctx, "ssh.password_auth_enabled"); ok {
+			if def, ok := registry.Lookup(s.osCtx, "ssh.password_auth_enabled"); ok {
 				result.Findings = append(result.Findings, types.Finding{
 					Title:       def.Title,
 					Severity:    def.Severity,
@@ -190,7 +190,7 @@ func (s *UnixSSHChecker) Check(ctx context.Context) types.AuditResult {
 	} else {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s WARNING: PasswordAuthentication setting not found (defaults may apply)", types.SymbolWarning))
-		if def, ok := registry.Lookup(s.ctx, "ssh.password_auth_not_set"); ok {
+		if def, ok := registry.Lookup(s.osCtx, "ssh.password_auth_not_set"); ok {
 			result.Findings = append(result.Findings, types.Finding{
 				Title:       def.Title,
 				Severity:    def.Severity,
@@ -233,7 +233,7 @@ func (s *WindowsSSHChecker) Check(ctx context.Context) types.AuditResult {
 		case "Stopped":
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s OpenSSH Server is installed but not running", types.SymbolWarning))
-			if def, ok := registry.Lookup(s.ctx, "ssh.server_not_running"); ok {
+			if def, ok := registry.Lookup(s.osCtx, "ssh.server_not_running"); ok {
 				result.Findings = append(result.Findings, types.Finding{
 					Title:       def.Title,
 					Severity:    def.Severity,
@@ -306,7 +306,7 @@ func (s *WindowsSSHChecker) Check(ctx context.Context) types.AuditResult {
 					if config.rootLogin {
 						result.Details = append(result.Details,
 							fmt.Sprintf("%s WARNING: Root login is permitted", types.SymbolWarning))
-						if def, ok := registry.Lookup(s.ctx, "ssh.root_login_permitted"); ok {
+						if def, ok := registry.Lookup(s.osCtx, "ssh.root_login_permitted"); ok {
 							result.Findings = append(result.Findings, types.Finding{
 								Title:       def.Title,
 								Severity:    def.Severity,
@@ -326,7 +326,7 @@ func (s *WindowsSSHChecker) Check(ctx context.Context) types.AuditResult {
 					if config.passwordAuth {
 						result.Details = append(result.Details,
 							fmt.Sprintf("%s WARNING: Password authentication is enabled", types.SymbolWarning))
-						if def, ok := registry.Lookup(s.ctx, "ssh.password_auth_enabled"); ok {
+						if def, ok := registry.Lookup(s.osCtx, "ssh.password_auth_enabled"); ok {
 							result.Findings = append(result.Findings, types.Finding{
 								Title:       def.Title,
 								Severity:    def.Severity,
@@ -345,7 +345,7 @@ func (s *WindowsSSHChecker) Check(ctx context.Context) types.AuditResult {
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: OpenSSH configuration file not found", types.SymbolWarning))
-			if def, ok := registry.Lookup(s.ctx, "ssh.config_missing"); ok {
+			if def, ok := registry.Lookup(s.osCtx, "ssh.config_missing"); ok {
 				result.Findings = append(result.Findings, types.Finding{
 					Title:       def.Title,
 					Severity:    def.Severity,

--- a/internal/security/checker/ssh.go
+++ b/internal/security/checker/ssh.go
@@ -3,6 +3,7 @@ package checker
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -14,7 +15,7 @@ import (
 
 // SSHChecker defines interface for SSH configuration checking
 type SSHChecker interface {
-	Check() types.AuditResult
+	Check(ctx context.Context) types.AuditResult
 }
 
 // UnixSSHChecker implements SSHChecker for Unix-like systems
@@ -57,7 +58,7 @@ type sshConfig struct {
 }
 
 // Check implements SSHChecker interface for Unix systems
-func (s *UnixSSHChecker) Check() types.AuditResult {
+func (s *UnixSSHChecker) Check(ctx context.Context) types.AuditResult {
 	result := types.AuditResult{
 		Name:        "SSH Configuration",
 		Status:      "CHECKING",
@@ -207,7 +208,7 @@ func (s *UnixSSHChecker) Check() types.AuditResult {
 }
 
 // Check implements SSHChecker interface for Windows systems
-func (s *WindowsSSHChecker) Check() types.AuditResult {
+func (s *WindowsSSHChecker) Check(ctx context.Context) types.AuditResult {
 	result := types.AuditResult{
 		Name:        "Windows SSH Configuration",
 		Status:      "CHECKING",
@@ -219,7 +220,7 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 	sshdInstalled := false
 
 	// Check OpenSSH installation
-	cmd := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-Command",
+	cmd := exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-NonInteractive", "-Command",
 		"(Get-Service -Name sshd -ErrorAction SilentlyContinue).Status")
 	output, err := cmd.CombinedOutput()
 	serviceStatus := strings.TrimSpace(string(output))
@@ -362,7 +363,7 @@ func (s *WindowsSSHChecker) Check() types.AuditResult {
 		result.Details = append(result.Details,
 			fmt.Sprintf("%s PuTTY is installed", types.SymbolInfo))
 
-		cmd = exec.Command("reg", "query", `HKCU\Software\SimonTatham\PuTTY\Sessions`)
+		cmd = exec.CommandContext(ctx, "reg", "query", `HKCU\Software\SimonTatham\PuTTY\Sessions`)
 		output, err := cmd.CombinedOutput()
 		if err == nil && len(output) > 0 {
 			sessions := strings.Split(string(output), "\n")

--- a/internal/security/checker/users.go
+++ b/internal/security/checker/users.go
@@ -38,13 +38,13 @@ type (
 	UnixUserChecker struct {
 		config         platformConfig
 		osType         string
-		ctx            registry.OSContext
+		osCtx          registry.OSContext
 		shadowReadable bool
 	}
 
 	// WindowsUserChecker implements UserChecker for Windows systems
 	WindowsUserChecker struct {
-		ctx registry.OSContext
+		osCtx registry.OSContext
 	}
 
 	// userAccount represents a parsed user account from /etc/passwd and,
@@ -109,17 +109,17 @@ func getPlatformConfig() platformConfig {
 }
 
 // NewUnixUserChecker creates a new Unix user checker with OS-specific settings
-func NewUnixUserChecker(ctx registry.OSContext) *UnixUserChecker {
+func NewUnixUserChecker(osCtx registry.OSContext) *UnixUserChecker {
 	return &UnixUserChecker{
 		config: getPlatformConfig(),
 		osType: runtime.GOOS,
-		ctx:    ctx,
+		osCtx:  osCtx,
 	}
 }
 
 // NewWindowsUserChecker creates a new Windows user checker
-func NewWindowsUserChecker(ctx registry.OSContext) *WindowsUserChecker {
-	return &WindowsUserChecker{ctx: ctx}
+func NewWindowsUserChecker(osCtx registry.OSContext) *WindowsUserChecker {
+	return &WindowsUserChecker{osCtx: osCtx}
 }
 
 // Check implements UserChecker interface for Unix systems
@@ -135,7 +135,7 @@ func (u *UnixUserChecker) Check(ctx context.Context) types.AuditResult {
 	authResult := u.checkAuthConfig()
 	result.Details = append(result.Details, authResult.Details...)
 	for _, key := range authResult.Keys {
-		if def, ok := registry.Lookup(u.ctx, key); ok {
+		if def, ok := registry.Lookup(u.osCtx, key); ok {
 			result.Findings = append(result.Findings, types.Finding{
 				Title:       def.Title,
 				Severity:    def.Severity,
@@ -458,7 +458,7 @@ func (u *UnixUserChecker) analyzeUsers(users []userAccount, result *types.AuditR
 				fmt.Sprintf("%s CRITICAL: Account %s has UID 0 (root-equivalent)",
 					types.SymbolCritical, user.username))
 			if _, dup := seen["users.uid_zero_non_root"]; !dup {
-				if def, ok := registry.Lookup(u.ctx, "users.uid_zero_non_root"); ok {
+				if def, ok := registry.Lookup(u.osCtx, "users.uid_zero_non_root"); ok {
 					result.Findings = append(result.Findings, types.Finding{
 						Title:       def.Title,
 						Severity:    def.Severity,
@@ -479,7 +479,7 @@ func (u *UnixUserChecker) analyzeUsers(users []userAccount, result *types.AuditR
 				fmt.Sprintf("%s WARNING: Account %s has no password and an interactive login shell",
 					types.SymbolWarning, user.username))
 			if _, dup := seen["users.no_password_login_shell"]; !dup {
-				if def, ok := registry.Lookup(u.ctx, "users.no_password_login_shell"); ok {
+				if def, ok := registry.Lookup(u.osCtx, "users.no_password_login_shell"); ok {
 					result.Findings = append(result.Findings, types.Finding{
 						Title:       def.Title,
 						Severity:    def.Severity,
@@ -498,7 +498,7 @@ func (u *UnixUserChecker) analyzeUsers(users []userAccount, result *types.AuditR
 				fmt.Sprintf("%s WARNING: Regular user %s has administrative privileges",
 					types.SymbolWarning, user.username))
 			if _, dup := seen["users.regular_user_admin_privileges"]; !dup {
-				if def, ok := registry.Lookup(u.ctx, "users.regular_user_admin_privileges"); ok {
+				if def, ok := registry.Lookup(u.osCtx, "users.regular_user_admin_privileges"); ok {
 					result.Findings = append(result.Findings, types.Finding{
 						Title:       def.Title,
 						Severity:    def.Severity,
@@ -517,7 +517,7 @@ func (u *UnixUserChecker) analyzeUsers(users []userAccount, result *types.AuditR
 				fmt.Sprintf("%s User %s has an interactive login shell: %s",
 					types.SymbolWarning, user.username, user.shell))
 			if _, dup := seen["users.login_shell_present"]; !dup {
-				if def, ok := registry.Lookup(u.ctx, "users.login_shell_present"); ok {
+				if def, ok := registry.Lookup(u.osCtx, "users.login_shell_present"); ok {
 					result.Findings = append(result.Findings, types.Finding{
 						Title:       def.Title,
 						Severity:    def.Severity,
@@ -638,7 +638,7 @@ func (u *UnixUserChecker) checkSecurityConcerns(ctx context.Context, result *typ
 					result.Details = append(result.Details,
 						fmt.Sprintf("%s CRITICAL: User %s has no password set",
 							types.SymbolCritical, fields[passwdFieldUsername]))
-					if def, ok := registry.Lookup(u.ctx, "users.empty_password_hash"); ok {
+					if def, ok := registry.Lookup(u.osCtx, "users.empty_password_hash"); ok {
 						result.Findings = append(result.Findings, types.Finding{
 							Title:       def.Title,
 							Severity:    def.Severity,
@@ -666,7 +666,7 @@ func (u *UnixUserChecker) checkSecurityConcerns(ctx context.Context, result *typ
 			} else {
 				result.Details = append(result.Details,
 					fmt.Sprintf("%s WARNING: Root account is unlocked", types.SymbolWarning))
-				if def, ok := registry.Lookup(u.ctx, "users.root_account_unlocked"); ok {
+				if def, ok := registry.Lookup(u.osCtx, "users.root_account_unlocked"); ok {
 					result.Findings = append(result.Findings, types.Finding{
 						Title:       def.Title,
 						Severity:    def.Severity,
@@ -692,7 +692,7 @@ func (u *UnixUserChecker) checkSecurityConcerns(ctx context.Context, result *typ
 						result.Details = append(result.Details,
 							fmt.Sprintf("%s CRITICAL: User %s has UID 0",
 								types.SymbolCritical, fields[0]))
-						if def, ok := registry.Lookup(u.ctx, "users.uid_zero_non_root"); ok {
+						if def, ok := registry.Lookup(u.osCtx, "users.uid_zero_non_root"); ok {
 							result.Findings = append(result.Findings, types.Finding{
 								Title:       def.Title,
 								Severity:    def.Severity,
@@ -812,7 +812,7 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 			details += " (Administrator)"
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s %s", types.SymbolWarning, details))
-			if def, ok := registry.Lookup(w.ctx, "users.administrator_account_active"); ok {
+			if def, ok := registry.Lookup(w.osCtx, "users.administrator_account_active"); ok {
 				result.Findings = append(result.Findings, types.Finding{
 					Title:       def.Title,
 					Severity:    def.Severity,
@@ -833,7 +833,7 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 				result.Details = append(result.Details,
 					fmt.Sprintf("%s %s", types.SymbolInfo, details))
 				if !msAccountFindingAdded {
-					if def, ok := registry.Lookup(w.ctx, "user.microsoft_account_no_local_password"); ok {
+					if def, ok := registry.Lookup(w.osCtx, "users.microsoft_account_no_local_password"); ok {
 						result.Findings = append(result.Findings, types.Finding{
 							Title:       def.Title,
 							Severity:    def.Severity,
@@ -850,7 +850,7 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 				result.Details = append(result.Details,
 					fmt.Sprintf("%s %s", types.SymbolInfo, details))
 				if !azureADFindingAdded {
-					if def, ok := registry.Lookup(w.ctx, "users.azure_ad_account_no_local_password"); ok {
+					if def, ok := registry.Lookup(w.osCtx, "users.azure_ad_account_no_local_password"); ok {
 						result.Findings = append(result.Findings, types.Finding{
 							Title:       def.Title,
 							Severity:    def.Severity,
@@ -867,7 +867,7 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 				result.Details = append(result.Details,
 					fmt.Sprintf("%s %s", types.SymbolInfo, details))
 				if !domainFindingAdded {
-					if def, ok := registry.Lookup(w.ctx, "users.domain_account_no_local_password"); ok {
+					if def, ok := registry.Lookup(w.osCtx, "users.domain_account_no_local_password"); ok {
 						result.Findings = append(result.Findings, types.Finding{
 							Title:       def.Title,
 							Severity:    def.Severity,
@@ -884,7 +884,7 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 				result.Details = append(result.Details,
 					fmt.Sprintf("%s %s", types.SymbolWarning, details))
 				if !unknownPrincipalFindingAdded {
-					if def, ok := registry.Lookup(w.ctx, "users.unknown_principal_no_local_password"); ok {
+					if def, ok := registry.Lookup(w.osCtx, "users.unknown_principal_no_local_password"); ok {
 						result.Findings = append(result.Findings, types.Finding{
 							Title:       def.Title,
 							Severity:    def.Severity,
@@ -902,7 +902,7 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 				result.Details = append(result.Details,
 					fmt.Sprintf("%s %s", types.SymbolWarning, details))
 				if !noPasswordFindingAdded {
-					if def, ok := registry.Lookup(w.ctx, "users.no_password_required"); ok {
+					if def, ok := registry.Lookup(w.osCtx, "users.no_password_required"); ok {
 						result.Findings = append(result.Findings, types.Finding{
 							Title:       def.Title,
 							Severity:    def.Severity,
@@ -946,7 +946,7 @@ func (w *WindowsUserChecker) checkSecurityPolicies(ctx context.Context, result *
 		} else {
 			result.Details = append(result.Details,
 				fmt.Sprintf("%s WARNING: User Account Control (UAC) is disabled", types.SymbolWarning))
-			if def, ok := registry.Lookup(w.ctx, "users.uac_disabled"); ok {
+			if def, ok := registry.Lookup(w.osCtx, "users.uac_disabled"); ok {
 				result.Findings = append(result.Findings, types.Finding{
 					Title:       def.Title,
 					Severity:    def.Severity,

--- a/internal/security/checker/users.go
+++ b/internal/security/checker/users.go
@@ -3,6 +3,7 @@ package checker
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io/fs"
 	"os"
@@ -20,55 +21,57 @@ const windowsUserCSVFields = 8
 
 // UserChecker defines interface for user account checking
 type UserChecker interface {
-	Check() types.AuditResult
+	Check(ctx context.Context) types.AuditResult
 }
 
-// platformConfig holds OS-specific configuration for user checking
-type platformConfig struct {
-	userSources []string
-	minUID      int
-}
+type (
+	// platformConfig holds OS-specific configuration for user checking
+	platformConfig struct {
+		userSources []string
+		minUID      int
+	}
 
-// UnixUserChecker implements UserChecker for Unix-like systems.
-// shadowReadable is set to true when /etc/shadow was successfully opened
-// during getLinuxUsers; it gates the no-password finding and surfaces a
-// diagnostic when the check runs without sufficient privileges.
-type UnixUserChecker struct {
-	config         platformConfig
-	osType         string
-	ctx            registry.OSContext
-	shadowReadable bool
-}
+	// UnixUserChecker implements UserChecker for Unix-like systems.
+	// shadowReadable is set to true when /etc/shadow was successfully opened
+	// during getLinuxUsers; it gates the no-password finding and surfaces a
+	// diagnostic when the check runs without sufficient privileges.
+	UnixUserChecker struct {
+		config         platformConfig
+		osType         string
+		ctx            registry.OSContext
+		shadowReadable bool
+	}
 
-// WindowsUserChecker implements UserChecker for Windows systems
-type WindowsUserChecker struct {
-	ctx registry.OSContext
-}
+	// WindowsUserChecker implements UserChecker for Windows systems
+	WindowsUserChecker struct {
+		ctx registry.OSContext
+	}
 
-// userAccount represents a parsed user account from /etc/passwd and,
-// where available, /etc/shadow. isSystem is true when the UID falls
-// below the platform minimum for regular user accounts. isLocked is
-// true when the shadow password field begins with ! or *. hasPassword
-// is true when a non-empty, non-placeholder password hash is present
-// in /etc/shadow; false indicates no credential is set.
-type userAccount struct {
-	username    string
-	uid         int
-	gid         int
-	homeDir     string
-	shell       string
-	isSystem    bool
-	isLocked    bool
-	isAdmin     bool
-	isDisabled  bool
-	hasPassword bool
-}
+	// userAccount represents a parsed user account from /etc/passwd and,
+	// where available, /etc/shadow. isSystem is true when the UID falls
+	// below the platform minimum for regular user accounts. isLocked is
+	// true when the shadow password field begins with ! or *. hasPassword
+	// is true when a non-empty, non-placeholder password hash is present
+	// in /etc/shadow; false indicates no credential is set.
+	userAccount struct {
+		username    string
+		uid         int
+		gid         int
+		homeDir     string
+		shell       string
+		isSystem    bool
+		isLocked    bool
+		isAdmin     bool
+		isDisabled  bool
+		hasPassword bool
+	}
 
-// authConfigResult holds the outcome of auth configuration detection.
-type authConfigResult struct {
-	Details []string
-	Keys    []registry.FindingKey
-}
+	// authConfigResult holds the outcome of auth configuration detection.
+	authConfigResult struct {
+		Details []string
+		Keys    []registry.FindingKey
+	}
+)
 
 // getPlatformConfig returns the appropriate configuration for the current OS
 func getPlatformConfig() platformConfig {
@@ -120,7 +123,7 @@ func NewWindowsUserChecker(ctx registry.OSContext) *WindowsUserChecker {
 }
 
 // Check implements UserChecker interface for Unix systems
-func (u *UnixUserChecker) Check() types.AuditResult {
+func (u *UnixUserChecker) Check(ctx context.Context) types.AuditResult {
 	result := types.AuditResult{
 		Name:        "User Account Security",
 		Status:      "CHECKING",
@@ -144,7 +147,7 @@ func (u *UnixUserChecker) Check() types.AuditResult {
 		}
 	}
 
-	users, err := u.getUsers()
+	users, err := u.getUsers(ctx)
 	if err != nil {
 		result.Status = "ERROR"
 		result.Description = fmt.Sprintf("Failed to analyze users: %v", err)
@@ -152,35 +155,35 @@ func (u *UnixUserChecker) Check() types.AuditResult {
 	}
 
 	u.analyzeUsers(users, &result)
-	u.checkSecurityConcerns(&result)
+	u.checkSecurityConcerns(ctx, &result)
 
 	result.Status = "COMPLETED"
 	return result
 }
 
 // getUsers retrieves user accounts based on OS type
-func (u *UnixUserChecker) getUsers() ([]userAccount, error) {
+func (u *UnixUserChecker) getUsers(ctx context.Context) ([]userAccount, error) {
 	switch u.osType {
 	case "darwin":
-		return u.getMacOSUsers()
+		return u.getMacOSUsers(ctx)
 	case "freebsd", "openbsd":
-		return u.getBSDUsers()
+		return u.getBSDUsers(ctx)
 	default:
-		return u.getLinuxUsers()
+		return u.getLinuxUsers(ctx)
 	}
 }
 
-func (u *UnixUserChecker) getMacOSUsers() ([]userAccount, error) {
+func (u *UnixUserChecker) getMacOSUsers(ctx context.Context) ([]userAccount, error) {
 	var users []userAccount
 
-	cmd := exec.Command("dscl", ".", "list", "/Users")
+	cmd := exec.CommandContext(ctx, "dscl", ".", "list", "/Users")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get macOS users: %v", err)
 	}
 
 	adminUsers := make(map[string]bool)
-	adminCmd := exec.Command("dscacheutil", "-q", "group", "-a", "name", "admin")
+	adminCmd := exec.CommandContext(ctx, "dscacheutil", "-q", "group", "-a", "name", "admin")
 	if adminOutput, err := adminCmd.CombinedOutput(); err == nil {
 		for _, line := range strings.Split(string(adminOutput), "\n") {
 			if strings.HasPrefix(line, "users:") {
@@ -202,7 +205,7 @@ func (u *UnixUserChecker) getMacOSUsers() ([]userAccount, error) {
 			continue
 		}
 
-		infoCmd := exec.Command("dscl", ".", "read", "/Users/"+username, // #nosec G204 -- username validated by isSafeUsername before use
+		infoCmd := exec.CommandContext(ctx, "dscl", ".", "read", "/Users/"+username, // #nosec G204 -- username validated by isSafeUsername before use
 			"UniqueID", "PrimaryGroupID", "NFSHomeDirectory", "UserShell")
 		infoOutput, err := infoCmd.CombinedOutput()
 		if err != nil {
@@ -240,12 +243,13 @@ func (u *UnixUserChecker) getMacOSUsers() ([]userAccount, error) {
 			continue
 		}
 
-		authCmd := exec.Command("dscl", ".", "read", "/Users/"+username, "AuthenticationAuthority") // #nosec G204 -- username validated by isSafeUsername before use
-		authOutput, err := authCmd.CombinedOutput()
-		if err != nil {
+		authCmd := exec.CommandContext(ctx, "dscl", ".", "read", "/Users/"+username, "AuthenticationAuthority") // #nosec G204 -- username validated by isSafeUsername before use
+		// A dscl failure means the account's disabled state is unknown, not
+		// enabled -- leave isDisabled false only when the read succeeded and
+		// the DisabledUser marker is genuinely absent.
+		if authOutput, err := authCmd.CombinedOutput(); err == nil {
 			account.isDisabled = strings.Contains(string(authOutput), "DisabledUser")
 		}
-		account.isDisabled = strings.Contains(string(authOutput), "DisabledUser")
 
 		users = append(users, account)
 	}
@@ -253,12 +257,12 @@ func (u *UnixUserChecker) getMacOSUsers() ([]userAccount, error) {
 	return users, nil
 }
 
-func (u *UnixUserChecker) getBSDUsers() ([]userAccount, error) {
+func (u *UnixUserChecker) getBSDUsers(ctx context.Context) ([]userAccount, error) {
 	var users []userAccount
 
 	if u.osType == "openbsd" {
 		// pwd_mkdb consistency check — failure is non-fatal, read proceeds regardless
-		if err := exec.Command("pwd_mkdb", "-c", "/etc/master.passwd").Run(); err != nil {
+		if err := exec.CommandContext(ctx, "pwd_mkdb", "-c", "/etc/master.passwd").Run(); err != nil {
 			// non-fatal: continue regardless of outcome
 			_ = err
 		}
@@ -304,7 +308,7 @@ func (u *UnixUserChecker) getBSDUsers() ([]userAccount, error) {
 			continue
 		}
 
-		groupCmd := exec.Command("id", "-Gn", account.username) // #nosec G204 -- username validated by isSafeUsername before use
+		groupCmd := exec.CommandContext(ctx, "id", "-Gn", account.username) // #nosec G204 -- username validated by isSafeUsername before use
 		if output, err := groupCmd.CombinedOutput(); err == nil {
 			for _, group := range strings.Fields(string(output)) {
 				if group == "wheel" {
@@ -324,7 +328,7 @@ func (u *UnixUserChecker) getBSDUsers() ([]userAccount, error) {
 	return users, nil
 }
 
-func (u *UnixUserChecker) getLinuxUsers() ([]userAccount, error) {
+func (u *UnixUserChecker) getLinuxUsers(ctx context.Context) ([]userAccount, error) {
 	var users []userAccount
 
 	passwdFile, err := os.Open("/etc/passwd")
@@ -355,7 +359,7 @@ func (u *UnixUserChecker) getLinuxUsers() ([]userAccount, error) {
 	// lookup to fail and silently zero out the sudoers map.
 	sudoers := make(map[string]bool)
 	for _, group := range []string{"sudo", "wheel", "admin"} {
-		cmd := exec.Command("getent", "group", group) // #nosec G204 -- group names are hardcoded literals, not user input
+		cmd := exec.CommandContext(ctx, "getent", "group", group) // #nosec G204 -- group names are hardcoded literals, not user input
 		if output, err := cmd.CombinedOutput(); err == nil {
 			for _, line := range strings.Split(string(output), "\n") {
 				if fields := strings.Split(line, ":"); len(fields) >= groupFieldCount {
@@ -623,7 +627,7 @@ func (u *UnixUserChecker) checkAuthConfig() authConfigResult {
 	return r
 }
 
-func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
+func (u *UnixUserChecker) checkSecurityConcerns(ctx context.Context, result *types.AuditResult) {
 	if u.osType != "darwin" {
 		if shadow, err := os.Open("/etc/shadow"); err == nil {
 			defer shadow.Close() // nolint:errcheck // read-only shadow file; close error does not affect scan results
@@ -654,7 +658,7 @@ func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
 			}
 		}
 
-		out, err := exec.Command("passwd", "-S", "root").CombinedOutput()
+		out, err := exec.CommandContext(ctx, "passwd", "-S", "root").CombinedOutput()
 		if err == nil {
 			if strings.Contains(string(out), "NP") || strings.Contains(string(out), "L") {
 				result.Details = append(result.Details,
@@ -712,7 +716,7 @@ func (u *UnixUserChecker) checkSecurityConcerns(result *types.AuditResult) {
 }
 
 // Check implements UserChecker interface for Windows systems
-func (w *WindowsUserChecker) Check() types.AuditResult {
+func (w *WindowsUserChecker) Check(ctx context.Context) types.AuditResult {
 	result := types.AuditResult{
 		Name:        "Windows User Account Security",
 		Status:      "CHECKING",
@@ -721,7 +725,7 @@ func (w *WindowsUserChecker) Check() types.AuditResult {
 		Findings:    make([]types.Finding, 0),
 	}
 
-	users, err := w.getWindowsUsers()
+	users, err := w.getWindowsUsers(ctx)
 	if err != nil {
 		result.Status = "ERROR"
 		result.Description = fmt.Sprintf("Failed to get user information: %v", err)
@@ -729,25 +733,25 @@ func (w *WindowsUserChecker) Check() types.AuditResult {
 	}
 
 	w.analyzeWindowsUsers(users, &result)
-	w.checkSecurityPolicies(&result)
+	w.checkSecurityPolicies(ctx, &result)
 
 	result.Status = "COMPLETED"
 	return result
 }
 
-func (w *WindowsUserChecker) getWindowsUsers() ([]windowsUserInfo, error) {
+func (w *WindowsUserChecker) getWindowsUsers(ctx context.Context) ([]windowsUserInfo, error) {
 	var users []windowsUserInfo
 
 	psCmd := `Get-LocalUser | ` +
 		`Select-Object Name,Enabled,PasswordRequired,PasswordLastSet,LastLogon,AccountExpires,Description,PrincipalSource | ` +
 		`ConvertTo-Csv -NoTypeInformation`
-	cmd := exec.Command("powershell", "-Command", psCmd)
+	cmd := exec.CommandContext(ctx, "powershell", "-Command", psCmd)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, err
 	}
 
-	adminCmd := exec.Command("powershell", "-Command",
+	adminCmd := exec.CommandContext(ctx, "powershell", "-Command",
 		`Get-LocalGroupMember -Group "Administrators" | Select-Object Name | ConvertTo-Csv -NoTypeInformation`)
 	adminOutput, err := adminCmd.CombinedOutput()
 	if err != nil {
@@ -918,8 +922,8 @@ func (w *WindowsUserChecker) analyzeWindowsUsers(users []windowsUserInfo, result
 	}
 }
 
-func (w *WindowsUserChecker) checkSecurityPolicies(result *types.AuditResult) {
-	cmd := exec.Command("net", "accounts")
+func (w *WindowsUserChecker) checkSecurityPolicies(ctx context.Context, result *types.AuditResult) {
+	cmd := exec.CommandContext(ctx, "net", "accounts")
 	output, err := cmd.CombinedOutput()
 	if err == nil {
 		result.Details = append(result.Details, "\nPassword Policies:")
@@ -932,7 +936,7 @@ func (w *WindowsUserChecker) checkSecurityPolicies(result *types.AuditResult) {
 		}
 	}
 
-	uacCmd := exec.Command("powershell", "-Command",
+	uacCmd := exec.CommandContext(ctx, "powershell", "-Command",
 		`Get-ItemProperty HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name EnableLUA`)
 	uacOutput, err := uacCmd.CombinedOutput()
 	if err == nil {

--- a/internal/security/enrichment/errors.go
+++ b/internal/security/enrichment/errors.go
@@ -10,8 +10,14 @@ var ErrNoEnricherConfigured = errors.New("no enrichment source configured")
 // Returned when input does not match CWE-N+
 var ErrInvalidCWEID = errors.New("invalid CWE identifier")
 
-// ErrEmptyRequest indicates an EnrichRequest contained no CVE identifiers to enrich.
-var ErrEmptyRequest = errors.New("enrichment request contains no CVE identifiers")
+// ErrEmptyRequest indicates an EnrichRequest contained no CWE identifiers to
+// enrich. No current producer: designated consumers are the enrichment
+// adapters (#89-#93), which share this sentinel so an empty request reports
+// identically regardless of source.
+var ErrEmptyRequest = errors.New("enrichment request contains no CWE identifiers")
 
-// ErrMissingAPIKey indicates an adapter that requires an API key could not find the required credential
+// ErrMissingAPIKey indicates an adapter requiring an API key could not find
+// the credential. No current producer: designated consumers are the keyed
+// enrichment adapters (#89-#93), which share this sentinel so a missing
+// credential reports identically regardless of source.
 var ErrMissingAPIKey = errors.New("required API key not found in environment")

--- a/internal/security/enrichment/validate.go
+++ b/internal/security/enrichment/validate.go
@@ -25,40 +25,6 @@ func NormalizeCWEID(input string) (string, error) {
 	return validateCanonicalCWE(input)
 }
 
-// ValidateCWEID returns nil if input is a valid CWE identifier in
-// canonical or URL form. Use NormalizeCWEID when the canonical form
-// is needed for downstream use.
-func ValidateCWEID(input string) error {
-	_, err := NormalizeCWEID(input)
-	return err
-}
-
-// NormalizeCWEIDs normalizes a slice of CWE identifiers. Returns the
-// canonical IDs that validated successfully and errors for the rest.
-// Rejects bulk input above the documented limit. Does not deduplicate.
-func NormalizeCWEIDs(inputs []string) (valid []string, errs []error) {
-	if len(inputs) == 0 {
-		return nil, nil
-	}
-	if len(inputs) > maxBulkValidateInput {
-		return nil, []error{
-			fmt.Errorf("%w: input size %d exceeds limit %d",
-				ErrInvalidCWEID, len(inputs), maxBulkValidateInput),
-		}
-	}
-
-	valid = make([]string, 0, len(inputs))
-	for _, input := range inputs {
-		id, err := NormalizeCWEID(input)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		valid = append(valid, id)
-	}
-	return valid, errs
-}
-
 func extractCWEFromURL(input string) (string, bool) {
 	if !strings.HasPrefix(input, cweURLPrefix) {
 		return "", false

--- a/internal/security/registry/registry.go
+++ b/internal/security/registry/registry.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	_ "embed"
 	"os"
+	"runtime"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -28,10 +29,8 @@ const (
 	PlatformDarwin  Platform = "darwin"
 	PlatformUnix    Platform = "unix"
 	PlatformUnknown Platform = "unknown"
-)
 
-// Distro family constants where derivatives resolve to parent family
-const (
+	// Distro family constants where derivatives resolve to parent family
 	// Linux Families
 	DistroDebian  Distro = "debian"
 	DistroRHEL    Distro = "rhel"
@@ -48,11 +47,9 @@ const (
 
 	// Non-Linux Platforms
 	DistroNone    Distro = ""
-	DistroUnknown Distro = "uknown"
-)
+	DistroUnknown Distro = "unknown"
 
-// Reference type classifications produced by ToReferences.
-const (
+	// Reference type classifications produced by ToReferences.
 	RefTypeCVE   = "CVE"
 	RefTypeCWE   = "CWE"
 	RefTypeCIS   = "CIS"
@@ -62,72 +59,79 @@ const (
 	RefTypeOther = "OTHER"
 )
 
-// OSContext obtains full platform and distro info to pass to auditor before registry lookups
-type OSContext struct {
-	Platform Platform
-	Families []Distro
-}
+type (
+	// OSContext obtains full platform and distro info to pass to auditor before registry lookups
+	OSContext struct {
+		Platform Platform
+		Families []Distro
+	}
 
-// FindingDefinition is a registry map for types.Finding
-type FindingDefinition struct {
-	Title       string   `yaml:"title"`
-	Severity    string   `yaml:"severity"`
-	CVSSScore   float64  `yaml:"cvss_score"`
-	CVSSVector  string   `yaml:"cvss_vector"`
-	CWE         string   `yaml:"cwe"`
-	Description string   `yaml:"description"`
-	Impact      string   `yaml:"impact"`
-	Resolution  string   `yaml:"resolution"`
-	References  []string `yaml:"references"`
-}
+	// FindingDefinition is a registry map for types.Finding
+	FindingDefinition struct {
+		Title       string   `yaml:"title"`
+		Severity    string   `yaml:"severity"`
+		CVSSScore   float64  `yaml:"cvss_score"`
+		CVSSVector  string   `yaml:"cvss_vector"`
+		CWE         string   `yaml:"cwe"`
+		Description string   `yaml:"description"`
+		Impact      string   `yaml:"impact"`
+		Resolution  string   `yaml:"resolution"`
+		References  []string `yaml:"references"`
+	}
+)
 
-// platformRegistry holds all indexed definitions
-type platformRegistry map[Platform]map[FindingKey]FindingDefinition
+type (
+	// platformRegistry holds all indexed definitions
+	platformRegistry map[Platform]map[FindingKey]FindingDefinition
 
-// Linux family registry holds distro index findings
-type linuxFamilyRegistry map[Distro]map[FindingKey]FindingDefinition
+	// familyRegistry holds finding definitions indexed by distro family,
+	// used for platforms whose findings vary by family (Linux, Unix/BSD)
+	familyRegistry map[Distro]map[FindingKey]FindingDefinition
+)
 
 var (
 	registry      platformRegistry
-	linuxRegistry linuxFamilyRegistry
+	linuxRegistry familyRegistry
+	unixRegistry  familyRegistry
+
+	//go:embed data/windows.yaml
+	windowsData []byte
+
+	//go:embed data/linux_common.yaml
+	linuxCommonData []byte
+
+	//go:embed data/linux_debian.yaml
+	linuxDebianData []byte
+
+	//go:embed data/linux_rhel.yaml
+	linuxRHELData []byte
+
+	//go:embed data/linux_arch.yaml
+	linuxArchData []byte
+
+	//go:embed data/linux_fedora.yaml
+	linuxFedoraData []byte
+
+	//go:embed data/linux_suse.yaml
+	linuxSUSEData []byte
+
+	//go:embed data/linux_alpine.yaml
+	linuxAlpineData []byte
+
+	//go:embed data/darwin.yaml
+	darwinData []byte
+
+	//go:embed data/unix_freebsd.yaml
+	unixFreeBSDData []byte
+
+	//go:embed data/unix_openbsd.yaml
+	unixOpenBSDData []byte
 )
-
-//go:embed data/windows.yaml
-var windowsData []byte
-
-//go:embed data/linux_common.yaml
-var linuxCommonData []byte
-
-//go:embed data/linux_debian.yaml
-var linuxDebianData []byte
-
-//go:embed data/linux_rhel.yaml
-var linuxRHELData []byte
-
-//go:embed data/linux_arch.yaml
-var linuxArchData []byte
-
-//go:embed data/linux_fedora.yaml
-var linuxFedoraData []byte
-
-//go:embed data/linux_suse.yaml
-var linuxSUSEData []byte
-
-//go:embed data/linux_alpine.yaml
-var linuxAlpineData []byte
-
-//go:embed data/darwin.yaml
-var darwinData []byte
-
-//go:embed data/unix_freebsd.yaml
-var unixFreeBSDData []byte
-
-//go:embed data/unix_openbsd.yaml
-var unixOpenBSDData []byte
 
 func init() {
 	registry = make(platformRegistry)
-	linuxRegistry = make(linuxFamilyRegistry)
+	linuxRegistry = make(familyRegistry)
+	unixRegistry = make(familyRegistry)
 
 	registry[PlatformWindows] = mustLoad(windowsData)
 	registry[PlatformDarwin] = mustLoad(darwinData)
@@ -140,10 +144,8 @@ func init() {
 	linuxRegistry[DistroSUSE] = mustLoad(linuxSUSEData)
 	linuxRegistry[DistroAlpine] = mustLoad(linuxAlpineData)
 
-	unixRegistry := make(map[Distro]map[FindingKey]FindingDefinition)
 	unixRegistry[DistroFreeBSD] = mustLoad(unixFreeBSDData)
 	unixRegistry[DistroOpenBSD] = mustLoad(unixOpenBSDData)
-	registry[PlatformUnix] = flattenUnix(unixRegistry)
 }
 
 // mustLoad parses a byte slice into a finding map
@@ -155,18 +157,6 @@ func mustLoad(data []byte) map[FindingKey]FindingDefinition {
 	out := make(map[FindingKey]FindingDefinition, len(raw))
 	for k, v := range raw {
 		out[FindingKey(k)] = v
-	}
-	return out
-}
-
-// flattenUnix merges unix family maps into a distro key map
-func flattenUnix(families map[Distro]map[FindingKey]FindingDefinition) map[FindingKey]FindingDefinition {
-	out := make(map[FindingKey]FindingDefinition)
-	for family, findings := range families {
-		for key, def := range findings {
-			prefixed := FindingKey(string(family) + "." + string(key))
-			out[prefixed] = def
-		}
 	}
 	return out
 }
@@ -185,6 +175,16 @@ func Lookup(ctx OSContext, key FindingKey) (FindingDefinition, bool) {
 		// fall through to common Linux findings
 		if def, ok := linuxRegistry[DistroGeneric][key]; ok {
 			return def, true
+		}
+		return FindingDefinition{}, false
+
+	case PlatformUnix:
+		for _, family := range ctx.Families {
+			if fm, ok := unixRegistry[family]; ok {
+				if def, ok := fm[key]; ok {
+					return def, true
+				}
+			}
 		}
 		return FindingDefinition{}, false
 
@@ -213,27 +213,33 @@ func DetectOS() OSContext {
 			Platform: PlatformLinux,
 			Families: detectLinuxFamilies(),
 		}
+	case PlatformUnix:
+		return OSContext{
+			Platform: PlatformUnix,
+			Families: []Distro{resolveDistro(runtime.GOOS)},
+		}
 	default:
 		return OSContext{Platform: platform}
 	}
 }
 
-// detectPlatform returns the Platform either via runtime.GOOS or /etc/os-release
+// detectPlatform returns the Platform from runtime.GOOS. Compile-time truth
+// cannot misidentify the host the way filesystem probes can (a Linux system
+// without /etc/os-release is still Linux); /etc/os-release is consulted only
+// for distro family resolution, never for platform identity.
 func detectPlatform() Platform {
-	// Check for Linux first via os-release presence
-	if _, err := os.Stat("/etc/os-release"); err == nil {
+	switch runtime.GOOS {
+	case "linux":
 		return PlatformLinux
-	}
-	// macOS
-	if _, err := os.Stat("/System/Library/CoreServices/SystemVersion.plist"); err == nil {
+	case "darwin":
 		return PlatformDarwin
-	}
-	// FreeBSD / OpenBSD / NetBSD
-	if _, err := os.Stat("/etc/rc.conf"); err == nil {
+	case "windows":
+		return PlatformWindows
+	case "freebsd", "openbsd", "netbsd":
 		return PlatformUnix
+	default:
+		return PlatformUnknown
 	}
-	// Windows — none of the above exist
-	return PlatformWindows
 }
 
 // detectLinuxFamilies parses /etc/os-release and returns the
@@ -243,7 +249,7 @@ func detectLinuxFamilies() []Distro {
 	if err != nil {
 		return []Distro{DistroGeneric}
 	}
-	defer file.Close() // nolint:errcheck // read-only file
+	defer file.Close() // nolint:errcheck // read-only file; no data at risk
 
 	var id, idLike string
 	scanner := bufio.NewScanner(file)

--- a/internal/security/types/types.go
+++ b/internal/security/types/types.go
@@ -2,36 +2,49 @@
 package types
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/papa0four/orkowatch/internal/security/enrichment"
 )
 
-// Status symbols for check results
+// Display, status, and severity vocabulary shared by every checker and
+// renderer. These are output contract values: symbols and status strings
+// appear verbatim in text output and reports, and severity strings match
+// registry YAML definitions, so none may change once shipped.
 const (
-	SymbolOK       = "[+]"
-	SymbolError    = "[-]"
-	SymbolWarning  = "[!]"
-	SymbolInfo     = "[*]"
+	// SymbolOK prefixes detail lines reporting a passing condition.
+	SymbolOK = "[+]"
+	// SymbolError prefixes detail lines reporting a check execution failure.
+	SymbolError = "[-]"
+	// SymbolWarning prefixes detail lines reporting a non-critical finding.
+	SymbolWarning = "[!]"
+	// SymbolInfo prefixes informational detail lines carrying no judgment.
+	SymbolInfo = "[*]"
+	// SymbolCritical prefixes detail lines reporting a critical finding.
 	SymbolCritical = "[X]"
-)
 
-// Status constants for audit results
-const (
+	// StatusCompleted marks a check that ran to completion.
 	StatusCompleted = "COMPLETED"
-	StatusWarning   = "WARNING"
-	StatusError     = "ERROR"
-	StatusSkipped   = "SKIPPED"
-	StatusChecking  = "CHECKING"
-)
+	// StatusWarning marks a check that completed but surfaced conditions
+	// requiring attention.
+	StatusWarning = "WARNING"
+	// StatusError marks a check that failed to execute.
+	StatusError = "ERROR"
+	// StatusSkipped marks a check excluded from the run by flag selection.
+	StatusSkipped = "SKIPPED"
+	// StatusChecking marks a check currently executing; results carrying it
+	// in final output indicate the check never reached a terminal status.
+	StatusChecking = "CHECKING"
 
-// Severity levels for audit findings
-const (
-	SeverityLow      = "LOW"
-	SeverityMedium   = "MEDIUM"
-	SeverityHigh     = "HIGH"
+	// SeverityLow through SeverityCritical are the canonical severity values
+	// in ascending rank order; SeverityLevel defines the ranking.
+	SeverityLow = "LOW"
+	// SeverityMedium is the second severity rank.
+	SeverityMedium = "MEDIUM"
+	// SeverityHigh is the third severity rank.
+	SeverityHigh = "HIGH"
+	// SeverityCritical is the highest severity rank.
 	SeverityCritical = "CRITICAL"
 )
 
@@ -48,49 +61,33 @@ type AuditResult struct {
 	Metadata    map[string]any // Additional check-specific metadata
 }
 
-// Finding represents a specific security finding
-type Finding struct {
-	Title       string
-	Description string
-	Severity    string
-	Category    string
-	Impact      string
-	Resolution  string
-	References  []Reference
-	Metadata    map[string]any
-}
+type (
+	// Finding represents a specific security finding
+	Finding struct {
+		Title       string
+		Description string
+		Severity    string
+		Category    string
+		Impact      string
+		Resolution  string
+		References  []Reference
+		Metadata    map[string]any
+	}
 
-// Reference provides additional information about a finding
-type Reference struct {
-	Title string
-	URL   string
-	Type  string // e.g., "CVE", "CWE", "NIST", "MITRE", etc.
-}
+	// Reference provides additional information about a finding
+	Reference struct {
+		Title string
+		URL   string
+		Type  string // e.g., "CVE", "CWE", "NIST", "MITRE", etc.
+	}
 
-// ValidationError represents a configuration validation error
-type ValidationError struct {
-	Checker string
-	Field   string
-	Message string
-}
-
-// ClassifiedReference is a non-CWE reference annotated by type.
-type ClassifiedReference struct {
-	Type  string
-	Value string
-}
-
-// ReferenceExtraction separates valid CWEs from malformed CWE attempts
-// and non-CWE references.
-type ReferenceExtraction struct {
-	CWEs   []string
-	Errors []error
-	Other  []ClassifiedReference
-}
-
-func (e *ValidationError) Error() string {
-	return fmt.Sprintf("validation error in %s: %s - %s", e.Checker, e.Field, e.Message)
-}
+	// ReferenceExtraction separates valid CWEs from malformed CWE attempts
+	// and non-CWE references.
+	ReferenceExtraction struct {
+		CWEs   []string
+		Errors []error
+	}
+)
 
 // SeverityLevel returns the numeric rank of a severity string for threshold
 // comparisons. Unknown values return -1 so they are never silently dropped.
@@ -133,7 +130,7 @@ func EffectiveSeverity(f Finding) string {
 
 // SeverityFormat returns the display symbol and fixed-width padded severity label
 func SeverityFormat(severity string) (symbol, label string) {
-	switch severity {
+	switch strings.ToUpper(severity) {
 	case SeverityCritical:
 		return SymbolCritical, "CRITICAL"
 	case SeverityHigh:
@@ -170,12 +167,7 @@ func (f *Finding) CWEReferences() ReferenceExtraction {
 			}
 			seen[id] = struct{}{}
 			ext.CWEs = append(ext.CWEs, id)
-			continue
 		}
-		ext.Other = append(ext.Other, ClassifiedReference{
-			Type:  ref.Type,
-			Value: ref.Title,
-		})
 	}
 	return ext
 }
@@ -198,7 +190,6 @@ func (r *AuditResult) AllCWEReferences() ReferenceExtraction {
 			ext.CWEs = append(ext.CWEs, id)
 		}
 		ext.Errors = append(ext.Errors, sub.Errors...)
-		ext.Other = append(ext.Other, sub.Other...)
 	}
 	return ext
 }

--- a/internal/softwarelist/softwarelist.go
+++ b/internal/softwarelist/softwarelist.go
@@ -4,6 +4,7 @@
 package softwarelist
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -20,9 +21,10 @@ type SoftwareEntry struct {
 
 // GetInstalledSoftwareList returns the installed software packages as a
 // structured slice. Each entry carries a discrete name and version field
-// suitable for enrichment lookups and structured report output.
-func GetInstalledSoftwareList() ([]SoftwareEntry, error) {
-	entries, err := getPlatformSoftwareList()
+// suitable for enrichment lookups and structured report output. ctx bounds
+// the platform package-manager invocations.
+func GetInstalledSoftwareList(ctx context.Context) ([]SoftwareEntry, error) {
+	entries, err := getPlatformSoftwareList(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("software enumeration failed: %w", err)
 	}
@@ -31,9 +33,9 @@ func GetInstalledSoftwareList() ([]SoftwareEntry, error) {
 
 // GetInstalledSoftware returns the installed software packages as a
 // formatted human-readable string. Used for text output and the standalone
-// software subcommand.
-func GetInstalledSoftware() (string, error) {
-	entries, err := getPlatformSoftwareList()
+// software subcommand. ctx bounds the platform package-manager invocations.
+func GetInstalledSoftware(ctx context.Context) (string, error) {
+	entries, err := getPlatformSoftwareList(ctx)
 	if err != nil {
 		return "", fmt.Errorf("software enumeration failed: %w", err)
 	}

--- a/internal/softwarelist/softwarelist_unix.go
+++ b/internal/softwarelist/softwarelist_unix.go
@@ -4,6 +4,7 @@
 package softwarelist
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"runtime"
@@ -13,26 +14,26 @@ import (
 // getPlatformSoftwareList returns installed software as a structured slice
 // by querying the platform package manager. Linux tries dpkg-query then rpm;
 // Darwin uses system_profiler; FreeBSD uses pkg info.
-func getPlatformSoftwareList() ([]SoftwareEntry, error) {
+func getPlatformSoftwareList(ctx context.Context) ([]SoftwareEntry, error) {
 	switch runtime.GOOS {
 	case "linux":
-		if output, err := exec.Command("dpkg-query", "-W", "-f=${Package}\t${Version}\n").Output(); err == nil {
+		if output, err := exec.CommandContext(ctx, "dpkg-query", "-W", "-f=${Package}\t${Version}\n").Output(); err == nil {
 			return parseTabDelimited(string(output)), nil
 		}
-		if output, err := exec.Command("rpm", "-qa", "--queryformat", "%{NAME}\t%{VERSION}\n").Output(); err == nil {
+		if output, err := exec.CommandContext(ctx, "rpm", "-qa", "--queryformat", "%{NAME}\t%{VERSION}\n").Output(); err == nil {
 			return parseTabDelimited(string(output)), nil
 		}
 		return nil, fmt.Errorf("no supported package manager found; try rerunning with sudo")
 
 	case "darwin":
-		output, err := exec.Command("system_profiler", "SPApplicationsDataType", "-json").Output()
+		output, err := exec.CommandContext(ctx, "system_profiler", "SPApplicationsDataType", "-json").Output()
 		if err != nil {
 			return nil, fmt.Errorf("insufficient permissions to list software packages; try rerunning with sudo")
 		}
 		return parseDarwinJSON(output), nil
 
 	case "freebsd":
-		output, err := exec.Command("pkg", "info", "-a", "--raw-format", "json").Output()
+		output, err := exec.CommandContext(ctx, "pkg", "info", "-a", "--raw-format", "json").Output()
 		if err != nil {
 			return nil, fmt.Errorf("insufficient permissions to list software packages; try rerunning with sudo")
 		}

--- a/internal/softwarelist/softwarelist_windows.go
+++ b/internal/softwarelist/softwarelist_windows.go
@@ -7,13 +7,11 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 
 	"golang.org/x/sys/windows/registry"
 )
 
-// getPlatformSoftware reads installed software directly from the Windows
+// getPlatformSoftwareList reads installed software directly from the Windows
 // registry. Four locations are checked for complete coverage:
 //   - HKLM 64-bit uninstall path (system-wide 64-bit installs)
 //   - HKLM 32-bit Wow6432Node path (system-wide 32-bit installs)
@@ -21,9 +19,13 @@ import (
 //   - HKCU 32-bit Wow6432Node path (current user 32-bit installs)
 //
 // A display name map deduplicates entries that appear in multiple paths.
-// wmic is called as a fallback for environments where registry
-// access is restricted, but its use is flagged since it is deprecated as of
-// Windows 10 21H1.
+// There is deliberately no exec fallback: the former wmic path queried
+// Win32_Product, whose enumeration triggers MSI consistency checks that can
+// reconfigure installed packages -- a read that mutates target state has no
+// place in an auditing tool. All four hives yielding nothing means the token
+// or host is broken, and the honest behavior is the error path. ctx is
+// accepted for cross-platform signature parity; the registry API offers no
+// cancellation point.
 func getPlatformSoftwareList(ctx context.Context) ([]SoftwareEntry, error) {
 	const (
 		uninstallPath   = `Software\Microsoft\Windows\CurrentVersion\Uninstall`
@@ -93,33 +95,5 @@ func getPlatformSoftwareList(ctx context.Context) ([]SoftwareEntry, error) {
 		return entries, nil
 	}
 
-	// wmic fallback
-	fmt.Fprintln(os.Stderr,
-		"[!] WARNING: registry read returned no results; falling back to wmic (deprecated on Windows 10 21H1+)")
-	output, err := exec.CommandContext(ctx, "wmic", "product", "get", "name,version").Output()
-	if err != nil {
-		return nil, fmt.Errorf("insufficient permissions to list software packages; try rerunning as Administrator")
-	}
-
-	// parse wmic tab-delimited output into entries
-	var wmicEntries []SoftwareEntry
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines[1:] { //skip header
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) == 0 {
-			continue
-		}
-		version := ""
-		name := line
-		if len(fields) > 1 {
-			version = fields[len(fields)-1]
-			name = strings.TrimSpace(strings.TrimSuffix(line, version))
-		}
-		wmicEntries = append(wmicEntries, SoftwareEntry{Name: name, Version: version})
-	}
-	return wmicEntries, nil
+	return nil, fmt.Errorf("no software entries readable from any registry uninstall hive; verify registry access or rerun as Administrator")
 }

--- a/internal/softwarelist/softwarelist_windows.go
+++ b/internal/softwarelist/softwarelist_windows.go
@@ -4,6 +4,7 @@
 package softwarelist
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -23,7 +24,7 @@ import (
 // wmic is called as a fallback for environments where registry
 // access is restricted, but its use is flagged since it is deprecated as of
 // Windows 10 21H1.
-func getPlatformSoftwareList() ([]SoftwareEntry, error) {
+func getPlatformSoftwareList(ctx context.Context) ([]SoftwareEntry, error) {
 	const (
 		uninstallPath   = `Software\Microsoft\Windows\CurrentVersion\Uninstall`
 		uninstallPath32 = `Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall`
@@ -95,7 +96,7 @@ func getPlatformSoftwareList() ([]SoftwareEntry, error) {
 	// wmic fallback
 	fmt.Fprintln(os.Stderr,
 		"[!] WARNING: registry read returned no results; falling back to wmic (deprecated on Windows 10 21H1+)")
-	output, err := exec.Command("wmic", "product", "get", "name,version").Output()
+	output, err := exec.CommandContext(ctx, "wmic", "product", "get", "name,version").Output()
 	if err != nil {
 		return nil, fmt.Errorf("insufficient permissions to list software packages; try rerunning as Administrator")
 	}


### PR DESCRIPTION
## Summary

The #54 security-posture checklist executed across the full tree. Every file was reviewed in its current form during this branch; the four never-verified areas (enrichment package, report internals, permissions Windows half, security.go as a whole) are now closed. Three known defect classes were fixed (csv accepted then failing at render, inaccurate format error messages, timeout orphaning in-flight scans), and the review surfaced and fixed several silent-failure defects that had never been observable.

## Changes

**Timeout and cancellation (all/audit/checkers/softwarelist)**
- `audit.RunAudit(ctx)`; all checker interfaces are `Check(ctx context.Context)`; every exec call is `exec.CommandContext`; `runBoundedFind` derives from the caller's deadline; the permissions walk checks ctx per entry; `finalize` shares the caller's ctx so `--timeout` is one budget for checks and enrichment together
- `audit.Options.Timeout` deleted; both commands run synchronously under `context.WithTimeout(cmd.Context(), ...)` -- the goroutine-and-select pattern that reported timeout while the scan kept executing against the host is gone. On timeout, child processes are killed at deadline; a child in uninterruptible I/O exits when its syscall returns
- `softwarelist` functions take ctx; `software` command moved to `RunE` with `cmd.Context()`, errors to stderr, nonzero exit

**Silent-failure defects fixed**
- `users.go`: Microsoft-account lookup used key `user.` against registry key `users.` -- the finding could never fire on any Windows host; corrected. macOS `isDisabled` derived account state from failed dscl output via an inverted error branch; scoped to success path
- `report_windows.go`: post-open reparse verification tested the wrong error variable, making the un-raceable half of the reparse defense vacuously pass on inspection failure; two deferred close captures assigned to non-named returns and were dead; all fixed
- `report_unix.go`: `refusedReason` was sudo-blind while the allowlist is sudo-aware, permitting elevated report writes into the invoking user's persistence paths (.ssh, shell rc); now judges both operator homes. `openAndWrite` verifies the opened descriptor via fstat, closing the Lstat/open race window
- `registry.go`: every Unix/BSD lookup was structurally dead (`flattenUnix` prefixed keys checkers never use); replaced with family-aware Unix lookup mirroring the Linux path. `detectPlatform` moved from filesystem probes (which declared os-release-less Linux hosts to be Windows) to `runtime.GOOS`
- `firewall.go`: Windows rules-enumeration failure now reports a SymbolError detail line instead of silently omitting the section
- `softwarelist_windows.go`: wmic fallback deleted -- `Win32_Product` enumeration triggers MSI reconfiguration on the target, a state-mutating read with no place in an auditing tool; all-hives-empty now returns an honest error

**Validation and normalization**
- csv rejected at flag validation in both commands with accurate messages; dead render-time csv branches and stale flag help removed
- `minSeverity`/`allMinSeverity` normalized once at validation; downstream re-uppercasing removed
- Bare `owatch` exits 1 after help; `Execute` reports all command errors to stderr, never stdout
- `outputResults` empty-result guard fails loudly instead of printing to stdout and exiting 0

**Dead code and naming**
- Deleted with zero callers: `ValidateCWEID`, `NormalizeCWEIDs`, `maxBulkValidateInput`, `types.ValidationError`, `types.ClassifiedReference`, `ReferenceExtraction.Other` (write-only on every audit). Sentinels `ErrEmptyRequest`/`ErrMissingAPIKey` retained with designated consumers (#89-#93) named in doc comments; `ErrEmptyRequest` wording corrected CVE to CWE
- Checker-package rename `ctx registry.OSContext` to `osCtx` across all five files plus `NewSecurityAuditor`, ending the collision with `ctx context.Context`
- `checks.go` `categoryCount` derived via iota; `MaskFromNames` flag-alias tolerance documented as contract; `DistroUnknown` value typo; `SeverityFormat` case-normalized; exported constants documented per linter

**Determinism and toolchain**
- `render` failure ordering sorted (text and serialization) so future adapter output diffs deterministically
- Go toolchain bumped to 1.26.5 clearing GO-2026-5856/GO-2026-4970 stdlib findings flagged by grype

## Verified

- defender: full matrix green -- pipeline, cross-compile, both sweep greps empty, baseline findings byte-consistent across text/JSON/YAML, csv/bogus rejection, min-severity filtering and disclosure, bare-root exit 1, stderr/stdout separation both directions, fperms timeout with zero surviving find processes, report write end-to-end
- **Windows (jsabs): NOT YET VERIFIED.** Owed before #127 starts: full pipeline, sweep greps, baseline comparison, csv/severity/root gates, icacls orphan-proof, report write, and the two Windows-exclusive proofs -- the Microsoft-account finding now firing where applicable, and registry-only software enumeration post-wmic-deletion
- BSD registry lookup fix is compile-verified only; behavioral proof lands with the BSD runner (#95-#98)

Closes #126 